### PR TITLE
Fixes #77 Add t keybinding shortcut to start a conversation

### DIFF
--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -22,7 +22,7 @@ pub fn parse(input: &str) -> Command {
         "w" | "west" => Command::Move(Direction::West),
         "l" | "look" => Command::Look,
         "h" | "help" => Command::Help,
-        "talk" => Command::Talk,
+        "t" | "talk" => Command::Talk,
         _ => {
             if lower.chars().all(|c| c.is_ascii_digit()) && !lower.is_empty() {
                 Command::Choose(lower)
@@ -79,6 +79,14 @@ mod tests {
         assert!(matches!(parse("H"), Command::Help));
         assert!(matches!(parse("help"), Command::Help));
         assert!(matches!(parse("Help"), Command::Help));
+    }
+
+    #[test]
+    fn parse_talk_variants() {
+        assert!(matches!(parse("t"), Command::Talk));
+        assert!(matches!(parse("T"), Command::Talk));
+        assert!(matches!(parse("talk"), Command::Talk));
+        assert!(matches!(parse("Talk"), Command::Talk));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `t` as a single-character shortcut for the `talk` command in the game screen
- Consistent with existing movement shortcuts (`n`, `s`, `e`, `w`) and look (`l`) / help (`h`)
- One-line change in `src/tui/commands.rs` plus tests covering `t`, `T`, `talk`, and `Talk`

## Test plan
- [ ] `cargo test` passes (209 tests, including new `parse_talk_variants`)
- [ ] `cargo clippy` reports no warnings
- [ ] In-game: press `t` + Enter → conversation initiates (same as typing `talk` + Enter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)