### PR TITLE
Fixes #78 Add message_log component with text wrapping

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,5 +1,6 @@
 mod app;
 mod commands;
+mod components;
 mod event;
 mod screens;
 

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -1,0 +1,1 @@
+pub mod message_log;

--- a/src/tui/components/message_log.rs
+++ b/src/tui/components/message_log.rs
@@ -1,0 +1,45 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span, Text},
+    widgets::{Block, Paragraph, Wrap},
+};
+
+use crate::tui::app::AppMessage;
+
+pub fn render(
+    frame: &mut Frame,
+    messages: &[AppMessage],
+    scroll_offset: usize,
+    block: Block,
+    area: Rect,
+) {
+    let panel_height = area.height.saturating_sub(2) as usize;
+
+    let all_lines: Vec<Line> = messages
+        .iter()
+        .flat_map(|msg| {
+            let style = if msg.debug {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            msg.text
+                .split('\n')
+                .map(|line| Line::from(Span::styled(line.to_string(), style)))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    let total_lines = all_lines.len();
+    let max_offset = total_lines.saturating_sub(panel_height);
+    let effective_offset = scroll_offset.min(max_offset);
+    let scroll_from_top = max_offset.saturating_sub(effective_offset) as u16;
+
+    let log = Paragraph::new(Text::from(all_lines))
+        .block(block)
+        .wrap(Wrap { trim: true })
+        .scroll((scroll_from_top, 0));
+    frame.render_widget(log, area);
+}

--- a/src/tui/screens/agent_conversation.rs
+++ b/src/tui/screens/agent_conversation.rs
@@ -4,10 +4,11 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout},
     style::{Color, Style},
-    text::{Line, Span, Text},
+    text::Text,
     widgets::{Block, Borders, Paragraph},
 };
 
+use super::super::components::message_log;
 use crate::tui::app::App;
 
 const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -29,29 +30,13 @@ pub fn render(frame: &mut Frame, app: &App) {
     ])
     .split(frame.area());
 
-    let visible_lines = areas[0].height.saturating_sub(2) as usize;
-    let total = app.messages.len();
-    let max_offset = total.saturating_sub(visible_lines);
-    let effective_offset = app.scroll_offset.min(max_offset);
-    let end = total.saturating_sub(effective_offset);
-    let start = end.saturating_sub(visible_lines);
-    let log_lines: Vec<Line> = app.messages[start..end]
-        .iter()
-        .flat_map(|msg| {
-            let style = if msg.debug {
-                Style::default().fg(Color::DarkGray)
-            } else {
-                Style::default()
-            };
-            msg.text
-                .split('\n')
-                .map(|line| Line::from(Span::styled(line.to_string(), style)))
-                .collect::<Vec<_>>()
-        })
-        .collect();
-    let log = Paragraph::new(Text::from(log_lines))
-        .block(Block::default().title("Conversation").borders(Borders::ALL));
-    frame.render_widget(log, areas[0]);
+    message_log::render(
+        frame,
+        &app.messages,
+        app.scroll_offset,
+        Block::default().title("Conversation").borders(Borders::ALL),
+        areas[0],
+    );
 
     let status_text = if app.agent_responding {
         format!("{} Responding...", spinner_frame())

--- a/src/tui/screens/conversation.rs
+++ b/src/tui/screens/conversation.rs
@@ -2,10 +2,10 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout},
     style::{Color, Modifier, Style},
-    text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, Paragraph},
 };
 
+use super::super::components::message_log;
 use crate::tui::app::App;
 
 pub fn render(frame: &mut Frame, app: &App) {
@@ -17,29 +17,13 @@ pub fn render(frame: &mut Frame, app: &App) {
     ])
     .split(frame.area());
 
-    let visible_lines = areas[0].height.saturating_sub(2) as usize;
-    let total = app.messages.len();
-    let max_offset = total.saturating_sub(visible_lines);
-    let effective_offset = app.scroll_offset.min(max_offset);
-    let end = total.saturating_sub(effective_offset);
-    let start = end.saturating_sub(visible_lines);
-    let log_lines: Vec<Line> = app.messages[start..end]
-        .iter()
-        .flat_map(|msg| {
-            let style = if msg.debug {
-                Style::default().fg(Color::DarkGray)
-            } else {
-                Style::default()
-            };
-            msg.text
-                .split('\n')
-                .map(|line| Line::from(Span::styled(line.to_string(), style)))
-                .collect::<Vec<_>>()
-        })
-        .collect();
-    let log = Paragraph::new(Text::from(log_lines))
-        .block(Block::default().title("Messages").borders(Borders::ALL));
-    frame.render_widget(log, areas[0]);
+    message_log::render(
+        frame,
+        &app.messages,
+        app.scroll_offset,
+        Block::default().title("Messages").borders(Borders::ALL),
+        areas[0],
+    );
 
     let items: Vec<ListItem> = app
         .conversation

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -2,10 +2,11 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout},
     style::{Color, Style},
-    text::{Line, Span, Text},
+    text::Text,
     widgets::{Block, Borders, Paragraph},
 };
 
+use super::super::components::message_log;
 use super::{agent_conversation, conversation, player_select};
 use crate::tui::app::{App, GameMode};
 
@@ -33,29 +34,13 @@ pub fn render(frame: &mut Frame, app: &App) {
     .split(frame.area());
 
     // Message log
-    let visible_lines = areas[0].height.saturating_sub(2) as usize;
-    let total = app.messages.len();
-    let max_offset = total.saturating_sub(visible_lines);
-    let effective_offset = app.scroll_offset.min(max_offset);
-    let end = total.saturating_sub(effective_offset);
-    let start = end.saturating_sub(visible_lines);
-    let log_lines: Vec<Line> = app.messages[start..end]
-        .iter()
-        .flat_map(|msg| {
-            let style = if msg.debug {
-                Style::default().fg(Color::DarkGray)
-            } else {
-                Style::default()
-            };
-            msg.text
-                .split('\n')
-                .map(|line| Line::from(Span::styled(line.to_string(), style)))
-                .collect::<Vec<_>>()
-        })
-        .collect();
-    let log = Paragraph::new(Text::from(log_lines))
-        .block(Block::default().title("Messages").borders(Borders::ALL));
-    frame.render_widget(log, areas[0]);
+    message_log::render(
+        frame,
+        &app.messages,
+        app.scroll_offset,
+        Block::default().title("Messages").borders(Borders::ALL),
+        areas[0],
+    );
 
     // Status bar
     let status = Paragraph::new("HP: 100 | MP: 50 | Location: Town Square")


### PR DESCRIPTION
## Summary

- Adds a new `tui/components/` module as the home for reusable TUI widgets shared across screens
- Implements `message_log::render()` in `tui/components/message_log.rs` with `Paragraph::wrap(Wrap { trim: true })` and `Paragraph::scroll()` — long lines now wrap within the panel instead of overflowing or clipping
- Updates all three message-displaying screens (`agent_conversation`, `game`, `conversation`) to use the shared helper, removing ~45 lines of duplicated scroll/render logic
- Fixes the scroll unit mismatch: the old code compared message count against row height; the new helper works in logical lines throughout

## Test plan

- [ ] Start server and connect a client
- [ ] Trigger a long agent response (longer than the panel width) and verify text wraps within the panel
- [ ] Verify PgUp/PgDn scrolls correctly in all three screens: Game mode, StandardConversation, AgentConversation
- [ ] `cargo fmt && cargo test && cargo clippy` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)