### PR TITLE
Fixes #63 Add checks:write permission to audit job

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,6 +36,9 @@ jobs:
   audit:
     name: cargo audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v3
       - uses: rustsec/audit-check@v2


### PR DESCRIPTION
## Summary
- Adds explicit `permissions` block to the `audit` job in `validate.yml`
- Grants `checks: write` so `rustsec/audit-check@v2` can create check runs on push-to-main events
- Grants `contents: read` as the minimum required for checkout

## Test plan
- [ ] Merge this PR and confirm the `cargo audit` job completes without "Resource not accessible by integration" error on the post-merge push run
- [ ] Confirm audit still passes on open PRs as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)