### PR TITLE
Fixes #75 Raise default conversation timeout to 5 minutes

### DIFF
--- a/muds/basic/mud.toml
+++ b/muds/basic/mud.toml
@@ -1,6 +1,6 @@
 [game_loop]
 tick_rate_ms = 500
-max_engage_ms = 30000
+max_engage_ms = 300000
 world_update_ms = 600000
 
 [spawn]

--- a/src/game/config/game_loop_config.rs
+++ b/src/game/config/game_loop_config.rs
@@ -16,7 +16,7 @@ impl GameLoopConfig {
     pub fn default_config() -> Self {
         Self {
             tick_rate_ms: 1000,
-            max_engage_ms: 30_000,
+            max_engage_ms: 300_000,
             world_update_ms: 600_000,
         }
     }
@@ -31,7 +31,7 @@ mod tests {
     fn default_config_has_expected_values() {
         let config = GameLoopConfig::default_config();
         assert_eq!(config.tick_rate_ms, 1000);
-        assert_eq!(config.max_engage_ms, 30_000);
+        assert_eq!(config.max_engage_ms, 300_000);
         assert_eq!(config.world_update_ms, 600_000);
     }
 

--- a/src/game/config/mud_config.rs
+++ b/src/game/config/mud_config.rs
@@ -62,7 +62,7 @@ mod tests {
     fn default_config_has_expected_values() {
         let config = MudConfig::default_config();
         assert_eq!(config.game_loop.tick_rate_ms, 1000);
-        assert_eq!(config.game_loop.max_engage_ms, 30_000);
+        assert_eq!(config.game_loop.max_engage_ms, 300_000);
         assert_eq!(config.game_loop.world_update_ms, 600_000);
         assert_eq!(config.spawn.world_id, "default");
         assert_eq!(config.spawn.dungeon_id, "default");

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -150,7 +150,7 @@ room_id = "default"
     fn load_without_mud_toml_uses_defaults() {
         let state = GameState::load(None).unwrap();
         assert_eq!(state.mud_config.game_loop.tick_rate_ms, 1000);
-        assert_eq!(state.mud_config.game_loop.max_engage_ms, 30_000);
+        assert_eq!(state.mud_config.game_loop.max_engage_ms, 300_000);
         assert_eq!(state.mud_config.game_loop.world_update_ms, 600_000);
     }
 


### PR DESCRIPTION
Raises `max_engage_ms` default from 30s to 5 minutes. The value is already configurable via `mud.toml` under `[game_loop]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)