### PR TITLE
Fixes #98 Implement full battle engagement turn flow

### DIFF
--- a/src/game/engagement.rs
+++ b/src/game/engagement.rs
@@ -1,3 +1,4 @@
+pub mod battle;
 pub mod conversation;
 #[allow(clippy::module_inception)]
 pub mod engagement;
@@ -8,6 +9,7 @@ pub mod resolved_action;
 pub mod turn_action;
 pub mod turn_order;
 
+pub use battle::{BattleEngagement, BattleMessage, BattlePhase, QueuedAbility};
 pub use engagement::Engagement;
 pub use engagement_type::EngagementType;
 pub use engagements::Engagements;

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -1,0 +1,391 @@
+pub mod loot;
+pub mod message;
+pub mod phase;
+pub mod queued_ability;
+
+use std::collections::HashMap;
+
+use crate::game::component::{Ability, Attribute, Cost};
+use crate::game::engagement::EngagementType;
+
+pub use message::BattleMessage;
+pub use phase::BattlePhase;
+pub use queued_ability::QueuedAbility;
+
+pub struct BattleTick {
+    pub engagement_id: i64,
+    pub all_participant_ids: Vec<i64>,
+    pub messages: Vec<BattleMessage>,
+    pub innate_entity_ids: Vec<i64>,
+    pub resolution_queue: Vec<QueuedAbility>,
+    pub phase: BattlePhase,
+}
+
+pub struct BattleEngagement {
+    pub factions: Vec<String>,
+    pub participants: HashMap<String, Vec<i64>>,
+    pub turn_phase: BattlePhase,
+    action_queue: HashMap<i64, Vec<QueuedAbility>>,
+    ticks_in_phase: u64,
+    pending_costs: HashMap<i64, Vec<(String, i64)>>,
+}
+
+impl BattleEngagement {
+    pub fn new(factions: Vec<String>, participants: HashMap<String, Vec<i64>>) -> Self {
+        Self {
+            factions,
+            participants,
+            turn_phase: BattlePhase::InnateEffects,
+            action_queue: HashMap::new(),
+            ticks_in_phase: 0,
+            pending_costs: HashMap::new(),
+        }
+    }
+
+    pub fn all_entity_ids(&self) -> Vec<i64> {
+        self.participants.values().flatten().copied().collect()
+    }
+
+    pub fn attacker_ids(&self) -> Vec<i64> {
+        self.factions
+            .first()
+            .and_then(|f| self.participants.get(f))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn defender_ids(&self) -> Vec<i64> {
+        let attacker_faction = self.factions.first().map(String::as_str);
+        self.participants
+            .iter()
+            .filter(|(f, _)| Some(f.as_str()) != attacker_faction)
+            .flat_map(|(_, ids)| ids.iter().copied())
+            .collect()
+    }
+
+    /// Queue an ability for the caster targeting the given entity. Validates and tracks resource
+    /// costs for potential refund. Returns false if the caster lacks sufficient resources.
+    pub fn queue_ability(
+        &mut self,
+        caster_id: i64,
+        ability: Ability,
+        target_id: i64,
+        entity_attrs: &HashMap<String, Attribute>,
+    ) -> bool {
+        for cost in &ability.costs {
+            let Cost::Resource {
+                resource_id,
+                amount,
+            } = cost;
+            match entity_attrs.get(resource_id) {
+                Some(attr) if attr.current_value >= *amount => {}
+                _ => return false,
+            }
+        }
+        let tracked: Vec<(String, i64)> = ability
+            .costs
+            .iter()
+            .map(|c| {
+                let Cost::Resource {
+                    resource_id,
+                    amount,
+                } = c;
+                (resource_id.clone(), *amount)
+            })
+            .collect();
+        if !tracked.is_empty() {
+            self.pending_costs
+                .entry(caster_id)
+                .or_default()
+                .extend(tracked);
+        }
+        self.action_queue
+            .entry(caster_id)
+            .or_default()
+            .push(QueuedAbility {
+                caster_id,
+                ability,
+                target_id,
+            });
+        true
+    }
+
+    pub fn refund_all_costs(&self, entities: &mut HashMap<i64, crate::game::entity::Entity>) {
+        for (entity_id, costs) in &self.pending_costs {
+            if let Some(entity) = entities.get_mut(entity_id) {
+                for (attr_id, amount) in costs {
+                    if let Some(attr) = entity.attributes.get_mut(attr_id) {
+                        attr.current_value = (attr.current_value + amount).min(attr.max_value);
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn remove_entity(&mut self, entity_id: i64) {
+        for ids in self.participants.values_mut() {
+            ids.retain(|&id| id != entity_id);
+        }
+        self.action_queue.remove(&entity_id);
+        self.pending_costs.remove(&entity_id);
+    }
+
+    pub fn surviving_faction_count(&self) -> usize {
+        self.participants
+            .values()
+            .filter(|ids| !ids.is_empty())
+            .count()
+    }
+
+    pub fn tick(&mut self, engagement_id: i64, max_engage_ticks: u64) -> BattleTick {
+        let all_participant_ids = self.all_entity_ids();
+        let mut messages = Vec::new();
+        let mut innate_entity_ids = Vec::new();
+        let mut resolution_queue = Vec::new();
+
+        match self.turn_phase.clone() {
+            BattlePhase::InnateEffects => {
+                innate_entity_ids = all_participant_ids.clone();
+                messages.push(BattleMessage::PhaseChange {
+                    phase: BattlePhase::AttackerPlanning,
+                });
+                self.turn_phase = BattlePhase::AttackerPlanning;
+                self.ticks_in_phase = 0;
+            }
+            BattlePhase::AttackerPlanning => {
+                self.ticks_in_phase += 1;
+                let attacker_ids = self.attacker_ids();
+                let all_submitted = attacker_ids
+                    .iter()
+                    .all(|id| self.action_queue.contains_key(id));
+                if all_submitted || self.ticks_in_phase >= max_engage_ticks {
+                    messages.push(BattleMessage::PhaseChange {
+                        phase: BattlePhase::DefenderResponse,
+                    });
+                    self.turn_phase = BattlePhase::DefenderResponse;
+                    self.ticks_in_phase = 0;
+                }
+            }
+            BattlePhase::DefenderResponse => {
+                self.ticks_in_phase += 1;
+                let defender_ids = self.defender_ids();
+                let all_submitted = defender_ids.is_empty()
+                    || defender_ids
+                        .iter()
+                        .all(|id| self.action_queue.contains_key(id));
+                if all_submitted || self.ticks_in_phase >= max_engage_ticks {
+                    messages.push(BattleMessage::PhaseChange {
+                        phase: BattlePhase::Resolution,
+                    });
+                    self.turn_phase = BattlePhase::Resolution;
+                    self.ticks_in_phase = 0;
+                }
+            }
+            BattlePhase::Resolution => {
+                resolution_queue = self
+                    .action_queue
+                    .drain()
+                    .flat_map(|(_, abilities)| abilities)
+                    .collect();
+                self.pending_costs.clear();
+                messages.push(BattleMessage::PhaseChange {
+                    phase: BattlePhase::InnateEffects,
+                });
+                self.turn_phase = BattlePhase::InnateEffects;
+                self.ticks_in_phase = 0;
+            }
+            BattlePhase::Concluded => {}
+        }
+
+        BattleTick {
+            engagement_id,
+            all_participant_ids,
+            messages,
+            innate_entity_ids,
+            resolution_queue,
+            phase: self.turn_phase.clone(),
+        }
+    }
+}
+
+fn battle_abilities(entity: &crate::game::entity::Entity) -> Vec<Ability> {
+    entity
+        .innate_abilities
+        .iter()
+        .filter(|a| a.engagement_types.contains(&EngagementType::Battle))
+        .cloned()
+        .collect()
+}
+
+pub fn entity_innate_battle_abilities(entity: &crate::game::entity::Entity) -> Vec<Ability> {
+    battle_abilities(entity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_participants() -> (Vec<String>, HashMap<String, Vec<i64>>) {
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2, 3]);
+        let factions = vec!["player".to_string(), "enemy".to_string()];
+        (factions, participants)
+    }
+
+    fn make_engagement() -> BattleEngagement {
+        let (factions, participants) = make_participants();
+        BattleEngagement::new(factions, participants)
+    }
+
+    #[test]
+    fn new_starts_in_innate_effects_phase() {
+        let eng = make_engagement();
+        assert_eq!(eng.turn_phase, BattlePhase::InnateEffects);
+    }
+
+    #[test]
+    fn all_entity_ids_returns_all_participants() {
+        let eng = make_engagement();
+        let mut ids = eng.all_entity_ids();
+        ids.sort();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn attacker_ids_returns_first_faction() {
+        let eng = make_engagement();
+        assert_eq!(eng.attacker_ids(), vec![1]);
+    }
+
+    #[test]
+    fn defender_ids_returns_non_first_factions() {
+        let eng = make_engagement();
+        let mut ids = eng.defender_ids();
+        ids.sort();
+        assert_eq!(ids, vec![2, 3]);
+    }
+
+    #[test]
+    fn remove_entity_removes_from_participants() {
+        let mut eng = make_engagement();
+        eng.remove_entity(2);
+        let mut ids = eng.all_entity_ids();
+        ids.sort();
+        assert_eq!(ids, vec![1, 3]);
+    }
+
+    #[test]
+    fn surviving_faction_count_counts_non_empty_factions() {
+        let mut eng = make_engagement();
+        assert_eq!(eng.surviving_faction_count(), 2);
+        eng.remove_entity(1);
+        assert_eq!(eng.surviving_faction_count(), 1);
+    }
+
+    #[test]
+    fn tick_innate_effects_transitions_to_attacker_planning() {
+        let mut eng = make_engagement();
+        let tick = eng.tick(1, 30);
+        assert_eq!(eng.turn_phase, BattlePhase::AttackerPlanning);
+        assert!(!tick.innate_entity_ids.is_empty());
+        assert!(tick.messages.iter().any(|m| matches!(
+            m,
+            BattleMessage::PhaseChange {
+                phase: BattlePhase::AttackerPlanning
+            }
+        )));
+    }
+
+    #[test]
+    fn tick_attacker_planning_waits_for_timeout() {
+        let mut eng = make_engagement();
+        eng.tick(1, 30); // InnateEffects → AttackerPlanning
+        let tick = eng.tick(1, 30);
+        assert_eq!(eng.turn_phase, BattlePhase::AttackerPlanning);
+        assert!(tick.messages.is_empty());
+    }
+
+    #[test]
+    fn tick_attacker_planning_advances_on_timeout() {
+        let mut eng = make_engagement();
+        eng.tick(1, 1); // InnateEffects → AttackerPlanning
+        let tick = eng.tick(1, 1); // timeout
+        assert_eq!(eng.turn_phase, BattlePhase::DefenderResponse);
+        assert!(tick.messages.iter().any(|m| matches!(
+            m,
+            BattleMessage::PhaseChange {
+                phase: BattlePhase::DefenderResponse
+            }
+        )));
+    }
+
+    #[test]
+    fn tick_defender_response_advances_on_timeout() {
+        let mut eng = make_engagement();
+        eng.tick(1, 1); // InnateEffects → AttackerPlanning
+        eng.tick(1, 1); // timeout → DefenderResponse
+        let tick = eng.tick(1, 1); // timeout → Resolution
+        assert_eq!(eng.turn_phase, BattlePhase::Resolution);
+        assert!(tick.messages.iter().any(|m| matches!(
+            m,
+            BattleMessage::PhaseChange {
+                phase: BattlePhase::Resolution
+            }
+        )));
+    }
+
+    #[test]
+    fn tick_resolution_drains_queue_and_resets() {
+        let mut eng = make_engagement();
+        eng.tick(1, 1); // → AttackerPlanning
+        eng.tick(1, 1); // → DefenderResponse
+        eng.tick(1, 1); // → Resolution
+        let tick = eng.tick(1, 1); // Resolution → InnateEffects
+        assert_eq!(eng.turn_phase, BattlePhase::InnateEffects);
+        assert!(tick.messages.iter().any(|m| matches!(
+            m,
+            BattleMessage::PhaseChange {
+                phase: BattlePhase::InnateEffects
+            }
+        )));
+    }
+
+    #[test]
+    fn tick_concluded_is_noop() {
+        let mut eng = make_engagement();
+        eng.turn_phase = BattlePhase::Concluded;
+        let tick = eng.tick(1, 30);
+        assert_eq!(eng.turn_phase, BattlePhase::Concluded);
+        assert!(tick.messages.is_empty());
+    }
+
+    #[test]
+    fn queue_ability_rejects_without_sufficient_resources() {
+        use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+
+        let mut eng = make_engagement();
+        let ability = Ability {
+            id: "fireball".to_string(),
+            name: "Fireball".to_string(),
+            description: None,
+            effects: vec![Effect {
+                name: "fire_damage".to_string(),
+                effect_type: EffectType::AttributeUpdate {
+                    attribute_id: "hp".to_string(),
+                    value: -20,
+                },
+                trigger_info: TriggerInfo::Once,
+                description: EffectDescription::default(),
+            }],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![Cost::Resource {
+                resource_id: "mp".to_string(),
+                amount: 10,
+            }],
+            modifiers: vec![],
+        };
+        let attrs: HashMap<String, Attribute> = HashMap::new(); // no mp
+        assert!(!eng.queue_ability(1, ability, 2, &attrs));
+    }
+}

--- a/src/game/engagement/battle/loot.rs
+++ b/src/game/engagement/battle/loot.rs
@@ -1,0 +1,6 @@
+pub fn resolve_loot(participants: &[i64]) {
+    tracing::info!(
+        participant_count = participants.len(),
+        "loot resolution placeholder"
+    );
+}

--- a/src/game/engagement/battle/message.rs
+++ b/src/game/engagement/battle/message.rs
@@ -1,0 +1,71 @@
+use std::fmt;
+
+use crate::game::engagement::battle::phase::BattlePhase;
+
+#[derive(Debug, Clone)]
+pub enum BattleMessage {
+    PhaseChange {
+        phase: BattlePhase,
+    },
+    AbilityCast {
+        caster_name: String,
+        target_name: String,
+        ability_name: String,
+    },
+    EntityDied {
+        name: String,
+    },
+    Meta(String),
+}
+
+impl fmt::Display for BattleMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BattleMessage::PhaseChange { phase } => write!(f, "[Battle: {phase}]"),
+            BattleMessage::AbilityCast {
+                caster_name,
+                target_name,
+                ability_name,
+            } => write!(f, "{caster_name} uses {ability_name} on {target_name}."),
+            BattleMessage::EntityDied { name } => write!(f, "{name} has been defeated!"),
+            BattleMessage::Meta(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_change_display() {
+        let msg = BattleMessage::PhaseChange {
+            phase: BattlePhase::Resolution,
+        };
+        assert_eq!(msg.to_string(), "[Battle: Resolution]");
+    }
+
+    #[test]
+    fn ability_cast_display() {
+        let msg = BattleMessage::AbilityCast {
+            caster_name: "Goblin".to_string(),
+            target_name: "Player".to_string(),
+            ability_name: "Slash".to_string(),
+        };
+        assert_eq!(msg.to_string(), "Goblin uses Slash on Player.");
+    }
+
+    #[test]
+    fn entity_died_display() {
+        let msg = BattleMessage::EntityDied {
+            name: "Goblin".to_string(),
+        };
+        assert_eq!(msg.to_string(), "Goblin has been defeated!");
+    }
+
+    #[test]
+    fn meta_display() {
+        let msg = BattleMessage::Meta("The battle has ended.".to_string());
+        assert_eq!(msg.to_string(), "The battle has ended.");
+    }
+}

--- a/src/game/engagement/battle/phase.rs
+++ b/src/game/engagement/battle/phase.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BattlePhase {
+    InnateEffects,
+    AttackerPlanning,
+    DefenderResponse,
+    Resolution,
+    Concluded,
+}
+
+impl fmt::Display for BattlePhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BattlePhase::InnateEffects => "Innate Effects",
+            BattlePhase::AttackerPlanning => "Attacker Planning",
+            BattlePhase::DefenderResponse => "Defender Response",
+            BattlePhase::Resolution => "Resolution",
+            BattlePhase::Concluded => "Concluded",
+        };
+        write!(f, "{s}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_human_readable() {
+        assert_eq!(BattlePhase::InnateEffects.to_string(), "Innate Effects");
+        assert_eq!(
+            BattlePhase::AttackerPlanning.to_string(),
+            "Attacker Planning"
+        );
+        assert_eq!(
+            BattlePhase::DefenderResponse.to_string(),
+            "Defender Response"
+        );
+        assert_eq!(BattlePhase::Resolution.to_string(), "Resolution");
+        assert_eq!(BattlePhase::Concluded.to_string(), "Concluded");
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let phases = [
+            BattlePhase::InnateEffects,
+            BattlePhase::AttackerPlanning,
+            BattlePhase::DefenderResponse,
+            BattlePhase::Resolution,
+            BattlePhase::Concluded,
+        ];
+        for phase in &phases {
+            let json = serde_json::to_string(phase).unwrap();
+            let restored: BattlePhase = serde_json::from_str(&json).unwrap();
+            assert_eq!(&restored, phase);
+        }
+    }
+}

--- a/src/game/engagement/battle/queued_ability.rs
+++ b/src/game/engagement/battle/queued_ability.rs
@@ -1,0 +1,48 @@
+use crate::game::component::Ability;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueuedAbility {
+    pub caster_id: i64,
+    pub ability: Ability,
+    pub target_id: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+    use crate::game::engagement::EngagementType;
+
+    fn test_ability() -> Ability {
+        Ability {
+            id: "attack".to_string(),
+            name: "Attack".to_string(),
+            description: None,
+            effects: vec![Effect {
+                name: "damage".to_string(),
+                effect_type: EffectType::AttributeUpdate {
+                    attribute_id: "hp".to_string(),
+                    value: -5,
+                },
+                trigger_info: TriggerInfo::Once,
+                description: EffectDescription::default(),
+            }],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+        }
+    }
+
+    #[test]
+    fn queued_ability_stores_fields() {
+        let ability = test_ability();
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability: ability.clone(),
+            target_id: 2,
+        };
+        assert_eq!(qa.caster_id, 1);
+        assert_eq!(qa.target_id, 2);
+        assert_eq!(qa.ability, ability);
+    }
+}

--- a/src/game/engagement/engagement.rs
+++ b/src/game/engagement/engagement.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::game::engagement::EngagementType;
 use crate::game::engagement::TurnAction;
 use crate::game::engagement::TurnOrder;
+use crate::game::engagement::battle::BattleEngagement;
 
 pub struct Engagement {
     pub id: i64,
@@ -12,6 +13,7 @@ pub struct Engagement {
     pub turn_order: TurnOrder,
     pub pending_actions: HashMap<i64, TurnAction>,
     pub ticks_on_current_turn: u64,
+    pub battle: Option<BattleEngagement>,
 }
 
 impl Engagement {
@@ -25,11 +27,19 @@ impl Engagement {
             turn_order,
             pending_actions: HashMap::new(),
             ticks_on_current_turn: 0,
+            battle: None,
         }
     }
 
-    pub fn new_battle(id: i64, room_id: String, entity_ids: Vec<i64>) -> Self {
+    pub fn new_battle(
+        id: i64,
+        room_id: String,
+        factions: Vec<String>,
+        participants: HashMap<String, Vec<i64>>,
+    ) -> Self {
+        let entity_ids: Vec<i64> = participants.values().flatten().copied().collect();
         let turn_order = TurnOrder::new(&entity_ids);
+        let battle = BattleEngagement::new(factions, participants);
         Self {
             id,
             engagement_type: EngagementType::Battle,
@@ -38,6 +48,7 @@ impl Engagement {
             turn_order,
             pending_actions: HashMap::new(),
             ticks_on_current_turn: 0,
+            battle: Some(battle),
         }
     }
 
@@ -53,6 +64,7 @@ impl Engagement {
             turn_order,
             pending_actions: HashMap::new(),
             ticks_on_current_turn: 0,
+            battle: None,
         }
     }
 
@@ -102,12 +114,32 @@ mod tests {
         Engagement::new(1, EngagementType::Battle, vec![10, 20, 30])
     }
 
+    fn make_battle_participants() -> (Vec<String>, HashMap<String, Vec<i64>>) {
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        (
+            vec!["player".to_string(), "enemy".to_string()],
+            participants,
+        )
+    }
+
     #[test]
     fn new_battle_sets_room_id_and_type() {
-        let eng = Engagement::new_battle(5, "room1".to_string(), vec![1, 2]);
+        let (factions, participants) = make_battle_participants();
+        let eng = Engagement::new_battle(5, "room1".to_string(), factions, participants);
         assert_eq!(eng.room_id, Some("room1".to_string()));
         assert_eq!(eng.engagement_type, EngagementType::Battle);
-        assert_eq!(eng.entity_ids, vec![1, 2]);
+        let mut ids = eng.entity_ids.clone();
+        ids.sort();
+        assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn new_battle_initializes_battle_engagement() {
+        let (factions, participants) = make_battle_participants();
+        let eng = Engagement::new_battle(5, "room1".to_string(), factions, participants);
+        assert!(eng.battle.is_some());
     }
 
     #[test]

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -8,6 +8,7 @@ use crate::game::engagement::Engagement;
 use crate::game::engagement::EngagementType;
 use crate::game::engagement::ResolvedAction;
 use crate::game::engagement::TurnAction;
+use crate::game::engagement::battle::{BattlePhase, BattleTick};
 
 pub struct Engagements {
     engagements_by_id: RwLock<HashMap<i64, Engagement>>,
@@ -30,10 +31,15 @@ impl Engagements {
         id
     }
 
-    /// Create a battle engagement tied to a specific room. Returns the new engagement's id.
-    pub async fn add_battle(&self, room_id: String, entity_ids: Vec<i64>) -> i64 {
+    /// Create a faction-aware battle engagement tied to a specific room. Returns the new id.
+    pub async fn add_battle(
+        &self,
+        room_id: String,
+        factions: Vec<String>,
+        participants: HashMap<String, Vec<i64>>,
+    ) -> i64 {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        let engagement = Engagement::new_battle(id, room_id, entity_ids);
+        let engagement = Engagement::new_battle(id, room_id, factions, participants);
         self.engagements_by_id.write().await.insert(id, engagement);
         id
     }
@@ -109,6 +115,48 @@ impl Engagements {
         }
         resolved
     }
+
+    /// Advance all battle engagements by one tick. Returns the tick results for each battle.
+    pub async fn tick_battles(&self, max_engage_ticks: u64) -> Vec<BattleTick> {
+        let mut results = Vec::new();
+        let mut map = self.engagements_by_id.write().await;
+        for engagement in map.values_mut() {
+            if let Some(battle) = &mut engagement.battle {
+                results.push(battle.tick(engagement.id, max_engage_ticks));
+            }
+        }
+        results
+    }
+
+    /// Remove dead entities from a battle's participant list. Returns the surviving faction count.
+    pub async fn update_battle_participants(
+        &self,
+        engagement_id: i64,
+        dead_entity_ids: &[i64],
+    ) -> usize {
+        let mut map = self.engagements_by_id.write().await;
+        let Some(engagement) = map.get_mut(&engagement_id) else {
+            return 0;
+        };
+        let Some(battle) = &mut engagement.battle else {
+            return 0;
+        };
+        for &dead_id in dead_entity_ids {
+            battle.remove_entity(dead_id);
+            engagement.entity_ids.retain(|&id| id != dead_id);
+        }
+        battle.surviving_faction_count()
+    }
+
+    /// Mark a battle engagement as concluded.
+    pub async fn conclude_battle(&self, engagement_id: i64) {
+        let mut map = self.engagements_by_id.write().await;
+        if let Some(engagement) = map.get_mut(&engagement_id)
+            && let Some(battle) = &mut engagement.battle
+        {
+            battle.turn_phase = BattlePhase::Concluded;
+        }
+    }
 }
 
 impl Default for Engagements {
@@ -155,11 +203,22 @@ fn build_resolved_action(
 mod tests {
     use super::*;
 
+    fn test_participants() -> (Vec<String>, HashMap<String, Vec<i64>>) {
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        (
+            vec!["player".to_string(), "enemy".to_string()],
+            participants,
+        )
+    }
+
     #[tokio::test]
     async fn add_battle_sets_room_id() {
         let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
         let id = engagements
-            .add_battle("room1".to_string(), vec![1, 2])
+            .add_battle("room1".to_string(), factions, participants)
             .await;
         let map = engagements.engagements_by_id.read().await;
         let eng = map.get(&id).unwrap();
@@ -170,8 +229,9 @@ mod tests {
     #[tokio::test]
     async fn find_battle_for_room_returns_id_when_present() {
         let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
         let id = engagements
-            .add_battle("room1".to_string(), vec![1, 2])
+            .add_battle("room1".to_string(), factions, participants)
             .await;
         assert_eq!(engagements.find_battle_for_room("room1").await, Some(id));
     }
@@ -179,8 +239,9 @@ mod tests {
     #[tokio::test]
     async fn find_battle_for_room_returns_none_for_different_room() {
         let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
         engagements
-            .add_battle("room1".to_string(), vec![1, 2])
+            .add_battle("room1".to_string(), factions, participants)
             .await;
         assert_eq!(engagements.find_battle_for_room("room2").await, None);
     }
@@ -190,6 +251,48 @@ mod tests {
         let engagements = Engagements::new();
         engagements.add_conversation(1, 2).await;
         assert_eq!(engagements.find_battle_for_room("room1").await, None);
+    }
+
+    #[tokio::test]
+    async fn tick_battles_advances_battle_phase() {
+        let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
+        engagements
+            .add_battle("room1".to_string(), factions, participants)
+            .await;
+        let results = engagements.tick_battles(30).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].phase,
+            crate::game::engagement::battle::BattlePhase::AttackerPlanning
+        );
+    }
+
+    #[tokio::test]
+    async fn update_battle_participants_removes_dead_and_returns_count() {
+        let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
+        let id = engagements
+            .add_battle("room1".to_string(), factions, participants)
+            .await;
+        let surviving = engagements.update_battle_participants(id, &[1]).await;
+        assert_eq!(surviving, 1); // only enemy remains
+    }
+
+    #[tokio::test]
+    async fn conclude_battle_sets_concluded_phase() {
+        let engagements = Engagements::new();
+        let (factions, participants) = test_participants();
+        let id = engagements
+            .add_battle("room1".to_string(), factions, participants)
+            .await;
+        engagements.conclude_battle(id).await;
+        let map = engagements.engagements_by_id.read().await;
+        let eng = map.get(&id).unwrap();
+        assert_eq!(
+            eng.battle.as_ref().unwrap().turn_phase,
+            crate::game::engagement::battle::BattlePhase::Concluded
+        );
     }
 
     #[tokio::test]

--- a/src/game/engagement/processing.rs
+++ b/src/game/engagement/processing.rs
@@ -1,7 +1,13 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::game::EngagementType;
-use crate::game::GameState;
+use crate::game::component::{Ability, AttributeType, EffectType, TriggerInfo};
+use crate::game::config::AttributeConfig;
+use crate::game::engagement::battle::loot;
+use crate::game::engagement::battle::{BattleMessage, BattleTick, entity_innate_battle_abilities};
+use crate::game::engagement::{EngagementType, TurnOrder};
+use crate::game::entity::Entity;
+use crate::game::{GameState, messaging};
 
 use super::conversation;
 
@@ -15,19 +21,262 @@ use super::conversation;
 ///    is resolved and returned as a [`crate::game::ResolvedAction`].
 /// 3. Dispatches each resolved action to the appropriate handler based on its
 ///    [`EngagementType`]. Currently only [`EngagementType::Conversation`] is handled.
+/// 4. Advances all battle engagements through their phase state machine and applies effects.
 pub async fn process(game_state: &Arc<GameState>, _tick: u64) {
-    // Derive the per-turn tick budget. Always at least 1 tick so engagements can't stall.
     let max_engage_ticks = (game_state.mud_config.game_loop.max_engage_ms
         / game_state.mud_config.game_loop.tick_rate_ms)
         .max(1);
 
-    // Advance all engagements and collect the ones whose turn just resolved.
     let resolved = game_state.engagements.process_tick(max_engage_ticks).await;
-
-    // Dispatch each resolved action to the right handler.
     for r in &resolved {
         if r.engagement_type == EngagementType::Conversation {
             conversation::handle(game_state, r).await;
+        }
+    }
+
+    let battle_results = game_state.engagements.tick_battles(max_engage_ticks).await;
+    for result in battle_results {
+        handle_battle_tick(game_state, result).await;
+    }
+}
+
+async fn handle_battle_tick(game_state: &Arc<GameState>, result: BattleTick) {
+    let engagement_id = result.engagement_id;
+    let all_ids = result.all_participant_ids.clone();
+
+    let (innate_jobs, entity_names, speed_sorted_casters) =
+        collect_entity_data(game_state, &result).await;
+
+    let mut cast_messages = Vec::new();
+    apply_battle_effects(
+        game_state,
+        &innate_jobs,
+        result.resolution_queue,
+        &speed_sorted_casters,
+        &entity_names,
+        &mut cast_messages,
+    )
+    .await;
+
+    let dead_ids = detect_dead_entities(game_state, &all_ids, &game_state.attribute_config).await;
+
+    let death_messages: Vec<BattleMessage> = dead_ids
+        .iter()
+        .map(|&id| BattleMessage::EntityDied {
+            name: entity_names
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| "Unknown".to_string()),
+        })
+        .collect();
+
+    let player_ids = find_participant_player_ids(game_state, &all_ids).await;
+    announce(&game_state.message_tx, &player_ids, &result.messages);
+    announce(&game_state.message_tx, &player_ids, &cast_messages);
+    announce(&game_state.message_tx, &player_ids, &death_messages);
+
+    let surviving = game_state
+        .engagements
+        .update_battle_participants(engagement_id, &dead_ids)
+        .await;
+
+    if surviving <= 1 {
+        loot::resolve_loot(&all_ids);
+        game_state.engagements.conclude_battle(engagement_id).await;
+        for &pid in &player_ids {
+            messaging::message(&game_state.message_tx, pid, "The battle has ended.");
+        }
+        game_state.engagements.remove(engagement_id).await;
+    }
+}
+
+async fn collect_entity_data(
+    game_state: &Arc<GameState>,
+    result: &BattleTick,
+) -> (Vec<(i64, Vec<Ability>)>, HashMap<i64, String>, Vec<i64>) {
+    let entities = game_state.active_entities.read().await;
+
+    let innate_jobs: Vec<(i64, Vec<Ability>)> = result
+        .innate_entity_ids
+        .iter()
+        .filter_map(|&eid| {
+            let entity = entities.get(&eid)?;
+            let abilities = entity_innate_battle_abilities(entity);
+            if abilities.is_empty() {
+                None
+            } else {
+                Some((eid, abilities))
+            }
+        })
+        .collect();
+
+    let entity_names: HashMap<i64, String> = result
+        .all_participant_ids
+        .iter()
+        .filter_map(|&eid| {
+            let name = entities
+                .get(&eid)?
+                .config_id
+                .as_deref()
+                .unwrap_or("Unknown")
+                .to_string();
+            Some((eid, name))
+        })
+        .collect();
+
+    let speed_sorted_casters = speed_sort_casters(
+        &result
+            .resolution_queue
+            .iter()
+            .map(|qa| qa.caster_id)
+            .collect::<Vec<_>>(),
+        &entities,
+        &game_state.attribute_config,
+    );
+
+    (innate_jobs, entity_names, speed_sorted_casters)
+}
+
+fn speed_sort_casters(
+    caster_ids: &[i64],
+    entities: &HashMap<i64, Entity>,
+    config: &AttributeConfig,
+) -> Vec<i64> {
+    let entity_refs: Vec<&Entity> = caster_ids
+        .iter()
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .filter_map(|&id| entities.get(&id))
+        .collect();
+    TurnOrder::new_from_entities(&entity_refs, config)
+        .order()
+        .to_vec()
+}
+
+async fn apply_battle_effects(
+    game_state: &Arc<GameState>,
+    innate_jobs: &[(i64, Vec<Ability>)],
+    resolution_queue: Vec<crate::game::engagement::battle::QueuedAbility>,
+    speed_sorted_casters: &[i64],
+    entity_names: &HashMap<i64, String>,
+    cast_messages: &mut Vec<BattleMessage>,
+) {
+    let mut entities = game_state.active_entities.write().await;
+
+    for (entity_id, abilities) in innate_jobs {
+        for ability in abilities {
+            apply_once_effects(ability, *entity_id, &mut entities);
+        }
+    }
+
+    let mut by_caster: HashMap<i64, Vec<crate::game::engagement::battle::QueuedAbility>> =
+        HashMap::new();
+    for qa in resolution_queue {
+        by_caster.entry(qa.caster_id).or_default().push(qa);
+    }
+
+    for &caster_id in speed_sorted_casters {
+        if let Some(abilities) = by_caster.remove(&caster_id) {
+            for qa in &abilities {
+                apply_once_effects(&qa.ability, qa.target_id, &mut entities);
+                cast_messages.push(ability_cast_message(qa, entity_names));
+            }
+        }
+    }
+    for abilities in by_caster.into_values() {
+        for qa in &abilities {
+            apply_once_effects(&qa.ability, qa.target_id, &mut entities);
+            cast_messages.push(ability_cast_message(qa, entity_names));
+        }
+    }
+}
+
+fn ability_cast_message(
+    qa: &crate::game::engagement::battle::QueuedAbility,
+    entity_names: &HashMap<i64, String>,
+) -> BattleMessage {
+    BattleMessage::AbilityCast {
+        caster_name: entity_names
+            .get(&qa.caster_id)
+            .cloned()
+            .unwrap_or_else(|| "Unknown".to_string()),
+        target_name: entity_names
+            .get(&qa.target_id)
+            .cloned()
+            .unwrap_or_else(|| "Unknown".to_string()),
+        ability_name: qa.ability.name.clone(),
+    }
+}
+
+fn apply_once_effects(ability: &Ability, target_id: i64, entities: &mut HashMap<i64, Entity>) {
+    let Some(entity) = entities.get_mut(&target_id) else {
+        return;
+    };
+    for effect in &ability.effects {
+        if let TriggerInfo::Once = effect.trigger_info
+            && let EffectType::AttributeUpdate {
+                attribute_id,
+                value,
+            } = &effect.effect_type
+            && let Some(attr) = entity.attributes.get_mut(attribute_id)
+        {
+            attr.current_value = (attr.current_value + value)
+                .max(attr.min_value)
+                .min(attr.max_value);
+        }
+    }
+}
+
+async fn detect_dead_entities(
+    game_state: &Arc<GameState>,
+    entity_ids: &[i64],
+    config: &AttributeConfig,
+) -> Vec<i64> {
+    let hp_def_ids: Vec<&str> = config
+        .attributes
+        .iter()
+        .filter(|def| matches!(def.attribute_type, AttributeType::HP))
+        .map(|def| def.id.as_str())
+        .collect();
+
+    let entities = game_state.active_entities.read().await;
+    entity_ids
+        .iter()
+        .filter(|&&id| is_entity_dead(id, &entities, &hp_def_ids))
+        .copied()
+        .collect()
+}
+
+fn is_entity_dead(entity_id: i64, entities: &HashMap<i64, Entity>, hp_def_ids: &[&str]) -> bool {
+    let Some(entity) = entities.get(&entity_id) else {
+        return false;
+    };
+    hp_def_ids.iter().any(|&hp_id| {
+        entity
+            .attributes
+            .get(hp_id)
+            .is_some_and(|attr| attr.current_value <= attr.min_value)
+    })
+}
+
+async fn find_participant_player_ids(game_state: &Arc<GameState>, entity_ids: &[i64]) -> Vec<i64> {
+    let players = game_state.active_players.read().await;
+    players
+        .values()
+        .filter(|p| entity_ids.contains(&p.entity_id))
+        .map(|p| p.id)
+        .collect()
+}
+
+fn announce(
+    tx: &tokio::sync::broadcast::Sender<crate::game::messaging::PlayerMessage>,
+    player_ids: &[i64],
+    messages: &[BattleMessage],
+) {
+    for msg in messages {
+        let text = msg.to_string();
+        for &pid in player_ids {
+            messaging::message(tx, pid, &text);
         }
     }
 }

--- a/src/game/engagement/turn_order.rs
+++ b/src/game/engagement/turn_order.rs
@@ -1,5 +1,9 @@
-/// Tracks the turn order for an engagement. Currently stubbed to sort entity ids ascending.
-/// In the future, turn order will be determined by entity attributes.
+use crate::game::component::AttributeCategory;
+use crate::game::config::AttributeConfig;
+use crate::game::entity::Entity;
+
+/// Tracks the turn order for an engagement. Sorted by entity ID ascending when using `new`;
+/// use `new_from_entities` to sort by Speed attribute descending.
 pub struct TurnOrder {
     order: Vec<i64>,
     current_index: usize,
@@ -11,6 +15,36 @@ impl TurnOrder {
         order.sort();
         Self {
             order,
+            current_index: 0,
+        }
+    }
+
+    /// Build a turn order from entities sorted by Speed attribute descending. Entities with
+    /// higher total speed go first; ties are broken by ascending entity ID.
+    pub fn new_from_entities(entities: &[&Entity], config: &AttributeConfig) -> Self {
+        let speed_def_ids: Vec<&str> = config
+            .attributes
+            .iter()
+            .filter(|def| def.attribute_category == AttributeCategory::Speed)
+            .map(|def| def.id.as_str())
+            .collect();
+
+        let mut entity_speeds: Vec<(i64, i64)> = entities
+            .iter()
+            .map(|entity| {
+                let speed: i64 = speed_def_ids
+                    .iter()
+                    .filter_map(|&def_id| entity.attributes.get(def_id))
+                    .map(|attr| attr.current_value)
+                    .sum();
+                (entity.id, speed)
+            })
+            .collect();
+
+        entity_speeds.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+        Self {
+            order: entity_speeds.into_iter().map(|(id, _)| id).collect(),
             current_index: 0,
         }
     }
@@ -76,5 +110,115 @@ mod tests {
         let mut turn_order = TurnOrder::new(&[]);
         turn_order.advance(); // should not panic
         assert_eq!(turn_order.current(), None);
+    }
+
+    #[test]
+    fn new_from_entities_sorts_by_speed_descending() {
+        use crate::game::component::location::Location;
+        use crate::game::component::{
+            Attribute, AttributeCategory, AttributeDefinition, AttributeType,
+        };
+        use crate::game::entity::{Entity, EntityType};
+
+        let config = AttributeConfig {
+            attributes: vec![AttributeDefinition {
+                id: "speed".to_string(),
+                title: "Speed".to_string(),
+                description: "Quickness.".to_string(),
+                min_value: 0,
+                max_value: 100,
+                attribute_type: AttributeType::Stat,
+                attribute_category: AttributeCategory::Speed,
+            }],
+        };
+
+        let loc = Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        };
+
+        let mut slow = Entity::new(1, EntityType::Enemy, loc.clone());
+        slow.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, 5),
+        );
+
+        let mut fast = Entity::new(2, EntityType::Enemy, loc.clone());
+        fast.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, 20),
+        );
+
+        let mut medium = Entity::new(3, EntityType::Enemy, loc);
+        medium.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, 10),
+        );
+
+        let order = TurnOrder::new_from_entities(&[&slow, &fast, &medium], &config);
+        assert_eq!(order.order(), &[2, 3, 1]);
+    }
+
+    #[test]
+    fn new_from_entities_tie_breaks_by_entity_id_ascending() {
+        use crate::game::component::location::Location;
+        use crate::game::component::{
+            Attribute, AttributeCategory, AttributeDefinition, AttributeType,
+        };
+        use crate::game::entity::{Entity, EntityType};
+
+        let config = AttributeConfig {
+            attributes: vec![AttributeDefinition {
+                id: "speed".to_string(),
+                title: "Speed".to_string(),
+                description: "Quickness.".to_string(),
+                min_value: 0,
+                max_value: 100,
+                attribute_type: AttributeType::Stat,
+                attribute_category: AttributeCategory::Speed,
+            }],
+        };
+
+        let loc = Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        };
+
+        let mut e5 = Entity::new(5, EntityType::Enemy, loc.clone());
+        e5.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, 10),
+        );
+
+        let mut e3 = Entity::new(3, EntityType::Enemy, loc);
+        e3.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, 10),
+        );
+
+        let order = TurnOrder::new_from_entities(&[&e5, &e3], &config);
+        assert_eq!(order.order(), &[3, 5]);
+    }
+
+    #[test]
+    fn new_from_entities_falls_back_to_entity_id_when_no_speed_attr() {
+        use crate::game::component::location::Location;
+        use crate::game::entity::{Entity, EntityType};
+
+        let config = AttributeConfig { attributes: vec![] };
+
+        let loc = Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        };
+
+        let e3 = Entity::new(3, EntityType::Enemy, loc.clone());
+        let e1 = Entity::new(1, EntityType::Enemy, loc);
+
+        let order = TurnOrder::new_from_entities(&[&e3, &e1], &config);
+        assert_eq!(order.order(), &[1, 3]);
     }
 }

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 use tracing;
 
 use crate::game::component::faction_relations::FactionRelation;
-use crate::game::entity::Entity;
 use crate::game::player::Player;
 use crate::game::{GameState, messaging};
+
+mod participants;
 
 enum RoomThreat {
     Hostile,
@@ -76,7 +77,7 @@ async fn start_battle(
     hostile_ids: Vec<i64>,
 ) {
     let (factions, participants) =
-        build_participants(game_state, player.entity_id, &hostile_ids).await;
+        participants::build_participants(game_state, player.entity_id, &hostile_ids).await;
     let all_ids: Vec<i64> = participants.values().flatten().copied().collect();
     tracing::info!(
         room_id,
@@ -92,48 +93,6 @@ async fn start_battle(
         player.id,
         "Hostile entities attack! A battle has started.",
     );
-}
-
-async fn build_participants(
-    game_state: &Arc<GameState>,
-    player_entity_id: i64,
-    hostile_ids: &[i64],
-) -> (Vec<String>, HashMap<String, Vec<i64>>) {
-    let entities = game_state.active_entities.read().await;
-
-    let mut participants: HashMap<String, Vec<i64>> = HashMap::new();
-    for &entity_id in std::iter::once(&player_entity_id).chain(hostile_ids.iter()) {
-        if let Some(entity) = entities.get(&entity_id) {
-            for faction in &entity.factions {
-                participants
-                    .entry(faction.clone())
-                    .or_default()
-                    .push(entity_id);
-            }
-        }
-    }
-
-    let factions = ordered_factions(&entities, player_entity_id, &participants);
-    (factions, participants)
-}
-
-fn ordered_factions(
-    entities: &HashMap<i64, Entity>,
-    player_entity_id: i64,
-    participants: &HashMap<String, Vec<i64>>,
-) -> Vec<String> {
-    let mut factions: Vec<String> = Vec::new();
-    if let Some(player_entity) = entities.get(&player_entity_id) {
-        for faction in &player_entity.factions {
-            factions.push(faction.clone());
-        }
-    }
-    for faction in participants.keys() {
-        if !factions.contains(faction) {
-            factions.push(faction.clone());
-        }
-    }
-    factions
 }
 
 fn entity_threat_toward_player(

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use tracing;
 
 use crate::game::component::faction_relations::FactionRelation;
+use crate::game::entity::Entity;
 use crate::game::player::Player;
 use crate::game::{GameState, messaging};
 
@@ -74,22 +75,65 @@ async fn start_battle(
     room_id: &str,
     hostile_ids: Vec<i64>,
 ) {
-    let mut battle_ids = vec![player.entity_id];
-    battle_ids.extend(hostile_ids);
+    let (factions, participants) =
+        build_participants(game_state, player.entity_id, &hostile_ids).await;
+    let all_ids: Vec<i64> = participants.values().flatten().copied().collect();
     tracing::info!(
         room_id,
-        entity_ids = ?battle_ids,
+        entity_ids = ?all_ids,
         "battle started"
     );
     game_state
         .engagements
-        .add_battle(room_id.to_string(), battle_ids)
+        .add_battle(room_id.to_string(), factions, participants)
         .await;
     messaging::message(
         &game_state.message_tx,
         player.id,
         "Hostile entities attack! A battle has started.",
     );
+}
+
+async fn build_participants(
+    game_state: &Arc<GameState>,
+    player_entity_id: i64,
+    hostile_ids: &[i64],
+) -> (Vec<String>, HashMap<String, Vec<i64>>) {
+    let entities = game_state.active_entities.read().await;
+
+    let mut participants: HashMap<String, Vec<i64>> = HashMap::new();
+    for &entity_id in std::iter::once(&player_entity_id).chain(hostile_ids.iter()) {
+        if let Some(entity) = entities.get(&entity_id) {
+            for faction in &entity.factions {
+                participants
+                    .entry(faction.clone())
+                    .or_default()
+                    .push(entity_id);
+            }
+        }
+    }
+
+    let factions = ordered_factions(&entities, player_entity_id, &participants);
+    (factions, participants)
+}
+
+fn ordered_factions(
+    entities: &HashMap<i64, Entity>,
+    player_entity_id: i64,
+    participants: &HashMap<String, Vec<i64>>,
+) -> Vec<String> {
+    let mut factions: Vec<String> = Vec::new();
+    if let Some(player_entity) = entities.get(&player_entity_id) {
+        for faction in &player_entity.factions {
+            factions.push(faction.clone());
+        }
+    }
+    for faction in participants.keys() {
+        if !factions.contains(faction) {
+            factions.push(faction.clone());
+        }
+    }
+    factions
 }
 
 fn entity_threat_toward_player(

--- a/src/game/interaction/room_threats/participants.rs
+++ b/src/game/interaction/room_threats/participants.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::game::GameState;
+use crate::game::entity::Entity;
+
+pub(super) async fn build_participants(
+    game_state: &Arc<GameState>,
+    player_entity_id: i64,
+    hostile_ids: &[i64],
+) -> (Vec<String>, HashMap<String, Vec<i64>>) {
+    let entities = game_state.active_entities.read().await;
+
+    let mut participants: HashMap<String, Vec<i64>> = HashMap::new();
+    for &entity_id in std::iter::once(&player_entity_id).chain(hostile_ids.iter()) {
+        if let Some(entity) = entities.get(&entity_id) {
+            for faction in &entity.factions {
+                participants
+                    .entry(faction.clone())
+                    .or_default()
+                    .push(entity_id);
+            }
+        }
+    }
+
+    let factions = ordered_factions(&entities, player_entity_id, &participants);
+    (factions, participants)
+}
+
+pub(super) fn ordered_factions(
+    entities: &HashMap<i64, Entity>,
+    player_entity_id: i64,
+    participants: &HashMap<String, Vec<i64>>,
+) -> Vec<String> {
+    let mut factions: Vec<String> = Vec::new();
+    if let Some(player_entity) = entities.get(&player_entity_id) {
+        for faction in &player_entity.factions {
+            factions.push(faction.clone());
+        }
+    }
+    for faction in participants.keys() {
+        if !factions.contains(faction) {
+            factions.push(faction.clone());
+        }
+    }
+    factions
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::game::GameState;
+    use crate::game::component::location::Location;
+    use crate::game::entity::{Entity, EntityType};
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn make_entity(id: i64, entity_type: EntityType, factions: &[&str]) -> Entity {
+        let mut entity = Entity::new(id, entity_type, test_location());
+        entity.factions = factions.iter().map(|s| s.to_string()).collect();
+        entity
+    }
+
+    // ordered_factions tests
+
+    #[test]
+    fn ordered_factions_player_faction_comes_first() {
+        let mut entities = HashMap::new();
+        entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+        entities.insert(2, make_entity(2, EntityType::Enemy, &["enemy"]));
+
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+
+        let factions = ordered_factions(&entities, 1, &participants);
+        assert_eq!(factions[0], "player");
+        assert!(factions.contains(&"enemy".to_string()));
+    }
+
+    #[test]
+    fn ordered_factions_no_duplicates() {
+        let mut entities = HashMap::new();
+        entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+
+        let factions = ordered_factions(&entities, 1, &participants);
+        assert_eq!(factions.len(), 1);
+        assert_eq!(factions[0], "player");
+    }
+
+    #[test]
+    fn ordered_factions_absent_player_returns_all_participant_keys() {
+        let entities: HashMap<i64, Entity> = HashMap::new();
+
+        let mut participants = HashMap::new();
+        participants.insert("enemy".to_string(), vec![2]);
+
+        let factions = ordered_factions(&entities, 99, &participants);
+        assert_eq!(factions, vec!["enemy".to_string()]);
+    }
+
+    #[test]
+    fn ordered_factions_multiple_non_player_factions_all_included() {
+        let mut entities = HashMap::new();
+        entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        participants.insert("neutral".to_string(), vec![3]);
+
+        let factions = ordered_factions(&entities, 1, &participants);
+        assert_eq!(factions[0], "player");
+        assert_eq!(factions.len(), 3);
+        assert!(factions.contains(&"enemy".to_string()));
+        assert!(factions.contains(&"neutral".to_string()));
+    }
+
+    // build_participants tests
+
+    #[tokio::test]
+    async fn build_participants_player_in_own_faction_bucket() {
+        let state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = state.active_entities.write().await;
+            entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+            entities.insert(2, make_entity(2, EntityType::Enemy, &["enemy"]));
+        }
+
+        let (_, participants) = build_participants(&state, 1, &[2]).await;
+        assert!(participants.get("player").unwrap().contains(&1));
+    }
+
+    #[tokio::test]
+    async fn build_participants_hostile_in_their_faction_bucket() {
+        let state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = state.active_entities.write().await;
+            entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+            entities.insert(2, make_entity(2, EntityType::Enemy, &["enemy"]));
+        }
+
+        let (_, participants) = build_participants(&state, 1, &[2]).await;
+        assert!(participants.get("enemy").unwrap().contains(&2));
+    }
+
+    #[tokio::test]
+    async fn build_participants_player_faction_is_first() {
+        let state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = state.active_entities.write().await;
+            entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+            entities.insert(2, make_entity(2, EntityType::Enemy, &["enemy"]));
+        }
+
+        let (factions, _) = build_participants(&state, 1, &[2]).await;
+        assert_eq!(factions[0], "player");
+    }
+
+    #[tokio::test]
+    async fn build_participants_missing_entity_skipped() {
+        let state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = state.active_entities.write().await;
+            entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+        }
+
+        let (factions, participants) = build_participants(&state, 1, &[99]).await;
+        assert_eq!(factions, vec!["player".to_string()]);
+        assert!(participants.get("player").unwrap().contains(&1));
+        assert!(!participants.contains_key("enemy"));
+    }
+
+    #[tokio::test]
+    async fn build_participants_entity_with_multiple_factions_appears_in_each() {
+        let state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = state.active_entities.write().await;
+            entities.insert(1, make_entity(1, EntityType::Player, &["player"]));
+            entities.insert(2, make_entity(2, EntityType::Enemy, &["enemy", "bandit"]));
+        }
+
+        let (_, participants) = build_participants(&state, 1, &[2]).await;
+        assert!(participants.get("enemy").unwrap().contains(&2));
+        assert!(participants.get("bandit").unwrap().contains(&2));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds faction-aware `BattleEngagement` with a full phase state machine: `InnateEffects → AttackerPlanning → DefenderResponse → Resolution → Concluded`
- Implements speed-based turn ordering via `TurnOrder::new_from_entities` using the `AttributeCategory::Speed` config
- Applies innate and queued ability effects per tick, detects HP-based death, and concludes the battle with a loot placeholder and player announcements

## Test plan

- [ ] `cargo test` — all unit tests pass (turn order sorting, phase transitions, participant removal, battle conclude)
- [ ] Start server, enter a room with a hostile enemy; confirm "A battle has started." message appears
- [ ] Verify battle phase messages are broadcast to the player each tick
- [ ] Kill all enemies (or die); confirm "The battle has ended." message appears and the engagement is removed
- [ ] Enter a room where a battle is already in progress; confirm "A battle is already underway here!" message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)