### PR TITLE
Fixes #76 Refactor tui/event.rs: move screen-specific handling into each screen

### DIFF
--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,19 +1,16 @@
 use std::time::Duration;
 
-use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers, MouseEventKind};
+use crossterm::event::{Event, EventStream, MouseEventKind};
 use futures_util::StreamExt;
 use ratatui::DefaultTerminal;
 use tokio::sync::mpsc;
 use tokio::time;
 
-use crate::game::{Interaction, Movement, TurnAction};
 use crate::network::NetworkEvent;
-use crate::network::client::send_interaction;
-use crate::network::client::{create_player, list_players, select_player};
+use crate::network::client::list_players;
 
-use super::app::{App, AppMessage, GameMode};
-use super::commands;
-use super::screens::game as layout;
+use super::app::{App, GameMode};
+use super::screens::{agent_conversation, conversation, game as game_screen, player_select};
 
 pub async fn run(
     terminal: &mut DefaultTerminal,
@@ -36,7 +33,7 @@ pub async fn run(
     }
 
     while !app.should_quit {
-        terminal.draw(|frame| layout::render(frame, app))?;
+        terminal.draw(|frame| game_screen::render(frame, app))?;
 
         tokio::select! {
             _ = spinner_ticker.tick(), if app.agent_responding => {}
@@ -65,16 +62,16 @@ async fn handle_terminal_event(
         Some(Ok(Event::Key(key))) => {
             match app.mode {
                 GameMode::PlayerSelect => {
-                    handle_player_select_key(app, key.modifiers, key.code).await;
+                    player_select::handle_key(app, key.modifiers, key.code).await;
                 }
                 GameMode::Game => {
-                    handle_game_key(app, key.modifiers, key.code).await;
+                    game_screen::handle_key(app, key.modifiers, key.code).await;
                 }
                 GameMode::StandardConversation => {
-                    handle_conversation_key(app, key.modifiers, key.code).await;
+                    conversation::handle_key(app, key.modifiers, key.code).await;
                 }
                 GameMode::AgentConversation => {
-                    handle_agent_conversation_key(app, key.modifiers, key.code).await;
+                    agent_conversation::handle_key(app, key.modifiers, key.code).await;
                 }
             }
             true
@@ -89,201 +86,5 @@ async fn handle_terminal_event(
         }
         Some(Ok(_)) => true,
         Some(Err(_)) | None => false,
-    }
-}
-
-async fn handle_player_select_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
-    if modifiers == KeyModifiers::CONTROL && code == KeyCode::Char('c') {
-        app.should_quit = true;
-        return;
-    }
-
-    if app.player_select.creating_player {
-        match code {
-            KeyCode::Esc => app.cancel_create(),
-            KeyCode::Backspace => {
-                app.player_select.player_name_input.pop();
-            }
-            KeyCode::Enter => {
-                let name = app.player_select.player_name_input.trim().to_string();
-                if !name.is_empty()
-                    && let (Some(url), Some(client_id)) = (
-                        app.connection.server_url.clone(),
-                        app.connection.client_id.clone(),
-                    )
-                    && let Ok(info) = create_player(&url, &client_id, &name).await
-                {
-                    let player_id = info.id;
-                    app.player_select.players.push(info);
-                    app.cancel_create();
-                    if select_player(&url, &client_id, player_id).await.is_ok() {
-                        app.mode = GameMode::Game;
-                    }
-                }
-            }
-            KeyCode::Char(c) => app.player_select.player_name_input.push(c),
-            _ => {}
-        }
-        return;
-    }
-
-    match code {
-        KeyCode::Up => app.select_prev(),
-        KeyCode::Down => app.select_next(),
-        KeyCode::Enter => {
-            let create_idx = app.player_select.players.len();
-            if app.player_select.selected_index == create_idx {
-                app.start_create();
-            } else if let Some(player) = app
-                .player_select
-                .players
-                .get(app.player_select.selected_index)
-            {
-                let player_id = player.id;
-                if let (Some(url), Some(client_id)) = (
-                    app.connection.server_url.clone(),
-                    app.connection.client_id.clone(),
-                ) && select_player(&url, &client_id, player_id).await.is_ok()
-                {
-                    app.mode = GameMode::Game;
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-async fn handle_conversation_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
-    match (modifiers, code) {
-        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-            app.should_quit = true;
-        }
-        (_, KeyCode::Up) => app.conversation.select_prev(),
-        (_, KeyCode::Down) => app.conversation.select_next(),
-        (_, KeyCode::Enter) => {
-            if let Some(choice) = app.conversation.selected_choice()
-                && let (Some(url), Some(client_id)) = (
-                    app.connection.server_url.as_deref(),
-                    app.connection.client_id.as_deref(),
-                )
-            {
-                let action =
-                    Interaction::EngagementAction(TurnAction::SelectDialogChoice { choice });
-                let _ = send_interaction(url, client_id, &action).await;
-            }
-        }
-        (_, KeyCode::PageUp) => app.scroll_up(),
-        (_, KeyCode::PageDown) => app.scroll_down(),
-        _ => {}
-    }
-}
-
-async fn handle_agent_conversation_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
-    match (modifiers, code) {
-        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-            app.should_quit = true;
-        }
-        (_, KeyCode::Char(c)) => {
-            app.input.push(c);
-        }
-        (_, KeyCode::Backspace) => {
-            app.input.pop();
-        }
-        (_, KeyCode::Enter) => {
-            let input: String = app.input.drain(..).collect();
-            if input.trim() == "/exit" {
-                if let (Some(url), Some(client_id)) = (
-                    app.connection.server_url.as_deref(),
-                    app.connection.client_id.as_deref(),
-                ) {
-                    let _ = send_interaction(url, client_id, &Interaction::EndConversation).await;
-                }
-            } else if !input.is_empty() {
-                if let (Some(url), Some(client_id)) = (
-                    app.connection.server_url.as_deref(),
-                    app.connection.client_id.as_deref(),
-                ) {
-                    let action = Interaction::EngagementAction(TurnAction::Respond {
-                        content: input.clone(),
-                    });
-                    let _ = send_interaction(url, client_id, &action).await;
-                }
-                app.messages.push(AppMessage::normal(input));
-                app.scroll_offset = 0;
-                app.agent_responding = true;
-            }
-        }
-        (_, KeyCode::PageUp) => app.scroll_up(),
-        (_, KeyCode::PageDown) => app.scroll_down(),
-        _ => {}
-    }
-}
-
-async fn handle_game_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
-    match (modifiers, code) {
-        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-            app.should_quit = true;
-        }
-        (_, KeyCode::Char(c)) => {
-            app.input.push(c);
-        }
-        (_, KeyCode::Backspace) => {
-            app.input.pop();
-        }
-        (_, KeyCode::Enter) => {
-            let input: String = app.input.drain(..).collect();
-            let cmd = commands::parse(&input);
-            let url = app.connection.server_url.as_deref();
-            let client_id = app.connection.client_id.as_deref();
-            match cmd {
-                commands::Command::Move(direction) => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let interaction = Interaction::Movement(Movement::TryDirection(direction));
-                        let _ = send_interaction(url, client_id, &interaction).await;
-                    }
-                }
-                commands::Command::Look => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(url, client_id, &Interaction::Look).await;
-                    }
-                }
-                commands::Command::Help => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(url, client_id, &Interaction::Help).await;
-                    }
-                }
-                commands::Command::Talk(msg) => {
-                    let has_initial = msg.is_some();
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(
-                            url,
-                            client_id,
-                            &Interaction::StartConversation {
-                                initial_message: msg,
-                            },
-                        )
-                        .await;
-                        if has_initial {
-                            app.agent_responding = true;
-                        }
-                    }
-                }
-                commands::Command::Choose(choice) => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let action =
-                            Interaction::EngagementAction(TurnAction::SelectDialogChoice {
-                                choice,
-                            });
-                        let _ = send_interaction(url, client_id, &action).await;
-                    }
-                }
-                _ => {}
-            }
-            app.messages.push(AppMessage::normal(input));
-            app.scroll_offset = 0;
-        }
-        (_, KeyCode::PageUp) => app.scroll_up(),
-        (_, KeyCode::PageDown) => app.scroll_down(),
-        _ => {}
     }
 }

--- a/src/tui/screens/agent_conversation.rs
+++ b/src/tui/screens/agent_conversation.rs
@@ -1,5 +1,6 @@
 use std::time::SystemTime;
 
+use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
@@ -9,7 +10,9 @@ use ratatui::{
 };
 
 use super::super::components::message_log;
-use crate::tui::app::App;
+use crate::game::{Interaction, TurnAction};
+use crate::network::client::send_interaction;
+use crate::tui::app::{App, AppMessage};
 
 const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
@@ -19,6 +22,47 @@ fn spinner_frame() -> char {
         .map(|d| d.as_millis() / 100)
         .unwrap_or(0) as usize;
     SPINNER_FRAMES[idx % SPINNER_FRAMES.len()]
+}
+
+pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    match (modifiers, code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            app.should_quit = true;
+        }
+        (_, KeyCode::Char(c)) => {
+            app.input.push(c);
+        }
+        (_, KeyCode::Backspace) => {
+            app.input.pop();
+        }
+        (_, KeyCode::Enter) => {
+            let input: String = app.input.drain(..).collect();
+            if input.trim() == "/exit" {
+                if let (Some(url), Some(client_id)) = (
+                    app.connection.server_url.as_deref(),
+                    app.connection.client_id.as_deref(),
+                ) {
+                    let _ = send_interaction(url, client_id, &Interaction::EndConversation).await;
+                }
+            } else if !input.is_empty() {
+                if let (Some(url), Some(client_id)) = (
+                    app.connection.server_url.as_deref(),
+                    app.connection.client_id.as_deref(),
+                ) {
+                    let action = Interaction::EngagementAction(TurnAction::Respond {
+                        content: input.clone(),
+                    });
+                    let _ = send_interaction(url, client_id, &action).await;
+                }
+                app.messages.push(AppMessage::normal(input));
+                app.scroll_offset = 0;
+                app.agent_responding = true;
+            }
+        }
+        (_, KeyCode::PageUp) => app.scroll_up(),
+        (_, KeyCode::PageDown) => app.scroll_down(),
+        _ => {}
+    }
 }
 
 pub fn render(frame: &mut Frame, app: &App) {

--- a/src/tui/screens/conversation.rs
+++ b/src/tui/screens/conversation.rs
@@ -1,3 +1,4 @@
+use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
@@ -6,7 +7,34 @@ use ratatui::{
 };
 
 use super::super::components::message_log;
+use crate::game::{Interaction, TurnAction};
+use crate::network::client::send_interaction;
 use crate::tui::app::App;
+
+pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    match (modifiers, code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            app.should_quit = true;
+        }
+        (_, KeyCode::Up) => app.conversation.select_prev(),
+        (_, KeyCode::Down) => app.conversation.select_next(),
+        (_, KeyCode::Enter) => {
+            if let Some(choice) = app.conversation.selected_choice()
+                && let (Some(url), Some(client_id)) = (
+                    app.connection.server_url.as_deref(),
+                    app.connection.client_id.as_deref(),
+                )
+            {
+                let action =
+                    Interaction::EngagementAction(TurnAction::SelectDialogChoice { choice });
+                let _ = send_interaction(url, client_id, &action).await;
+            }
+        }
+        (_, KeyCode::PageUp) => app.scroll_up(),
+        (_, KeyCode::PageDown) => app.scroll_down(),
+        _ => {}
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &App) {
     let option_count = app.conversation.options.len() as u16;

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -1,3 +1,4 @@
+use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
@@ -8,7 +9,79 @@ use ratatui::{
 
 use super::super::components::message_log;
 use super::{agent_conversation, conversation, player_select};
-use crate::tui::app::{App, GameMode};
+use crate::game::{Interaction, Movement, TurnAction};
+use crate::network::client::send_interaction;
+use crate::tui::app::{App, AppMessage, GameMode};
+use crate::tui::commands;
+
+pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    match (modifiers, code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            app.should_quit = true;
+        }
+        (_, KeyCode::Char(c)) => {
+            app.input.push(c);
+        }
+        (_, KeyCode::Backspace) => {
+            app.input.pop();
+        }
+        (_, KeyCode::Enter) => {
+            let input: String = app.input.drain(..).collect();
+            let cmd = commands::parse(&input);
+            let url = app.connection.server_url.as_deref();
+            let client_id = app.connection.client_id.as_deref();
+            match cmd {
+                commands::Command::Move(direction) => {
+                    if let (Some(url), Some(client_id)) = (url, client_id) {
+                        let interaction = Interaction::Movement(Movement::TryDirection(direction));
+                        let _ = send_interaction(url, client_id, &interaction).await;
+                    }
+                }
+                commands::Command::Look => {
+                    if let (Some(url), Some(client_id)) = (url, client_id) {
+                        let _ = send_interaction(url, client_id, &Interaction::Look).await;
+                    }
+                }
+                commands::Command::Help => {
+                    if let (Some(url), Some(client_id)) = (url, client_id) {
+                        let _ = send_interaction(url, client_id, &Interaction::Help).await;
+                    }
+                }
+                commands::Command::Talk(msg) => {
+                    let has_initial = msg.is_some();
+                    if let (Some(url), Some(client_id)) = (url, client_id) {
+                        let _ = send_interaction(
+                            url,
+                            client_id,
+                            &Interaction::StartConversation {
+                                initial_message: msg,
+                            },
+                        )
+                        .await;
+                        if has_initial {
+                            app.agent_responding = true;
+                        }
+                    }
+                }
+                commands::Command::Choose(choice) => {
+                    if let (Some(url), Some(client_id)) = (url, client_id) {
+                        let action =
+                            Interaction::EngagementAction(TurnAction::SelectDialogChoice {
+                                choice,
+                            });
+                        let _ = send_interaction(url, client_id, &action).await;
+                    }
+                }
+                _ => {}
+            }
+            app.messages.push(AppMessage::normal(input));
+            app.scroll_offset = 0;
+        }
+        (_, KeyCode::PageUp) => app.scroll_up(),
+        (_, KeyCode::PageDown) => app.scroll_down(),
+        _ => {}
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &App) {
     if app.mode == GameMode::PlayerSelect {

--- a/src/tui/screens/player_select.rs
+++ b/src/tui/screens/player_select.rs
@@ -1,3 +1,4 @@
+use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
@@ -6,7 +7,69 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
 };
 
-use crate::tui::app::App;
+use crate::network::client::{create_player, select_player};
+use crate::tui::app::{App, GameMode};
+
+pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    if modifiers == KeyModifiers::CONTROL && code == KeyCode::Char('c') {
+        app.should_quit = true;
+        return;
+    }
+
+    if app.player_select.creating_player {
+        match code {
+            KeyCode::Esc => app.cancel_create(),
+            KeyCode::Backspace => {
+                app.player_select.player_name_input.pop();
+            }
+            KeyCode::Enter => {
+                let name = app.player_select.player_name_input.trim().to_string();
+                if !name.is_empty()
+                    && let (Some(url), Some(client_id)) = (
+                        app.connection.server_url.clone(),
+                        app.connection.client_id.clone(),
+                    )
+                    && let Ok(info) = create_player(&url, &client_id, &name).await
+                {
+                    let player_id = info.id;
+                    app.player_select.players.push(info);
+                    app.cancel_create();
+                    if select_player(&url, &client_id, player_id).await.is_ok() {
+                        app.mode = GameMode::Game;
+                    }
+                }
+            }
+            KeyCode::Char(c) => app.player_select.player_name_input.push(c),
+            _ => {}
+        }
+        return;
+    }
+
+    match code {
+        KeyCode::Up => app.select_prev(),
+        KeyCode::Down => app.select_next(),
+        KeyCode::Enter => {
+            let create_idx = app.player_select.players.len();
+            if app.player_select.selected_index == create_idx {
+                app.start_create();
+            } else if let Some(player) = app
+                .player_select
+                .players
+                .get(app.player_select.selected_index)
+            {
+                let player_id = player.id;
+                if let (Some(url), Some(client_id)) = (
+                    app.connection.server_url.clone(),
+                    app.connection.client_id.clone(),
+                ) && select_player(&url, &client_id, player_id).await.is_ok()
+                {
+                    app.mode = GameMode::Game;
+                }
+            }
+        }
+        _ => {}
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &App) {
     let areas = Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).split(frame.area());


### PR DESCRIPTION
## Summary

- Reduces `event.rs` to a thin router — `run()` loop + `handle_terminal_event()` dispatcher only
- Moves each screen's key-handling logic into its own module as `pub async fn handle_key`: `player_select`, `game`, `conversation`, `agent_conversation`
- Mirrors the existing pattern where each screen already owns its `render` function

## Test plan

- [ ] `cargo fmt` — passes
- [ ] `cargo test` — all 212 tests pass
- [ ] `cargo clippy` — no warnings
- [ ] Manual smoke test: all existing keybindings (movement, player select, conversation, agent conversation) work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)