### PR TITLE
Fixes #106 Rename EntityType::Monster to Enemy and apply default faction relations

### DIFF
--- a/muds/basic/entities/zombie.toml
+++ b/muds/basic/entities/zombie.toml
@@ -1,5 +1,5 @@
-entity_type = "monster"
-factions = ["monster"]
+entity_type = "enemy"
+factions = ["enemy"]
 
 [[attributes]]
 definition_id = "hp"

--- a/src/game/component/faction_relations.rs
+++ b/src/game/component/faction_relations.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 const PLAYER_FACTION_ID: &str = "player";
-const MONSTER_FACTION_ID: &str = "monster";
+const ENEMY_FACTION_ID: &str = "enemy";
 
 static NON_INTERACTIVE: FactionRelation = FactionRelation::NonInteractive;
 
@@ -24,7 +24,7 @@ pub struct FactionRelations {
 }
 
 impl FactionRelations {
-    pub fn default_for_monster() -> Self {
+    pub fn default_for_enemy() -> Self {
         let mut factions = HashMap::new();
         factions.insert(PLAYER_FACTION_ID.to_string(), FactionRelation::Hostile);
         Self { factions }
@@ -33,7 +33,7 @@ impl FactionRelations {
     pub fn default_for_player() -> Self {
         let mut factions = HashMap::new();
         factions.insert(PLAYER_FACTION_ID.to_string(), FactionRelation::Friendly);
-        factions.insert(MONSTER_FACTION_ID.to_string(), FactionRelation::Hostile);
+        factions.insert(ENEMY_FACTION_ID.to_string(), FactionRelation::Hostile);
         Self { factions }
     }
 
@@ -43,9 +43,9 @@ impl FactionRelations {
             .unwrap_or(&NON_INTERACTIVE)
     }
 
-    pub fn monster_relation(&self) -> &FactionRelation {
+    pub fn enemy_relation(&self) -> &FactionRelation {
         self.factions
-            .get(MONSTER_FACTION_ID)
+            .get(ENEMY_FACTION_ID)
             .unwrap_or(&NON_INTERACTIVE)
     }
 
@@ -97,20 +97,17 @@ mod tests {
     }
 
     #[test]
-    fn default_for_monster_has_player_hostile() {
-        let relations = FactionRelations::default_for_monster();
+    fn default_for_enemy_has_player_hostile() {
+        let relations = FactionRelations::default_for_enemy();
         assert_eq!(relations.player_relation(), &FactionRelation::Hostile);
-        assert_eq!(
-            relations.monster_relation(),
-            &FactionRelation::NonInteractive
-        );
+        assert_eq!(relations.enemy_relation(), &FactionRelation::NonInteractive);
     }
 
     #[test]
-    fn default_for_player_has_player_friendly_monster_hostile() {
+    fn default_for_player_has_player_friendly_enemy_hostile() {
         let relations = FactionRelations::default_for_player();
         assert_eq!(relations.player_relation(), &FactionRelation::Friendly);
-        assert_eq!(relations.monster_relation(), &FactionRelation::Hostile);
+        assert_eq!(relations.enemy_relation(), &FactionRelation::Hostile);
     }
 
     #[test]
@@ -123,12 +120,9 @@ mod tests {
     }
 
     #[test]
-    fn monster_relation_returns_non_interactive_when_absent() {
+    fn enemy_relation_returns_non_interactive_when_absent() {
         let relations = FactionRelations::default();
-        assert_eq!(
-            relations.monster_relation(),
-            &FactionRelation::NonInteractive
-        );
+        assert_eq!(relations.enemy_relation(), &FactionRelation::NonInteractive);
     }
 
     #[test]
@@ -145,7 +139,7 @@ mod tests {
 
     #[test]
     fn relation_for_returns_non_interactive_for_unknown_faction() {
-        let relations = FactionRelations::default_for_monster();
+        let relations = FactionRelations::default_for_enemy();
         assert_eq!(
             relations.relation_for("bandits"),
             &FactionRelation::NonInteractive
@@ -157,12 +151,12 @@ mod tests {
         let toml = r#"
 [factions]
 player = "hostile"
-monster = "friendly"
+enemy = "friendly"
 bandits = "unfriendly"
 "#;
         let relations: FactionRelations = toml::from_str(toml).unwrap();
         assert_eq!(relations.player_relation(), &FactionRelation::Hostile);
-        assert_eq!(relations.monster_relation(), &FactionRelation::Friendly);
+        assert_eq!(relations.enemy_relation(), &FactionRelation::Friendly);
         assert_eq!(relations.factions["bandits"], FactionRelation::Unfriendly);
     }
 }

--- a/src/game/config/entity_config.rs
+++ b/src/game/config/entity_config.rs
@@ -16,7 +16,7 @@ fn default_agent_type() -> String {
 #[serde(rename_all = "snake_case")]
 pub enum EntityTypeConfig {
     Character,
-    Monster,
+    Enemy,
     Object,
 }
 

--- a/src/game/config/faction_config.rs
+++ b/src/game/config/faction_config.rs
@@ -21,8 +21,8 @@ impl FactionConfig {
             factions: vec![
                 Faction::player(),
                 Faction {
-                    id: "monster".to_string(),
-                    name: "Monster".to_string(),
+                    id: "enemy".to_string(),
+                    name: "Enemy".to_string(),
                     description: "Hostile creatures of the world.".to_string(),
                 },
             ],
@@ -41,7 +41,7 @@ mod tests {
         let config = FactionConfig::default_config();
         let ids: Vec<&str> = config.factions.iter().map(|f| f.id.as_str()).collect();
         assert!(ids.contains(&"player"));
-        assert!(ids.contains(&"monster"));
+        assert!(ids.contains(&"enemy"));
         assert_eq!(config.factions.len(), 2);
     }
 

--- a/src/game/config/map_loader.rs
+++ b/src/game/config/map_loader.rs
@@ -182,7 +182,7 @@ async fn sync_entity(
 ) -> Result<(), Box<dyn Error>> {
     let entity_type = match config.entity_type {
         EntityTypeConfig::Character => EntityType::Character,
-        EntityTypeConfig::Monster => EntityType::Monster,
+        EntityTypeConfig::Enemy => EntityType::Enemy,
         EntityTypeConfig::Object => EntityType::Object,
     };
     let location = Location {

--- a/src/game/config/map_loader.rs
+++ b/src/game/config/map_loader.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::path::Path;
 
-use crate::game::component::Attribute;
+use crate::game::component::{Attribute, FactionRelations};
 use crate::game::config::entity_config::{EntityTypeConfig, load_entity_configs};
 use crate::game::config::map_config::load_map;
 use crate::game::config::{FactionConfig, ResourceConfig};
@@ -206,12 +206,10 @@ async fn sync_entity(
     if !config.attributes.is_empty() {
         sync_entity_attributes(pool, entity_id, config).await?;
     }
-    if !config.factions.is_empty() {
-        faction_repo::set_entity_factions(pool, entity_id, &config.factions).await?;
-    }
-    if let Some(relations) = &config.faction_relations {
-        faction_relations_repo::set_entity_relations(pool, entity_id, relations).await?;
-    }
+    let factions = effective_factions(&entity_type, &config.factions);
+    faction_repo::set_entity_factions(pool, entity_id, &factions).await?;
+    let relations = effective_faction_relations(&entity_type, config.faction_relations.as_ref());
+    faction_relations_repo::set_entity_relations(pool, entity_id, &relations).await?;
     sync_entity_abilities(pool, entity_id, config).await?;
     Ok(())
 }
@@ -263,6 +261,30 @@ async fn sync_entity_attributes(
         .collect();
     entity_repo::update_attributes(pool, entity_id, &attrs).await?;
     Ok(())
+}
+
+fn effective_factions(entity_type: &EntityType, config_factions: &[String]) -> Vec<String> {
+    if !config_factions.is_empty() {
+        return config_factions.to_vec();
+    }
+    match entity_type {
+        EntityType::Player => vec!["player".to_string()],
+        EntityType::Enemy => vec!["enemy".to_string()],
+        _ => vec![],
+    }
+}
+
+fn effective_faction_relations(
+    entity_type: &EntityType,
+    config_relations: Option<&FactionRelations>,
+) -> FactionRelations {
+    config_relations
+        .cloned()
+        .unwrap_or_else(|| match entity_type {
+            EntityType::Player => FactionRelations::default_for_player(),
+            EntityType::Enemy => FactionRelations::default_for_enemy(),
+            _ => FactionRelations::default(),
+        })
 }
 
 #[cfg(test)]
@@ -567,5 +589,91 @@ mod tests {
         assert_eq!(attrs["hp"], Attribute::new("hp".to_string(), 10, 90, 75));
         // mp current_value 50 clamped to new max 30
         assert_eq!(attrs["mp"], Attribute::new("mp".to_string(), 0, 30, 30));
+    }
+
+    fn make_enemy_configs() -> HashMap<String, EntityConfig> {
+        use crate::game::config::entity_config::{EntityConfig, EntityTypeConfig};
+        let config = EntityConfig {
+            id: Some("entities/zombie".to_string()),
+            entity_type: EntityTypeConfig::Enemy,
+            description: None,
+            persona: None,
+            attributes: vec![],
+            entity_effects: vec![],
+            innate_abilities: vec![],
+            factions: vec![],
+            faction_relations: None,
+        };
+        let mut map = HashMap::new();
+        map.insert("entities/zombie".to_string(), config);
+        map
+    }
+
+    fn make_universe_with_enemy() -> Universe {
+        let mut universe = Universe::default();
+        let mut world = World::new("w1".to_string());
+        let mut dungeon = Dungeon::new("d1".to_string());
+        let mut room = Room::new(
+            "r1".to_string(),
+            Description::new(Some("A room.".to_string())),
+        );
+        room.entities.push("entities/zombie".to_string());
+        dungeon.rooms.insert("r1".to_string(), room);
+        world.dungeons.insert("d1".to_string(), dungeon);
+        universe.worlds.insert("w1".to_string(), world);
+        universe
+    }
+
+    async fn setup_enemy_faction(db: &Database) {
+        use crate::game::component::Faction;
+        faction_repo::upsert(
+            db.pool(),
+            &Faction {
+                id: "enemy".to_string(),
+                name: "Enemy".to_string(),
+                description: "Hostile creatures of the world.".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn load_entities_writes_default_factions_for_enemy() {
+        let db = Database::connect_in_memory().await.unwrap();
+        setup_enemy_faction(&db).await;
+        let universe = make_universe_with_enemy();
+        load_map_into_db(db.pool(), &universe).await.unwrap();
+        load_entities_into_db(db.pool(), &universe, &make_enemy_configs())
+            .await
+            .unwrap();
+
+        let entities = entity_repo::find_by_location(db.pool(), &innkeeper_location())
+            .await
+            .unwrap();
+        assert_eq!(entities.len(), 1);
+        assert!(entities[0].factions.contains("enemy"));
+    }
+
+    #[tokio::test]
+    async fn load_entities_writes_default_faction_relations_for_enemy() {
+        use crate::game::component::faction_relations::FactionRelation;
+
+        let db = Database::connect_in_memory().await.unwrap();
+        setup_enemy_faction(&db).await;
+        let universe = make_universe_with_enemy();
+        load_map_into_db(db.pool(), &universe).await.unwrap();
+        load_entities_into_db(db.pool(), &universe, &make_enemy_configs())
+            .await
+            .unwrap();
+
+        let entities = entity_repo::find_by_location(db.pool(), &innkeeper_location())
+            .await
+            .unwrap();
+        assert_eq!(entities.len(), 1);
+        assert_eq!(
+            entities[0].faction_relations.player_relation(),
+            &FactionRelation::Hostile
+        );
     }
 }

--- a/src/game/entity.rs
+++ b/src/game/entity.rs
@@ -13,7 +13,7 @@ use crate::game::component::Location;
 pub enum EntityType {
     Player,
     Character,
-    Monster,
+    Enemy,
     Object,
 }
 
@@ -43,9 +43,14 @@ impl Entity {
         if matches!(entity_type, EntityType::Player) {
             factions.insert("player".to_string());
         }
-        if matches!(entity_type, EntityType::Monster) {
-            factions.insert("monster".to_string());
+        if matches!(entity_type, EntityType::Enemy) {
+            factions.insert("enemy".to_string());
         }
+        let faction_relations = match entity_type {
+            EntityType::Player => FactionRelations::default_for_player(),
+            EntityType::Enemy => FactionRelations::default_for_enemy(),
+            _ => FactionRelations::default(),
+        };
         Self {
             id,
             entity_type,
@@ -57,7 +62,7 @@ impl Entity {
             description: None,
             ai: None,
             factions,
-            faction_relations: FactionRelations::default(),
+            faction_relations,
         }
     }
 }
@@ -65,6 +70,7 @@ impl Entity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::component::faction_relations::FactionRelation;
 
     fn test_location() -> Location {
         Location {
@@ -91,9 +97,9 @@ mod tests {
     }
 
     #[test]
-    fn monster_entity_has_monster_faction() {
-        let entity = Entity::new(2, EntityType::Monster, test_location());
-        assert!(entity.factions.contains("monster"));
+    fn enemy_entity_has_enemy_faction() {
+        let entity = Entity::new(2, EntityType::Enemy, test_location());
+        assert!(entity.factions.contains("enemy"));
         assert_eq!(entity.factions.len(), 1);
     }
 
@@ -101,5 +107,37 @@ mod tests {
     fn non_player_entity_has_empty_factions() {
         let entity = Entity::new(2, EntityType::Character, test_location());
         assert!(entity.factions.is_empty());
+    }
+
+    #[test]
+    fn player_entity_has_default_faction_relations() {
+        let entity = Entity::new(1, EntityType::Player, test_location());
+        assert_eq!(
+            entity.faction_relations.player_relation(),
+            &FactionRelation::Friendly
+        );
+        assert_eq!(
+            entity.faction_relations.enemy_relation(),
+            &FactionRelation::Hostile
+        );
+    }
+
+    #[test]
+    fn enemy_entity_has_default_faction_relations() {
+        let entity = Entity::new(2, EntityType::Enemy, test_location());
+        assert_eq!(
+            entity.faction_relations.player_relation(),
+            &FactionRelation::Hostile
+        );
+        assert_eq!(
+            entity.faction_relations.enemy_relation(),
+            &FactionRelation::NonInteractive
+        );
+    }
+
+    #[test]
+    fn character_entity_has_empty_faction_relations() {
+        let entity = Entity::new(3, EntityType::Character, test_location());
+        assert!(entity.faction_relations.factions.is_empty());
     }
 }

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -193,7 +193,7 @@ room_id = "default"
             .map(|f| f.id.as_str())
             .collect();
         assert!(ids.contains(&"player"));
-        assert!(ids.contains(&"monster"));
+        assert!(ids.contains(&"enemy"));
     }
 
     #[test]

--- a/src/game/interaction/look.rs
+++ b/src/game/interaction/look.rs
@@ -37,7 +37,7 @@ pub async fn process(game_state: &Arc<GameState>, db: &Database, player: &Player
 fn entity_type_label(entity_type: &EntityType) -> &'static str {
     match entity_type {
         EntityType::Character => "character",
-        EntityType::Monster => "monster",
+        EntityType::Enemy => "enemy",
         EntityType::Object => "object",
         EntityType::Player => "player",
     }

--- a/src/persistence/entity_repo.rs
+++ b/src/persistence/entity_repo.rs
@@ -1,10 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sqlx::SqlitePool;
 
 use crate::game::component::Attribute;
 use crate::game::{Entity, EntityType, Location};
 use crate::persistence::error::PersistenceError;
+use crate::persistence::{faction_relations_repo, faction_repo};
 
 type EntityRow = (
     i64,
@@ -93,36 +94,17 @@ pub async fn find_by_id(pool: &SqlitePool, id: i64) -> Result<Option<Entity>, Pe
     let row: Option<EntityRow> = sqlx::query_as(
         "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description FROM entities WHERE id = ?",
     )
-        .bind(id)
-        .fetch_optional(pool)
-        .await?;
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
 
-    Ok(row.map(
-        |(id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description)| {
-            let attributes = attrs_json
-                .and_then(|json| match serde_json::from_str(&json) {
-                    Ok(v) => Some(v),
-                    Err(e) => {
-                        tracing::warn!("Failed to deserialize attributes for entity {id}: {e}");
-                        None
-                    }
-                })
-                .unwrap_or_default();
-            let mut entity = Entity::new(
-                id,
-                entity_type_from_str(&et),
-                Location {
-                    world_id,
-                    dungeon_id,
-                    room_id,
-                },
-            );
-            entity.config_id = config_id;
-            entity.attributes = attributes;
-            entity.description = description;
-            entity
-        },
-    ))
+    if let Some(row) = row {
+        let mut entity = build_entity(row);
+        load_faction_data(pool, &mut entity).await?;
+        Ok(Some(entity))
+    } else {
+        Ok(None)
+    }
 }
 
 pub async fn find_by_location(
@@ -132,41 +114,19 @@ pub async fn find_by_location(
     let rows: Vec<EntityRow> = sqlx::query_as(
         "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description FROM entities WHERE world_id = ? AND dungeon_id = ? AND room_id = ?",
     )
-        .bind(&location.world_id)
-        .bind(&location.dungeon_id)
-        .bind(&location.room_id)
-        .fetch_all(pool)
-        .await?;
+    .bind(&location.world_id)
+    .bind(&location.dungeon_id)
+    .bind(&location.room_id)
+    .fetch_all(pool)
+    .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(
-            |(id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description)| {
-                let attributes = attrs_json
-                    .and_then(|json| match serde_json::from_str(&json) {
-                        Ok(v) => Some(v),
-                        Err(e) => {
-                            tracing::warn!("Failed to deserialize attributes for entity {id}: {e}");
-                            None
-                        }
-                    })
-                    .unwrap_or_default();
-                let mut entity = Entity::new(
-                    id,
-                    entity_type_from_str(&et),
-                    Location {
-                        world_id,
-                        dungeon_id,
-                        room_id,
-                    },
-                );
-                entity.config_id = config_id;
-                entity.attributes = attributes;
-                entity.description = description;
-                entity
-            },
-        )
-        .collect())
+    let mut entities = Vec::new();
+    for row in rows {
+        let mut entity = build_entity(row);
+        load_faction_data(pool, &mut entity).await?;
+        entities.push(entity);
+    }
+    Ok(entities)
 }
 
 pub async fn find_config_entities_by_dungeon(
@@ -182,35 +142,56 @@ pub async fn find_config_entities_by_dungeon(
     .fetch_all(pool)
     .await?;
 
-    Ok(rows
+    let mut entities = Vec::new();
+    for row in rows {
+        let mut entity = build_entity(row);
+        load_faction_data(pool, &mut entity).await?;
+        entities.push(entity);
+    }
+    Ok(entities)
+}
+
+fn build_entity(
+    (id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description): EntityRow,
+) -> Entity {
+    let attributes = attrs_json
+        .and_then(|json| match serde_json::from_str(&json) {
+            Ok(v) => Some(v),
+            Err(e) => {
+                tracing::warn!("Failed to deserialize attributes for entity {id}: {e}");
+                None
+            }
+        })
+        .unwrap_or_default();
+    let mut entity = Entity::new(
+        id,
+        entity_type_from_str(&et),
+        Location {
+            world_id,
+            dungeon_id,
+            room_id,
+        },
+    );
+    entity.config_id = config_id;
+    entity.attributes = attributes;
+    entity.description = description;
+    entity
+}
+
+async fn load_faction_data(pool: &SqlitePool, entity: &mut Entity) -> Result<(), PersistenceError> {
+    let db_factions: HashSet<String> = faction_repo::find_by_entity(pool, entity.id)
+        .await?
         .into_iter()
-        .map(
-            |(id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description)| {
-                let attributes = attrs_json
-                    .and_then(|json| match serde_json::from_str(&json) {
-                        Ok(v) => Some(v),
-                        Err(e) => {
-                            tracing::warn!("Failed to deserialize attributes for entity {id}: {e}");
-                            None
-                        }
-                    })
-                    .unwrap_or_default();
-                let mut entity = Entity::new(
-                    id,
-                    entity_type_from_str(&et),
-                    Location {
-                        world_id,
-                        dungeon_id,
-                        room_id,
-                    },
-                );
-                entity.config_id = config_id;
-                entity.attributes = attributes;
-                entity.description = description;
-                entity
-            },
-        )
-        .collect())
+        .map(|f| f.id)
+        .collect();
+    if !db_factions.is_empty() {
+        entity.factions = db_factions;
+    }
+    let db_relations = faction_relations_repo::find_by_entity(pool, entity.id).await?;
+    if !db_relations.factions.is_empty() {
+        entity.faction_relations = db_relations;
+    }
+    Ok(())
 }
 
 pub async fn update_attributes(
@@ -576,6 +557,67 @@ mod tests {
 
         let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
         assert!(found.attributes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_id_loads_factions_and_faction_relations() {
+        use crate::game::component::Faction;
+        use crate::game::component::faction_relations::FactionRelation;
+        use crate::persistence::{faction_relations_repo, faction_repo};
+
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        faction_repo::upsert(
+            db.pool(),
+            &Faction {
+                id: "enemy".to_string(),
+                name: "Enemy".to_string(),
+                description: "Hostile creatures.".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        faction_repo::set_entity_factions(db.pool(), id, &["enemy".to_string()])
+            .await
+            .unwrap();
+
+        use crate::game::component::FactionRelations;
+        faction_relations_repo::set_entity_relations(
+            db.pool(),
+            id,
+            &FactionRelations::default_for_enemy(),
+        )
+        .await
+        .unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert!(found.factions.contains("enemy"));
+        assert_eq!(
+            found.faction_relations.player_relation(),
+            &FactionRelation::Hostile
+        );
+    }
+
+    #[tokio::test]
+    async fn find_by_id_uses_entity_defaults_when_no_faction_data() {
+        use crate::game::component::faction_relations::FactionRelation;
+
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert!(found.factions.contains("enemy"));
+        assert_eq!(
+            found.faction_relations.player_relation(),
+            &FactionRelation::Hostile
+        );
     }
 
     #[tokio::test]

--- a/src/persistence/entity_repo.rs
+++ b/src/persistence/entity_repo.rs
@@ -262,7 +262,7 @@ fn entity_type_to_str(et: &EntityType) -> &'static str {
     match et {
         EntityType::Player => "player",
         EntityType::Character => "character",
-        EntityType::Monster => "monster",
+        EntityType::Enemy => "enemy",
         EntityType::Object => "object",
     }
 }
@@ -270,7 +270,7 @@ fn entity_type_to_str(et: &EntityType) -> &'static str {
 fn entity_type_from_str(s: &str) -> EntityType {
     match s {
         "player" => EntityType::Player,
-        "monster" => EntityType::Monster,
+        "enemy" => EntityType::Enemy,
         "object" => EntityType::Object,
         _ => EntityType::Character,
     }

--- a/src/persistence/faction_relations_repo.rs
+++ b/src/persistence/faction_relations_repo.rs
@@ -94,7 +94,7 @@ mod tests {
         let db = Database::connect_in_memory().await.unwrap();
         let entity_id = setup(&db).await;
 
-        let mut relations = FactionRelations::default_for_monster();
+        let mut relations = FactionRelations::default_for_enemy();
         relations
             .factions
             .insert("bandits".to_string(), FactionRelation::Unfriendly);
@@ -105,7 +105,7 @@ mod tests {
 
         let found = find_by_entity(db.pool(), entity_id).await.unwrap();
         assert_eq!(found.player_relation(), &FactionRelation::Hostile);
-        assert_eq!(found.monster_relation(), &FactionRelation::NonInteractive);
+        assert_eq!(found.enemy_relation(), &FactionRelation::NonInteractive);
         assert_eq!(found.factions["bandits"], FactionRelation::Unfriendly);
     }
 
@@ -114,13 +114,9 @@ mod tests {
         let db = Database::connect_in_memory().await.unwrap();
         let entity_id = setup(&db).await;
 
-        set_entity_relations(
-            db.pool(),
-            entity_id,
-            &FactionRelations::default_for_monster(),
-        )
-        .await
-        .unwrap();
+        set_entity_relations(db.pool(), entity_id, &FactionRelations::default_for_enemy())
+            .await
+            .unwrap();
 
         set_entity_relations(
             db.pool(),
@@ -132,7 +128,7 @@ mod tests {
 
         let found = find_by_entity(db.pool(), entity_id).await.unwrap();
         assert_eq!(found.player_relation(), &FactionRelation::Friendly);
-        assert_eq!(found.monster_relation(), &FactionRelation::Hostile);
+        assert_eq!(found.enemy_relation(), &FactionRelation::Hostile);
     }
 
     #[tokio::test]
@@ -142,7 +138,7 @@ mod tests {
 
         let found = find_by_entity(db.pool(), entity_id).await.unwrap();
         assert_eq!(found.player_relation(), &FactionRelation::NonInteractive);
-        assert_eq!(found.monster_relation(), &FactionRelation::NonInteractive);
+        assert_eq!(found.enemy_relation(), &FactionRelation::NonInteractive);
         assert!(found.factions.is_empty());
     }
 
@@ -151,13 +147,9 @@ mod tests {
         let db = Database::connect_in_memory().await.unwrap();
         let entity_id = setup(&db).await;
 
-        set_entity_relations(
-            db.pool(),
-            entity_id,
-            &FactionRelations::default_for_monster(),
-        )
-        .await
-        .unwrap();
+        set_entity_relations(db.pool(), entity_id, &FactionRelations::default_for_enemy())
+            .await
+            .unwrap();
 
         entity_repo::delete(db.pool(), entity_id).await.unwrap();
 


### PR DESCRIPTION
## Summary

- Renames `EntityType::Monster` → `EntityType::Enemy` and `EntityTypeConfig::Monster` → `EntityTypeConfig::Enemy` across all source files
- Updates the `"monster"` faction string to `"enemy"` everywhere (faction config, entity constructor, `faction_relations` constants, `zombie.toml`)
- Renames `FactionRelations::default_for_monster()` → `default_for_enemy()` and `monster_relation()` → `enemy_relation()`
- Fixes `Entity::new()` to apply type-appropriate default faction relations (`default_for_player()`, `default_for_enemy()`, or empty) instead of always using `FactionRelations::default()` — covers all entity loading paths since entity_repo always goes through `Entity::new()`

## Test plan

- [ ] All 268 existing tests pass (`cargo test`)
- [ ] No clippy warnings (`cargo clippy`)
- [ ] New tests in `entity.rs` verify `Player`, `Enemy`, and `Character` entities each get the correct default `faction_relations` on construction
- [ ] `zombie.toml` updated to `entity_type = "enemy"` and `factions = ["enemy"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)