### PR TITLE
Fixes #97 Trigger battle engagement on room entry based on faction relations

### DIFF
--- a/src/game/component/interaction.rs
+++ b/src/game/component/interaction.rs
@@ -17,6 +17,8 @@ pub enum Interaction {
     EngagementAction(TurnAction),
     StartConversation { initial_message: Option<String> },
     EndConversation,
+    JoinBattle { engagement_id: i64 },
+    LeaveBattle { engagement_id: i64 },
 }
 
 #[cfg(test)]

--- a/src/game/engagement/engagement.rs
+++ b/src/game/engagement/engagement.rs
@@ -7,6 +7,7 @@ use crate::game::engagement::TurnOrder;
 pub struct Engagement {
     pub id: i64,
     pub engagement_type: EngagementType,
+    pub room_id: Option<String>,
     pub entity_ids: Vec<i64>,
     pub turn_order: TurnOrder,
     pub pending_actions: HashMap<i64, TurnAction>,
@@ -19,6 +20,20 @@ impl Engagement {
         Self {
             id,
             engagement_type,
+            room_id: None,
+            entity_ids,
+            turn_order,
+            pending_actions: HashMap::new(),
+            ticks_on_current_turn: 0,
+        }
+    }
+
+    pub fn new_battle(id: i64, room_id: String, entity_ids: Vec<i64>) -> Self {
+        let turn_order = TurnOrder::new(&entity_ids);
+        Self {
+            id,
+            engagement_type: EngagementType::Battle,
+            room_id: Some(room_id),
             entity_ids,
             turn_order,
             pending_actions: HashMap::new(),
@@ -33,6 +48,7 @@ impl Engagement {
         Self {
             id,
             engagement_type: EngagementType::Conversation,
+            room_id: None,
             entity_ids: vec![player_entity_id, npc_entity_id],
             turn_order,
             pending_actions: HashMap::new(),
@@ -84,6 +100,26 @@ mod tests {
 
     fn make_engagement() -> Engagement {
         Engagement::new(1, EngagementType::Battle, vec![10, 20, 30])
+    }
+
+    #[test]
+    fn new_battle_sets_room_id_and_type() {
+        let eng = Engagement::new_battle(5, "room1".to_string(), vec![1, 2]);
+        assert_eq!(eng.room_id, Some("room1".to_string()));
+        assert_eq!(eng.engagement_type, EngagementType::Battle);
+        assert_eq!(eng.entity_ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn new_sets_room_id_to_none() {
+        let eng = make_engagement();
+        assert_eq!(eng.room_id, None);
+    }
+
+    #[test]
+    fn new_conversation_sets_room_id_to_none() {
+        let eng = Engagement::new_conversation(2, 10, 20);
+        assert_eq!(eng.room_id, None);
     }
 
     #[test]

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -30,6 +30,26 @@ impl Engagements {
         id
     }
 
+    /// Create a battle engagement tied to a specific room. Returns the new engagement's id.
+    pub async fn add_battle(&self, room_id: String, entity_ids: Vec<i64>) -> i64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let engagement = Engagement::new_battle(id, room_id, entity_ids);
+        self.engagements_by_id.write().await.insert(id, engagement);
+        id
+    }
+
+    /// Returns the engagement id of an active Battle in the given room, or `None`.
+    pub async fn find_battle_for_room(&self, room_id: &str) -> Option<i64> {
+        self.engagements_by_id
+            .read()
+            .await
+            .values()
+            .find(|e| {
+                e.engagement_type == EngagementType::Battle && e.room_id.as_deref() == Some(room_id)
+            })
+            .map(|e| e.id)
+    }
+
     /// Create a conversation engagement where only the player takes turns.
     /// Returns the new engagement's id.
     pub async fn add_conversation(&self, player_entity_id: i64, npc_entity_id: i64) -> i64 {
@@ -134,6 +154,43 @@ fn build_resolved_action(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn add_battle_sets_room_id() {
+        let engagements = Engagements::new();
+        let id = engagements
+            .add_battle("room1".to_string(), vec![1, 2])
+            .await;
+        let map = engagements.engagements_by_id.read().await;
+        let eng = map.get(&id).unwrap();
+        assert_eq!(eng.room_id, Some("room1".to_string()));
+        assert_eq!(eng.engagement_type, EngagementType::Battle);
+    }
+
+    #[tokio::test]
+    async fn find_battle_for_room_returns_id_when_present() {
+        let engagements = Engagements::new();
+        let id = engagements
+            .add_battle("room1".to_string(), vec![1, 2])
+            .await;
+        assert_eq!(engagements.find_battle_for_room("room1").await, Some(id));
+    }
+
+    #[tokio::test]
+    async fn find_battle_for_room_returns_none_for_different_room() {
+        let engagements = Engagements::new();
+        engagements
+            .add_battle("room1".to_string(), vec![1, 2])
+            .await;
+        assert_eq!(engagements.find_battle_for_room("room2").await, None);
+    }
+
+    #[tokio::test]
+    async fn find_battle_for_room_returns_none_for_conversation() {
+        let engagements = Engagements::new();
+        engagements.add_conversation(1, 2).await;
+        assert_eq!(engagements.find_battle_for_room("room1").await, None);
+    }
 
     #[tokio::test]
     async fn add_returns_sequential_ids() {

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -2,6 +2,7 @@ pub mod conversation;
 pub mod help;
 pub mod look;
 pub mod movement;
+pub mod room_threats;
 
 use std::sync::Arc;
 

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use tracing;
 
 use crate::game::component::interaction::Movement;
+use crate::game::engagement::TurnAction;
 use crate::game::player::Player;
 use crate::game::{GameState, Interaction};
 use crate::persistence::Database;
@@ -42,32 +43,63 @@ async fn dispatch_interaction(
     interaction: Interaction,
 ) {
     match interaction {
-        Interaction::Look => {
-            look::process(game_state, db, player).await;
+        Interaction::Look => look::process(game_state, db, player).await,
+        Interaction::Help => help::process(game_state, player).await,
+        Interaction::Movement(m) => dispatch_movement(game_state, db, player, m).await,
+        Interaction::EngagementAction(action) => {
+            dispatch_engagement_action(game_state, player, action).await;
         }
-        Interaction::Help => {
-            help::process(game_state, player).await;
+        conv @ (Interaction::StartConversation { .. } | Interaction::EndConversation) => {
+            dispatch_conversation(game_state, player, conv).await;
         }
-        Interaction::Movement(Movement::TryDirection(direction)) => {
+        Interaction::JoinBattle { engagement_id } | Interaction::LeaveBattle { engagement_id } => {
+            tracing::debug!(engagement_id, "battle interaction");
+        }
+    }
+}
+
+async fn dispatch_movement(
+    game_state: &Arc<GameState>,
+    db: &Database,
+    player: &Player,
+    movement: Movement,
+) {
+    match movement {
+        Movement::TryDirection(direction) => {
             movement::process(game_state, db, player, direction).await;
         }
-        Interaction::Movement(Movement::Warp(_)) => {}
-        Interaction::EngagementAction(action) => {
-            let accepted = game_state
-                .engagements
-                .submit_action_for_entity(player.entity_id, action)
-                .await;
-            tracing::debug!(
-                entity_id = player.entity_id,
-                accepted,
-                "engagement action submitted"
-            );
-        }
+        Movement::Warp(_) => {}
+    }
+}
+
+async fn dispatch_engagement_action(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    action: TurnAction,
+) {
+    let accepted = game_state
+        .engagements
+        .submit_action_for_entity(player.entity_id, action)
+        .await;
+    tracing::debug!(
+        entity_id = player.entity_id,
+        accepted,
+        "engagement action submitted"
+    );
+}
+
+async fn dispatch_conversation(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    interaction: Interaction,
+) {
+    match interaction {
         Interaction::StartConversation { initial_message } => {
             conversation::process(game_state, player, initial_message).await;
         }
         Interaction::EndConversation => {
             conversation::end_player_conversation(game_state, player).await;
         }
+        _ => {}
     }
 }

--- a/src/game/interaction/movement.rs
+++ b/src/game/interaction/movement.rs
@@ -1,9 +1,7 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
 use tracing;
 
-use crate::game::component::faction_relations::FactionRelation;
 use crate::game::component::interaction::Direction;
 use crate::game::map::universe::navigation::Navigation;
 use crate::game::player::Player;
@@ -13,6 +11,7 @@ use crate::persistence::Database;
 use crate::persistence::{entity_repo, room_repo};
 
 use super::look;
+use super::room_threats;
 
 struct NavTarget {
     world_id: Option<String>,
@@ -91,7 +90,7 @@ async fn execute_move(
         format!("You move {direction}."),
     );
     look::process(game_state, db, player).await;
-    check_room_hostility(game_state, player, &new_location.room_id).await;
+    room_threats::check_room_hostility(game_state, player, &new_location.room_id).await;
 }
 
 async fn update_entity_location(
@@ -121,107 +120,5 @@ async fn sync_if_dungeon_changed(
         || new_location.dungeon_id != old_location.dungeon_id;
     if dungeon_changed && let Err(e) = game_state.sync_active_entities(db.pool()).await {
         tracing::error!("Failed to sync active entities after dungeon change: {e}");
-    }
-}
-
-enum RoomThreat {
-    Hostile,
-    Unfriendly,
-    None,
-}
-
-async fn check_room_hostility(game_state: &Arc<GameState>, player: &Player, room_id: &str) {
-    if game_state
-        .engagements
-        .find_battle_for_room(room_id)
-        .await
-        .is_some()
-    {
-        messaging::message(
-            &game_state.message_tx,
-            player.id,
-            "A battle is already underway here! You can join or flee.",
-        );
-        return;
-    }
-
-    let (hostile_ids, unfriendly_ids) =
-        scan_room_threats(game_state, player.entity_id, room_id).await;
-
-    if !hostile_ids.is_empty() {
-        start_battle(game_state, player, room_id, hostile_ids).await;
-    } else if !unfriendly_ids.is_empty() {
-        messaging::message(
-            &game_state.message_tx,
-            player.id,
-            "Some here look unfriendly. You could choose to engage them.",
-        );
-    }
-}
-
-async fn scan_room_threats(
-    game_state: &Arc<GameState>,
-    player_entity_id: i64,
-    room_id: &str,
-) -> (Vec<i64>, Vec<i64>) {
-    let entities = game_state.active_entities.read().await;
-    let player_factions = entities
-        .get(&player_entity_id)
-        .map(|e| e.factions.clone())
-        .unwrap_or_default();
-
-    let mut hostile_ids = Vec::new();
-    let mut unfriendly_ids = Vec::new();
-    for entity in entities.values() {
-        if entity.id == player_entity_id || entity.location.room_id != room_id {
-            continue;
-        }
-        match entity_threat_toward_player(&entity.faction_relations.factions, &player_factions) {
-            RoomThreat::Hostile => hostile_ids.push(entity.id),
-            RoomThreat::Unfriendly => unfriendly_ids.push(entity.id),
-            RoomThreat::None => {}
-        }
-    }
-    (hostile_ids, unfriendly_ids)
-}
-
-async fn start_battle(
-    game_state: &Arc<GameState>,
-    player: &Player,
-    room_id: &str,
-    hostile_ids: Vec<i64>,
-) {
-    let mut battle_ids = vec![player.entity_id];
-    battle_ids.extend(hostile_ids);
-    game_state
-        .engagements
-        .add_battle(room_id.to_string(), battle_ids)
-        .await;
-    messaging::message(
-        &game_state.message_tx,
-        player.id,
-        "Hostile entities attack! A battle has started.",
-    );
-}
-
-fn entity_threat_toward_player(
-    entity_faction_relations: &std::collections::HashMap<String, FactionRelation>,
-    player_factions: &HashSet<String>,
-) -> RoomThreat {
-    let mut found_unfriendly = false;
-    for faction_id in player_factions {
-        match entity_faction_relations
-            .get(faction_id)
-            .unwrap_or(&FactionRelation::NonInteractive)
-        {
-            FactionRelation::Hostile => return RoomThreat::Hostile,
-            FactionRelation::Unfriendly => found_unfriendly = true,
-            _ => {}
-        }
-    }
-    if found_unfriendly {
-        RoomThreat::Unfriendly
-    } else {
-        RoomThreat::None
     }
 }

--- a/src/game/interaction/movement.rs
+++ b/src/game/interaction/movement.rs
@@ -1,7 +1,9 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use tracing;
 
+use crate::game::component::faction_relations::FactionRelation;
 use crate::game::component::interaction::Direction;
 use crate::game::map::universe::navigation::Navigation;
 use crate::game::player::Player;
@@ -89,6 +91,7 @@ async fn execute_move(
         format!("You move {direction}."),
     );
     look::process(game_state, db, player).await;
+    check_room_hostility(game_state, player, &new_location.room_id).await;
 }
 
 async fn update_entity_location(
@@ -118,5 +121,107 @@ async fn sync_if_dungeon_changed(
         || new_location.dungeon_id != old_location.dungeon_id;
     if dungeon_changed && let Err(e) = game_state.sync_active_entities(db.pool()).await {
         tracing::error!("Failed to sync active entities after dungeon change: {e}");
+    }
+}
+
+enum RoomThreat {
+    Hostile,
+    Unfriendly,
+    None,
+}
+
+async fn check_room_hostility(game_state: &Arc<GameState>, player: &Player, room_id: &str) {
+    if game_state
+        .engagements
+        .find_battle_for_room(room_id)
+        .await
+        .is_some()
+    {
+        messaging::message(
+            &game_state.message_tx,
+            player.id,
+            "A battle is already underway here! You can join or flee.",
+        );
+        return;
+    }
+
+    let (hostile_ids, unfriendly_ids) =
+        scan_room_threats(game_state, player.entity_id, room_id).await;
+
+    if !hostile_ids.is_empty() {
+        start_battle(game_state, player, room_id, hostile_ids).await;
+    } else if !unfriendly_ids.is_empty() {
+        messaging::message(
+            &game_state.message_tx,
+            player.id,
+            "Some here look unfriendly. You could choose to engage them.",
+        );
+    }
+}
+
+async fn scan_room_threats(
+    game_state: &Arc<GameState>,
+    player_entity_id: i64,
+    room_id: &str,
+) -> (Vec<i64>, Vec<i64>) {
+    let entities = game_state.active_entities.read().await;
+    let player_factions = entities
+        .get(&player_entity_id)
+        .map(|e| e.factions.clone())
+        .unwrap_or_default();
+
+    let mut hostile_ids = Vec::new();
+    let mut unfriendly_ids = Vec::new();
+    for entity in entities.values() {
+        if entity.id == player_entity_id || entity.location.room_id != room_id {
+            continue;
+        }
+        match entity_threat_toward_player(&entity.faction_relations.factions, &player_factions) {
+            RoomThreat::Hostile => hostile_ids.push(entity.id),
+            RoomThreat::Unfriendly => unfriendly_ids.push(entity.id),
+            RoomThreat::None => {}
+        }
+    }
+    (hostile_ids, unfriendly_ids)
+}
+
+async fn start_battle(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    room_id: &str,
+    hostile_ids: Vec<i64>,
+) {
+    let mut battle_ids = vec![player.entity_id];
+    battle_ids.extend(hostile_ids);
+    game_state
+        .engagements
+        .add_battle(room_id.to_string(), battle_ids)
+        .await;
+    messaging::message(
+        &game_state.message_tx,
+        player.id,
+        "Hostile entities attack! A battle has started.",
+    );
+}
+
+fn entity_threat_toward_player(
+    entity_faction_relations: &std::collections::HashMap<String, FactionRelation>,
+    player_factions: &HashSet<String>,
+) -> RoomThreat {
+    let mut found_unfriendly = false;
+    for faction_id in player_factions {
+        match entity_faction_relations
+            .get(faction_id)
+            .unwrap_or(&FactionRelation::NonInteractive)
+        {
+            FactionRelation::Hostile => return RoomThreat::Hostile,
+            FactionRelation::Unfriendly => found_unfriendly = true,
+            _ => {}
+        }
+    }
+    if found_unfriendly {
+        RoomThreat::Unfriendly
+    } else {
+        RoomThreat::None
     }
 }

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -1,0 +1,115 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use tracing;
+
+use crate::game::component::faction_relations::FactionRelation;
+use crate::game::player::Player;
+use crate::game::{GameState, messaging};
+
+enum RoomThreat {
+    Hostile,
+    Unfriendly,
+    None,
+}
+
+pub async fn check_room_hostility(game_state: &Arc<GameState>, player: &Player, room_id: &str) {
+    if game_state
+        .engagements
+        .find_battle_for_room(room_id)
+        .await
+        .is_some()
+    {
+        messaging::message(
+            &game_state.message_tx,
+            player.id,
+            "A battle is already underway here! You can join or flee.",
+        );
+        return;
+    }
+
+    let (hostile_ids, unfriendly_ids) =
+        scan_room_threats(game_state, player.entity_id, room_id).await;
+
+    if !hostile_ids.is_empty() {
+        start_battle(game_state, player, room_id, hostile_ids).await;
+    } else if !unfriendly_ids.is_empty() {
+        messaging::message(
+            &game_state.message_tx,
+            player.id,
+            "Some here look unfriendly. You could choose to engage them.",
+        );
+    }
+}
+
+async fn scan_room_threats(
+    game_state: &Arc<GameState>,
+    player_entity_id: i64,
+    room_id: &str,
+) -> (Vec<i64>, Vec<i64>) {
+    let entities = game_state.active_entities.read().await;
+    let player_factions = entities
+        .get(&player_entity_id)
+        .map(|e| e.factions.clone())
+        .unwrap_or_default();
+
+    let mut hostile_ids = Vec::new();
+    let mut unfriendly_ids = Vec::new();
+    for entity in entities.values() {
+        if entity.id == player_entity_id || entity.location.room_id != room_id {
+            continue;
+        }
+        match entity_threat_toward_player(&entity.faction_relations.factions, &player_factions) {
+            RoomThreat::Hostile => hostile_ids.push(entity.id),
+            RoomThreat::Unfriendly => unfriendly_ids.push(entity.id),
+            RoomThreat::None => {}
+        }
+    }
+    (hostile_ids, unfriendly_ids)
+}
+
+async fn start_battle(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    room_id: &str,
+    hostile_ids: Vec<i64>,
+) {
+    let mut battle_ids = vec![player.entity_id];
+    battle_ids.extend(hostile_ids);
+    tracing::info!(
+        room_id,
+        entity_ids = ?battle_ids,
+        "battle started"
+    );
+    game_state
+        .engagements
+        .add_battle(room_id.to_string(), battle_ids)
+        .await;
+    messaging::message(
+        &game_state.message_tx,
+        player.id,
+        "Hostile entities attack! A battle has started.",
+    );
+}
+
+fn entity_threat_toward_player(
+    entity_faction_relations: &HashMap<String, FactionRelation>,
+    player_factions: &HashSet<String>,
+) -> RoomThreat {
+    let mut found_unfriendly = false;
+    for faction_id in player_factions {
+        match entity_faction_relations
+            .get(faction_id)
+            .unwrap_or(&FactionRelation::NonInteractive)
+        {
+            FactionRelation::Hostile => return RoomThreat::Hostile,
+            FactionRelation::Unfriendly => found_unfriendly = true,
+            _ => {}
+        }
+    }
+    if found_unfriendly {
+        RoomThreat::Unfriendly
+    } else {
+        RoomThreat::None
+    }
+}

--- a/src/network/server/handlers/player.rs
+++ b/src/network/server/handlers/player.rs
@@ -5,6 +5,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use tracing::info;
 
+use crate::game::interaction::room_threats;
 use crate::game::{Entity, EntityType, Location, Player};
 use crate::network::event::{NetworkEvent, PlayerInfo, PlayerListResponse};
 use crate::network::server::state::{AppState, PlayerCreateBody, PlayerListBody, PlayerSelectBody};
@@ -89,8 +90,10 @@ async fn activate_player(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
+    let room_id = entity.location.room_id.clone();
     register_player_in_game_state(state, client_id, player, entity).await;
     notify_player_selected(state, client_id, player).await;
+    room_threats::check_room_hostility(&state.game_state, player, &room_id).await;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Adds `room_id: Option<String>` to `Engagement` and a `new_battle` constructor; adds `add_battle` / `find_battle_for_room` to `Engagements`
- Adds `JoinBattle` and `LeaveBattle` variants to the `Interaction` enum (stub dispatch with debug logging; full battle TUI is #98)
- After each successful movement, checks the destination room for hostile/unfriendly entities and auto-starts a battle engagement or announces options accordingly

## Test plan

- [ ] `cargo fmt && cargo test && cargo clippy` passes clean (279 tests, no warnings)
- [ ] New unit tests cover `Engagement::new_battle`, `Engagements::add_battle`, and `Engagements::find_battle_for_room`
- [ ] Move a player into a room containing an enemy entity → "Hostile entities attack! A battle has started." message appears
- [ ] Move into a room with an unfriendly entity → unfriendly announcement appears
- [ ] Move into a room where a battle is already active → join/flee announcement appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)