### PR TITLE
Fixes #99 Add battle TUI screen with live engagement updates

### DIFF
--- a/muds/basic/mud.toml
+++ b/muds/basic/mud.toml
@@ -1,6 +1,6 @@
 [game_loop]
 tick_rate_ms = 500
-max_engage_ms = 300000
+max_engage_ms = 5000
 world_update_ms = 600000
 
 [spawn]

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -5,6 +5,7 @@ pub mod queued_ability;
 
 use std::collections::HashMap;
 
+use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
 use crate::game::component::{Ability, Attribute, Cost};
 use crate::game::engagement::EngagementType;
 
@@ -19,6 +20,8 @@ pub struct BattleTick {
     pub innate_entity_ids: Vec<i64>,
     pub resolution_queue: Vec<QueuedAbility>,
     pub phase: BattlePhase,
+    pub factions: Vec<String>,
+    pub participants: HashMap<String, Vec<i64>>,
 }
 
 pub struct BattleEngagement {
@@ -204,6 +207,8 @@ impl BattleEngagement {
             innate_entity_ids,
             resolution_queue,
             phase: self.turn_phase.clone(),
+            factions: self.factions.clone(),
+            participants: self.participants.clone(),
         }
     }
 }
@@ -219,6 +224,26 @@ fn battle_abilities(entity: &crate::game::entity::Entity) -> Vec<Ability> {
 
 pub fn entity_innate_battle_abilities(entity: &crate::game::entity::Entity) -> Vec<Ability> {
     battle_abilities(entity)
+}
+
+pub fn default_attack_ability() -> Ability {
+    Ability {
+        id: "attack".to_string(),
+        name: "Attack".to_string(),
+        description: Some("A basic physical attack.".to_string()),
+        effects: vec![Effect {
+            name: "physical_damage".to_string(),
+            effect_type: EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -10,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription::default(),
+        }],
+        engagement_types: vec![EngagementType::Battle],
+        costs: vec![],
+        modifiers: vec![],
+    }
 }
 
 #[cfg(test)]

--- a/src/game/engagement/battle/message.rs
+++ b/src/game/engagement/battle/message.rs
@@ -1,8 +1,10 @@
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 use crate::game::engagement::battle::phase::BattlePhase;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum BattleMessage {
     PhaseChange {
         phase: BattlePhase,

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -4,6 +4,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use tokio::sync::RwLock;
 use tracing;
 
+use crate::game::component::{Ability, Attribute};
 use crate::game::engagement::Engagement;
 use crate::game::engagement::EngagementType;
 use crate::game::engagement::ResolvedAction;
@@ -146,6 +147,27 @@ impl Engagements {
             engagement.entity_ids.retain(|&id| id != dead_id);
         }
         battle.surviving_faction_count()
+    }
+
+    /// Queue an ability in the entity's active battle engagement.
+    /// Returns false if the entity is not in a battle or lacks resources.
+    pub async fn queue_battle_ability(
+        &self,
+        entity_id: i64,
+        ability: Ability,
+        target_id: i64,
+        entity_attrs: &HashMap<String, Attribute>,
+    ) -> bool {
+        let mut map = self.engagements_by_id.write().await;
+        for engagement in map.values_mut() {
+            if engagement.engagement_type == EngagementType::Battle
+                && engagement.entity_ids.contains(&entity_id)
+                && let Some(battle) = &mut engagement.battle
+            {
+                return battle.queue_ability(entity_id, ability, target_id, entity_attrs);
+            }
+        }
+        false
     }
 
     /// Mark a battle engagement as concluded.

--- a/src/game/engagement/processing.rs
+++ b/src/game/engagement/processing.rs
@@ -7,6 +7,7 @@ use crate::game::engagement::battle::loot;
 use crate::game::engagement::battle::{BattleMessage, BattleTick, entity_innate_battle_abilities};
 use crate::game::engagement::{EngagementType, TurnOrder};
 use crate::game::entity::Entity;
+use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
 use crate::game::{GameState, messaging};
 
 use super::conversation;
@@ -36,11 +37,15 @@ pub async fn process(game_state: &Arc<GameState>, _tick: u64) {
 
     let battle_results = game_state.engagements.tick_battles(max_engage_ticks).await;
     for result in battle_results {
-        handle_battle_tick(game_state, result).await;
+        handle_battle_tick(game_state, result, max_engage_ticks).await;
     }
 }
 
-async fn handle_battle_tick(game_state: &Arc<GameState>, result: BattleTick) {
+async fn handle_battle_tick(
+    game_state: &Arc<GameState>,
+    result: BattleTick,
+    max_engage_ticks: u64,
+) {
     let engagement_id = result.engagement_id;
     let all_ids = result.all_participant_ids.clone();
 
@@ -70,21 +75,41 @@ async fn handle_battle_tick(game_state: &Arc<GameState>, result: BattleTick) {
         })
         .collect();
 
+    let all_tick_messages: Vec<BattleMessage> = result
+        .messages
+        .iter()
+        .chain(cast_messages.iter())
+        .chain(death_messages.iter())
+        .cloned()
+        .collect();
+
     let player_ids = find_participant_player_ids(game_state, &all_ids).await;
-    announce(&game_state.message_tx, &player_ids, &result.messages);
-    announce(&game_state.message_tx, &player_ids, &cast_messages);
-    announce(&game_state.message_tx, &player_ids, &death_messages);
 
     let surviving = game_state
         .engagements
         .update_battle_participants(engagement_id, &dead_ids)
         .await;
 
+    let update = build_battle_update(
+        game_state,
+        &result.factions,
+        &result.participants,
+        result.phase,
+        all_tick_messages,
+        max_engage_ticks,
+        engagement_id,
+    )
+    .await;
+
+    for &pid in &player_ids {
+        messaging::battle_update(&game_state.message_tx, pid, update.clone());
+    }
+
     if surviving <= 1 {
         loot::resolve_loot(&all_ids);
         game_state.engagements.conclude_battle(engagement_id).await;
         for &pid in &player_ids {
-            messaging::message(&game_state.message_tx, pid, "The battle has ended.");
+            messaging::battle_ended(&game_state.message_tx, pid, engagement_id);
         }
         game_state.engagements.remove(engagement_id).await;
     }
@@ -95,6 +120,7 @@ async fn collect_entity_data(
     result: &BattleTick,
 ) -> (Vec<(i64, Vec<Ability>)>, HashMap<i64, String>, Vec<i64>) {
     let entities = game_state.active_entities.read().await;
+    let players = game_state.active_players.read().await;
 
     let innate_jobs: Vec<(i64, Vec<Ability>)> = result
         .innate_entity_ids
@@ -113,14 +139,19 @@ async fn collect_entity_data(
     let entity_names: HashMap<i64, String> = result
         .all_participant_ids
         .iter()
-        .filter_map(|&eid| {
-            let name = entities
-                .get(&eid)?
-                .config_id
-                .as_deref()
-                .unwrap_or("Unknown")
-                .to_string();
-            Some((eid, name))
+        .map(|&eid| {
+            let name = players
+                .values()
+                .find(|p| p.entity_id == eid)
+                .map(|p| p.name.clone())
+                .or_else(|| {
+                    entities
+                        .get(&eid)
+                        .and_then(|e| e.config_id.as_deref())
+                        .map(str::to_string)
+                })
+                .unwrap_or_else(|| format!("Entity {eid}"));
+            (eid, name)
         })
         .collect();
 
@@ -268,15 +299,58 @@ async fn find_participant_player_ids(game_state: &Arc<GameState>, entity_ids: &[
         .collect()
 }
 
-fn announce(
-    tx: &tokio::sync::broadcast::Sender<crate::game::messaging::PlayerMessage>,
-    player_ids: &[i64],
-    messages: &[BattleMessage],
-) {
-    for msg in messages {
-        let text = msg.to_string();
-        for &pid in player_ids {
-            messaging::message(tx, pid, &text);
-        }
+async fn build_battle_update(
+    game_state: &Arc<GameState>,
+    factions: &[String],
+    participants: &HashMap<String, Vec<i64>>,
+    phase: crate::game::engagement::battle::BattlePhase,
+    messages: Vec<BattleMessage>,
+    max_turn_ticks: u64,
+    engagement_id: i64,
+) -> BattleUpdateMessage {
+    let entities = game_state.active_entities.read().await;
+    let players = game_state.active_players.read().await;
+    let hp_attr_id = messaging::hp_attribute_id(&game_state.attribute_config);
+
+    let participant_infos = participants
+        .iter()
+        .map(|(faction, ids)| {
+            let infos = ids
+                .iter()
+                .map(|&id| {
+                    let entity = entities.get(&id);
+                    let name = players
+                        .values()
+                        .find(|p| p.entity_id == id)
+                        .map(|p| p.name.clone())
+                        .or_else(|| {
+                            entity
+                                .and_then(|e| e.config_id.as_deref())
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_else(|| format!("Entity {id}"));
+                    let (hp_current, hp_max) = entity
+                        .and_then(|e| e.attributes.get(&hp_attr_id))
+                        .map(|a| (a.current_value, a.max_value))
+                        .unwrap_or((0, 0));
+                    BattleParticipantInfo {
+                        id,
+                        name,
+                        hp_current,
+                        hp_max,
+                    }
+                })
+                .collect();
+            (faction.clone(), infos)
+        })
+        .collect();
+
+    BattleUpdateMessage {
+        engagement_id,
+        factions: factions.to_vec(),
+        participants: participant_infos,
+        phase,
+        messages,
+        max_turn_ticks,
     }
 }

--- a/src/game/engagement/turn_action.rs
+++ b/src/game/engagement/turn_action.rs
@@ -7,6 +7,7 @@ pub enum TurnAction {
     SelectDialogChoice { choice: String },
     SendMessage { content: String },
     Respond { content: String },
+    QueueAbility { ability_id: String, target_id: i64 },
 }
 
 #[cfg(test)]

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -10,6 +10,7 @@ use tracing;
 
 use crate::game::component::interaction::Movement;
 use crate::game::engagement::TurnAction;
+use crate::game::engagement::battle;
 use crate::game::player::Player;
 use crate::game::{GameState, Interaction};
 use crate::persistence::Database;
@@ -78,14 +79,57 @@ async fn dispatch_engagement_action(
     player: &Player,
     action: TurnAction,
 ) {
+    match action {
+        TurnAction::QueueAbility {
+            ability_id,
+            target_id,
+        } => {
+            dispatch_queue_ability(game_state, player, &ability_id, target_id).await;
+        }
+        other => {
+            let accepted = game_state
+                .engagements
+                .submit_action_for_entity(player.entity_id, other)
+                .await;
+            tracing::debug!(
+                entity_id = player.entity_id,
+                accepted,
+                "engagement action submitted"
+            );
+        }
+    }
+}
+
+async fn dispatch_queue_ability(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    ability_id: &str,
+    target_id: i64,
+) {
+    let (ability_opt, attrs) = {
+        let entities = game_state.active_entities.read().await;
+        let Some(entity) = entities.get(&player.entity_id) else {
+            return;
+        };
+        let ability = entity
+            .innate_abilities
+            .iter()
+            .find(|a| a.id == ability_id)
+            .cloned()
+            .or_else(|| (ability_id == "attack").then(battle::default_attack_ability));
+        (ability, entity.attributes.clone())
+    };
+    let Some(ability) = ability_opt else {
+        return;
+    };
     let accepted = game_state
         .engagements
-        .submit_action_for_entity(player.entity_id, action)
+        .queue_battle_ability(player.entity_id, ability, target_id, &attrs)
         .await;
     tracing::debug!(
         entity_id = player.entity_id,
         accepted,
-        "engagement action submitted"
+        "battle ability queued"
     );
 }
 

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -3,7 +3,13 @@ use std::sync::Arc;
 
 use tracing;
 
+use crate::game::component::attribute_definition::AttributeType;
 use crate::game::component::faction_relations::FactionRelation;
+use crate::game::engagement::battle::{
+    BattlePhase, default_attack_ability, entity_innate_battle_abilities,
+};
+use crate::game::entity::Entity;
+use crate::game::messaging::{BattleParticipantInfo, BattleStartedMessage};
 use crate::game::player::Player;
 use crate::game::{GameState, messaging};
 
@@ -84,15 +90,123 @@ async fn start_battle(
         entity_ids = ?all_ids,
         "battle started"
     );
-    game_state
+
+    let engagement_id = game_state
         .engagements
-        .add_battle(room_id.to_string(), factions, participants)
+        .add_battle(room_id.to_string(), factions.clone(), participants.clone())
         .await;
+
+    let max_engage_ticks = (game_state.mud_config.game_loop.max_engage_ms
+        / game_state.mud_config.game_loop.tick_rate_ms)
+        .max(1);
+
+    let started_msg = build_battle_started_message(
+        game_state,
+        player,
+        engagement_id,
+        &factions,
+        &participants,
+        max_engage_ticks,
+    )
+    .await;
+
+    messaging::battle_started(&game_state.message_tx, player.id, started_msg);
     messaging::message(
         &game_state.message_tx,
         player.id,
         "Hostile entities attack! A battle has started.",
     );
+}
+
+async fn build_battle_started_message(
+    game_state: &Arc<GameState>,
+    player: &Player,
+    engagement_id: i64,
+    factions: &[String],
+    participants: &HashMap<String, Vec<i64>>,
+    max_turn_ticks: u64,
+) -> BattleStartedMessage {
+    let entities = game_state.active_entities.read().await;
+    let players = game_state.active_players.read().await;
+    let hp_attr_id = hp_attribute_id(&game_state.attribute_config);
+
+    let participant_infos = build_participant_infos(participants, &entities, &players, &hp_attr_id);
+
+    let mut available_abilities = entities
+        .get(&player.entity_id)
+        .map(entity_innate_battle_abilities)
+        .unwrap_or_default();
+    if available_abilities.is_empty() {
+        available_abilities.push(default_attack_ability());
+    }
+
+    let mut turn_order: Vec<i64> = participants.values().flatten().copied().collect();
+    turn_order.sort_unstable();
+
+    BattleStartedMessage {
+        engagement_id,
+        factions: factions.to_vec(),
+        participants: participant_infos,
+        phase: BattlePhase::InnateEffects,
+        turn_order,
+        countdown_ticks: max_turn_ticks,
+        max_turn_ticks,
+        available_abilities,
+    }
+}
+
+fn build_participant_infos(
+    participants: &HashMap<String, Vec<i64>>,
+    entities: &HashMap<i64, Entity>,
+    players: &HashMap<String, Player>,
+    hp_attr_id: &str,
+) -> HashMap<String, Vec<BattleParticipantInfo>> {
+    participants
+        .iter()
+        .map(|(faction, ids)| {
+            let infos = ids
+                .iter()
+                .map(|&id| {
+                    let entity = entities.get(&id);
+                    let name = resolve_entity_name(id, entity, players);
+                    let (hp_current, hp_max) = entity
+                        .and_then(|e| e.attributes.get(hp_attr_id))
+                        .map(|a| (a.current_value, a.max_value))
+                        .unwrap_or((0, 0));
+                    BattleParticipantInfo {
+                        id,
+                        name,
+                        hp_current,
+                        hp_max,
+                    }
+                })
+                .collect();
+            (faction.clone(), infos)
+        })
+        .collect()
+}
+
+fn resolve_entity_name(
+    entity_id: i64,
+    entity: Option<&Entity>,
+    players: &HashMap<String, Player>,
+) -> String {
+    if let Some(player) = players.values().find(|p| p.entity_id == entity_id) {
+        return player.name.clone();
+    }
+    entity
+        .and_then(|e| e.config_id.as_deref())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("Entity {entity_id}"))
+}
+
+fn hp_attribute_id(attribute_config: &crate::game::config::AttributeConfig) -> String {
+    attribute_config
+        .attributes
+        .iter()
+        .find(|def| matches!(def.attribute_type, AttributeType::HP))
+        .map(|def| def.id.clone())
+        .unwrap_or_else(|| "hp".to_string())
 }
 
 fn entity_threat_toward_player(

--- a/src/game/messaging.rs
+++ b/src/game/messaging.rs
@@ -1,8 +1,13 @@
 pub mod stream;
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
+use crate::game::component::Ability;
+use crate::game::component::attribute_definition::AttributeType;
+use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::game::map::universe::room::Room;
 
 pub use stream::stream_message;
@@ -21,6 +26,36 @@ pub enum StreamingState {
 }
 
 #[derive(Debug, Clone)]
+pub struct BattleParticipantInfo {
+    pub id: i64,
+    pub name: String,
+    pub hp_current: i64,
+    pub hp_max: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BattleUpdateMessage {
+    pub engagement_id: i64,
+    pub factions: Vec<String>,
+    pub participants: HashMap<String, Vec<BattleParticipantInfo>>,
+    pub phase: BattlePhase,
+    pub messages: Vec<BattleMessage>,
+    pub max_turn_ticks: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct BattleStartedMessage {
+    pub engagement_id: i64,
+    pub factions: Vec<String>,
+    pub participants: HashMap<String, Vec<BattleParticipantInfo>>,
+    pub phase: BattlePhase,
+    pub turn_order: Vec<i64>,
+    pub countdown_ticks: u64,
+    pub max_turn_ticks: u64,
+    pub available_abilities: Vec<Ability>,
+}
+
+#[derive(Debug, Clone)]
 pub enum Message {
     Complete(String),
     Streaming {
@@ -32,6 +67,11 @@ pub enum Message {
         options: Vec<String>,
     },
     ConversationEnded,
+    BattleStarted(Box<BattleStartedMessage>),
+    BattleUpdate(Box<BattleUpdateMessage>),
+    BattleEnded {
+        engagement_id: i64,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -44,6 +84,35 @@ pub fn message(tx: &broadcast::Sender<PlayerMessage>, player_id: i64, content: i
     let _ = tx.send(PlayerMessage {
         player_id,
         message: Message::Complete(content.into()),
+    });
+}
+
+pub fn battle_started(
+    tx: &broadcast::Sender<PlayerMessage>,
+    player_id: i64,
+    data: BattleStartedMessage,
+) {
+    let _ = tx.send(PlayerMessage {
+        player_id,
+        message: Message::BattleStarted(Box::new(data)),
+    });
+}
+
+pub fn battle_update(
+    tx: &broadcast::Sender<PlayerMessage>,
+    player_id: i64,
+    data: BattleUpdateMessage,
+) {
+    let _ = tx.send(PlayerMessage {
+        player_id,
+        message: Message::BattleUpdate(Box::new(data)),
+    });
+}
+
+pub fn battle_ended(tx: &broadcast::Sender<PlayerMessage>, player_id: i64, engagement_id: i64) {
+    let _ = tx.send(PlayerMessage {
+        player_id,
+        message: Message::BattleEnded { engagement_id },
     });
 }
 
@@ -78,4 +147,13 @@ pub fn message_room_description(
         .unwrap_or("You look around but see nothing remarkable.")
         .to_string();
     message(tx, player_id, content);
+}
+
+pub fn hp_attribute_id(attribute_config: &crate::game::config::AttributeConfig) -> String {
+    attribute_config
+        .attributes
+        .iter()
+        .find(|def| matches!(def.attribute_type, AttributeType::HP))
+        .map(|def| def.id.clone())
+        .unwrap_or_else(|| "hp".to_string())
 }

--- a/src/network/event.rs
+++ b/src/network/event.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
+use crate::game::component::Ability;
+use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::game::messaging::ConversationKind;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +26,25 @@ pub struct PlayerInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlayerListResponse {
     pub players: Vec<PlayerInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParticipantInfo {
+    pub id: i64,
+    pub name: String,
+    pub hp_current: i64,
+    pub hp_max: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BattleSnapshot {
+    pub factions: Vec<String>,
+    pub participants: HashMap<String, Vec<ParticipantInfo>>,
+    pub phase: BattlePhase,
+    pub turn_order: Vec<i64>,
+    pub countdown_ticks: u64,
+    pub max_turn_ticks: u64,
+    pub available_abilities: Vec<Ability>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -54,6 +77,18 @@ pub enum NetworkEvent {
         options: Vec<String>,
     },
     ConversationEnded,
+    BattleStarted {
+        engagement_id: i64,
+        snapshot: BattleSnapshot,
+    },
+    BattleUpdate {
+        engagement_id: i64,
+        snapshot: BattleSnapshot,
+        messages: Vec<BattleMessage>,
+    },
+    BattleEnded {
+        engagement_id: i64,
+    },
 }
 
 #[cfg(test)]

--- a/src/network/server/handlers/player.rs
+++ b/src/network/server/handlers/player.rs
@@ -5,6 +5,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use tracing::info;
 
+use crate::game::component::Attribute;
 use crate::game::interaction::room_threats;
 use crate::game::{Entity, EntityType, Location, Player};
 use crate::network::event::{NetworkEvent, PlayerInfo, PlayerListResponse};
@@ -43,7 +44,8 @@ pub async fn player_create_handler(
         dungeon_id: spawn.dungeon_id.clone(),
         room_id: spawn.room_id.clone(),
     };
-    let entity = Entity::new(0, EntityType::Player, location);
+    let mut entity = Entity::new(0, EntityType::Player, location);
+    entity.attributes = default_player_attributes();
     let entity_id = entity_repo::insert(pool, &entity)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -119,6 +121,19 @@ async fn register_player_in_game_state(
     if let Err(e) = state.game_state.sync_active_entities(pool).await {
         tracing::error!(error = %e, "Failed to sync active entities on player select");
     }
+}
+
+fn default_player_attributes() -> std::collections::HashMap<String, Attribute> {
+    let mut attrs = std::collections::HashMap::new();
+    attrs.insert(
+        "hp".to_string(),
+        Attribute::new("hp".to_string(), 0, 100, 100),
+    );
+    attrs.insert(
+        "mp".to_string(),
+        Attribute::new("mp".to_string(), 0, 50, 50),
+    );
+    attrs
 }
 
 async fn notify_player_selected(state: &AppState, client_id: &str, player: &Player) {

--- a/src/network/server/message_relay.rs
+++ b/src/network/server/message_relay.rs
@@ -5,8 +5,10 @@ use tokio::sync::RwLock;
 use tokio::sync::broadcast;
 
 use crate::game::GameState;
-use crate::game::messaging::{Message, PlayerMessage, StreamingState};
-use crate::network::event::NetworkEvent;
+use crate::game::messaging::{
+    BattleStartedMessage, BattleUpdateMessage, Message, PlayerMessage, StreamingState,
+};
+use crate::network::event::{BattleSnapshot, NetworkEvent, ParticipantInfo};
 
 use super::state::ConnectedClient;
 
@@ -23,7 +25,6 @@ pub fn spawn(
 ) {
     tokio::spawn(async move {
         while let Ok(pm) = msg_rx.recv().await {
-            // Map the game message to the appropriate network event.
             let (player_id, network_event) = match pm.message {
                 Message::Complete(content) => (
                     pm.player_id,
@@ -33,7 +34,6 @@ pub fn spawn(
                     },
                 ),
                 Message::Streaming { chunk, state } => {
-                    // is_final signals the client that the streaming message is complete.
                     let is_final = matches!(state, StreamingState::Complete);
                     (
                         pm.player_id,
@@ -49,8 +49,30 @@ pub fn spawn(
                     NetworkEvent::ConversationStarted { kind, options },
                 ),
                 Message::ConversationEnded => (pm.player_id, NetworkEvent::ConversationEnded),
+                Message::BattleStarted(data) => (
+                    pm.player_id,
+                    NetworkEvent::BattleStarted {
+                        engagement_id: data.engagement_id,
+                        snapshot: battle_snapshot_from_message(*data),
+                    },
+                ),
+                Message::BattleUpdate(data) => {
+                    let messages = data.messages.clone();
+                    let engagement_id = data.engagement_id;
+                    (
+                        pm.player_id,
+                        NetworkEvent::BattleUpdate {
+                            engagement_id,
+                            snapshot: battle_update_snapshot(*data),
+                            messages,
+                        },
+                    )
+                }
+                Message::BattleEnded { engagement_id } => {
+                    (pm.player_id, NetworkEvent::BattleEnded { engagement_id })
+                }
             };
-            // Look up the client_id for this player to find their SSE channel.
+
             let players = game_state.active_players.read().await;
             let client_id = players
                 .iter()
@@ -65,4 +87,60 @@ pub fn spawn(
             }
         }
     });
+}
+
+fn battle_update_snapshot(data: BattleUpdateMessage) -> BattleSnapshot {
+    let participants = data
+        .participants
+        .into_iter()
+        .map(|(faction, infos)| {
+            let converted = infos
+                .into_iter()
+                .map(|p| ParticipantInfo {
+                    id: p.id,
+                    name: p.name,
+                    hp_current: p.hp_current,
+                    hp_max: p.hp_max,
+                })
+                .collect();
+            (faction, converted)
+        })
+        .collect();
+    BattleSnapshot {
+        factions: data.factions,
+        participants,
+        phase: data.phase,
+        turn_order: vec![],
+        countdown_ticks: 0,
+        max_turn_ticks: data.max_turn_ticks,
+        available_abilities: vec![],
+    }
+}
+
+fn battle_snapshot_from_message(data: BattleStartedMessage) -> BattleSnapshot {
+    let participants = data
+        .participants
+        .into_iter()
+        .map(|(faction, infos)| {
+            let converted = infos
+                .into_iter()
+                .map(|p| ParticipantInfo {
+                    id: p.id,
+                    name: p.name,
+                    hp_current: p.hp_current,
+                    hp_max: p.hp_max,
+                })
+                .collect();
+            (faction, converted)
+        })
+        .collect();
+    BattleSnapshot {
+        factions: data.factions,
+        participants,
+        phase: data.phase,
+        turn_order: data.turn_order,
+        countdown_ticks: data.countdown_ticks,
+        max_turn_ticks: data.max_turn_ticks,
+        available_abilities: data.available_abilities,
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,8 @@
+mod battle_state;
 mod conversation_state;
 mod network_event_handler;
 
+pub use battle_state::{BattleFocus, BattleState};
 pub use conversation_state::ConversationState;
 
 use crate::network::event::PlayerInfo;
@@ -33,6 +35,7 @@ pub enum GameMode {
     Game,
     StandardConversation,
     AgentConversation,
+    Battle,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -58,6 +61,7 @@ pub struct App {
     pub connection: ConnectionState,
     pub player_select: PlayerSelectState,
     pub conversation: ConversationState,
+    pub battle: Option<BattleState>,
     pub current_player_id: Option<i64>,
     pub streaming_message_index: Option<usize>,
     pub agent_responding: bool,
@@ -78,6 +82,7 @@ impl App {
             connection: ConnectionState::default(),
             player_select: PlayerSelectState::default(),
             conversation: ConversationState::default(),
+            battle: None,
             current_player_id: None,
             streaming_message_index: None,
             agent_responding: false,
@@ -98,6 +103,7 @@ impl App {
             },
             player_select: PlayerSelectState::default(),
             conversation: ConversationState::default(),
+            battle: None,
             current_player_id: None,
             streaming_message_index: None,
             agent_responding: false,

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -1,0 +1,81 @@
+use crate::game::engagement::battle::BattleMessage;
+use crate::network::event::BattleSnapshot;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BattleFocus {
+    Abilities,
+    EntityList,
+}
+
+#[derive(Debug, Clone)]
+pub struct BattleState {
+    pub engagement_id: i64,
+    pub snapshot: BattleSnapshot,
+    pub message_log: Vec<BattleMessage>,
+    pub selected_ability_index: usize,
+    pub selected_entity_index: usize,
+    pub entity_scroll: usize,
+    pub focus: BattleFocus,
+}
+
+impl BattleState {
+    pub fn new(engagement_id: i64, snapshot: BattleSnapshot) -> Self {
+        Self {
+            engagement_id,
+            snapshot,
+            message_log: Vec::new(),
+            selected_ability_index: 0,
+            selected_entity_index: 0,
+            entity_scroll: 0,
+            focus: BattleFocus::Abilities,
+        }
+    }
+
+    pub fn select_next_ability(&mut self) {
+        let len = self.snapshot.available_abilities.len();
+        if len > 0 {
+            self.selected_ability_index = (self.selected_ability_index + 1) % len;
+        }
+    }
+
+    pub fn select_prev_ability(&mut self) {
+        let len = self.snapshot.available_abilities.len();
+        if len > 0 {
+            self.selected_ability_index = (self.selected_ability_index + len - 1) % len;
+        }
+    }
+
+    pub fn select_next_entity(&mut self) {
+        let len = self.all_entity_ids().len();
+        if len > 0 {
+            self.selected_entity_index = (self.selected_entity_index + 1) % len;
+        }
+    }
+
+    pub fn select_prev_entity(&mut self) {
+        let len = self.all_entity_ids().len();
+        if len > 0 {
+            self.selected_entity_index = (self.selected_entity_index + len - 1) % len;
+        }
+    }
+
+    pub fn toggle_focus(&mut self) {
+        self.focus = match self.focus {
+            BattleFocus::Abilities => BattleFocus::EntityList,
+            BattleFocus::EntityList => BattleFocus::Abilities,
+        };
+    }
+
+    pub fn selected_target_id(&self) -> Option<i64> {
+        let ids = self.all_entity_ids();
+        ids.get(self.selected_entity_index).copied()
+    }
+
+    pub fn all_entity_ids(&self) -> Vec<i64> {
+        self.snapshot
+            .participants
+            .values()
+            .flat_map(|infos| infos.iter().map(|p| p.id))
+            .collect()
+    }
+}

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -1,7 +1,9 @@
+use crate::game::engagement::battle::BattleMessage;
 use crate::game::messaging::ConversationKind;
 use crate::network::NetworkEvent;
+use crate::network::event::BattleSnapshot;
 
-use super::{App, AppMessage, GameMode};
+use super::{App, AppMessage, BattleState, GameMode};
 
 impl App {
     pub fn handle_network_event(&mut self, event: NetworkEvent) {
@@ -41,46 +43,90 @@ impl App {
                 player_id,
                 chunk,
                 is_final,
-            } => {
-                if Some(player_id) == self.current_player_id {
-                    match self.streaming_message_index {
-                        None => {
-                            let idx = self.messages.len();
-                            self.messages.push(AppMessage::normal(chunk));
-                            if !is_final {
-                                self.streaming_message_index = Some(idx);
-                            }
-                        }
-                        Some(idx) => {
-                            if let Some(msg) = self.messages.get_mut(idx) {
-                                msg.text.push_str(&chunk);
-                            }
-                            if is_final {
-                                self.streaming_message_index = None;
-                            }
-                        }
-                    }
-                    if is_final {
-                        self.agent_responding = false;
-                    }
-                }
+            } => self.handle_message_chunk(player_id, chunk, is_final),
+            NetworkEvent::ConversationStarted { kind, options } => {
+                self.handle_conversation_started(kind, options);
             }
-            NetworkEvent::ConversationStarted { kind, options } => match kind {
-                ConversationKind::Dialog => {
-                    self.mode = GameMode::StandardConversation;
-                    self.conversation.options = options;
-                    self.conversation.selected_index = 0;
-                }
-                ConversationKind::Agent => {
-                    self.mode = GameMode::AgentConversation;
-                    self.messages.clear();
-                    self.scroll_offset = 0;
-                }
-            },
             NetworkEvent::ConversationEnded => {
                 self.mode = GameMode::Game;
                 self.conversation.reset();
             }
+            NetworkEvent::BattleStarted {
+                engagement_id,
+                snapshot,
+            } => self.handle_battle_started(engagement_id, snapshot),
+            NetworkEvent::BattleUpdate {
+                engagement_id,
+                snapshot,
+                messages,
+            } => self.handle_battle_update(engagement_id, snapshot, messages),
+            NetworkEvent::BattleEnded { engagement_id: _ } => {
+                self.battle = None;
+                self.mode = GameMode::Game;
+            }
         }
+    }
+
+    fn handle_message_chunk(&mut self, player_id: i64, chunk: String, is_final: bool) {
+        if Some(player_id) != self.current_player_id {
+            return;
+        }
+        match self.streaming_message_index {
+            None => {
+                let idx = self.messages.len();
+                self.messages.push(AppMessage::normal(chunk));
+                if !is_final {
+                    self.streaming_message_index = Some(idx);
+                }
+            }
+            Some(idx) => {
+                if let Some(msg) = self.messages.get_mut(idx) {
+                    msg.text.push_str(&chunk);
+                }
+                if is_final {
+                    self.streaming_message_index = None;
+                }
+            }
+        }
+        if is_final {
+            self.agent_responding = false;
+        }
+    }
+
+    fn handle_conversation_started(&mut self, kind: ConversationKind, options: Vec<String>) {
+        match kind {
+            ConversationKind::Dialog => {
+                self.mode = GameMode::StandardConversation;
+                self.conversation.options = options;
+                self.conversation.selected_index = 0;
+            }
+            ConversationKind::Agent => {
+                self.mode = GameMode::AgentConversation;
+                self.messages.clear();
+                self.scroll_offset = 0;
+            }
+        }
+    }
+
+    fn handle_battle_started(&mut self, engagement_id: i64, snapshot: BattleSnapshot) {
+        self.battle = Some(BattleState::new(engagement_id, snapshot));
+        self.mode = GameMode::Battle;
+    }
+
+    fn handle_battle_update(
+        &mut self,
+        engagement_id: i64,
+        snapshot: BattleSnapshot,
+        messages: Vec<BattleMessage>,
+    ) {
+        let Some(battle) = &mut self.battle else {
+            return;
+        };
+        if battle.engagement_id != engagement_id {
+            return;
+        }
+        battle.snapshot.participants = snapshot.participants;
+        battle.snapshot.phase = snapshot.phase;
+        battle.message_log.extend(messages);
     }
 }

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -10,7 +10,9 @@ use crate::network::NetworkEvent;
 use crate::network::client::list_players;
 
 use super::app::{App, GameMode};
-use super::screens::{agent_conversation, conversation, game as game_screen, player_select};
+use super::screens::{
+    agent_conversation, battle as battle_screen, conversation, game as game_screen, player_select,
+};
 
 pub async fn run(
     terminal: &mut DefaultTerminal,
@@ -72,6 +74,9 @@ async fn handle_terminal_event(
                 }
                 GameMode::AgentConversation => {
                     agent_conversation::handle_key(app, key.modifiers, key.code).await;
+                }
+                GameMode::Battle => {
+                    battle_screen::handle_key(app, key.modifiers, key.code).await;
                 }
             }
             true

--- a/src/tui/screens.rs
+++ b/src/tui/screens.rs
@@ -1,4 +1,5 @@
 pub mod agent_conversation;
+pub mod battle;
 pub mod conversation;
 pub mod discovery;
 pub mod game;

--- a/src/tui/screens/battle.rs
+++ b/src/tui/screens/battle.rs
@@ -1,0 +1,346 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+};
+
+use crate::game::engagement::battle::BattleMessage;
+use crate::game::{Interaction, TurnAction};
+use crate::network::client::send_interaction;
+use crate::network::event::ParticipantInfo;
+use crate::tui::app::{App, BattleFocus, BattleState, GameMode};
+
+pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    match (modifiers, code) {
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => app.should_quit = true,
+        (_, KeyCode::Up) => handle_navigate_up(app),
+        (_, KeyCode::Down) => handle_navigate_down(app),
+        (_, KeyCode::Tab) => {
+            if let Some(battle) = &mut app.battle {
+                battle.toggle_focus();
+            }
+        }
+        (_, KeyCode::Enter) => handle_queue_ability(app).await,
+        (_, KeyCode::Esc) => handle_leave_battle(app).await,
+        (_, KeyCode::PageUp) => handle_page_up(app),
+        (_, KeyCode::PageDown) => handle_page_down(app),
+        _ => {}
+    }
+}
+
+fn handle_navigate_up(app: &mut App) {
+    if let Some(battle) = &mut app.battle {
+        match battle.focus {
+            BattleFocus::Abilities => battle.select_prev_ability(),
+            BattleFocus::EntityList => battle.select_prev_entity(),
+        }
+    }
+}
+
+fn handle_navigate_down(app: &mut App) {
+    if let Some(battle) = &mut app.battle {
+        match battle.focus {
+            BattleFocus::Abilities => battle.select_next_ability(),
+            BattleFocus::EntityList => battle.select_next_entity(),
+        }
+    }
+}
+
+async fn handle_queue_ability(app: &mut App) {
+    let Some(battle) = &app.battle else { return };
+    if battle.focus != BattleFocus::Abilities {
+        return;
+    }
+    let ability = battle
+        .snapshot
+        .available_abilities
+        .get(battle.selected_ability_index)
+        .cloned();
+    let target_id = battle.selected_target_id();
+    let Some(url) = app.connection.server_url.as_deref() else {
+        return;
+    };
+    let Some(client_id) = app.connection.client_id.as_deref() else {
+        return;
+    };
+    if let (Some(ability), Some(target_id)) = (ability, target_id) {
+        let action = Interaction::EngagementAction(TurnAction::QueueAbility {
+            ability_id: ability.id,
+            target_id,
+        });
+        let _ = send_interaction(url, client_id, &action).await;
+    }
+}
+
+async fn handle_leave_battle(app: &mut App) {
+    if let Some(battle) = &app.battle {
+        let engagement_id = battle.engagement_id;
+        if let (Some(url), Some(client_id)) = (
+            app.connection.server_url.as_deref(),
+            app.connection.client_id.as_deref(),
+        ) {
+            let _ =
+                send_interaction(url, client_id, &Interaction::LeaveBattle { engagement_id }).await;
+        }
+    }
+    app.battle = None;
+    app.mode = GameMode::Game;
+}
+
+fn handle_page_up(app: &mut App) {
+    if app
+        .battle
+        .as_ref()
+        .is_some_and(|b| b.focus == BattleFocus::EntityList)
+    {
+        if let Some(battle) = &mut app.battle {
+            battle.entity_scroll = battle.entity_scroll.saturating_sub(1);
+        }
+    } else {
+        app.scroll_up();
+    }
+}
+
+fn handle_page_down(app: &mut App) {
+    if app
+        .battle
+        .as_ref()
+        .is_some_and(|b| b.focus == BattleFocus::EntityList)
+    {
+        if let Some(battle) = &mut app.battle {
+            battle.entity_scroll += 1;
+        }
+    } else {
+        app.scroll_down();
+    }
+}
+
+pub fn render(frame: &mut Frame, app: &App) {
+    let Some(battle) = &app.battle else {
+        return;
+    };
+
+    let areas = Layout::vertical([
+        Constraint::Length(8),
+        Constraint::Fill(1),
+        Constraint::Length(3),
+    ])
+    .split(frame.area());
+
+    render_combatants_panel(frame, battle, areas[0]);
+    render_middle_row(frame, app, battle, areas[1]);
+    render_status_bar(frame, battle, areas[2]);
+}
+
+fn render_combatants_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
+    let is_focused = battle.focus == BattleFocus::EntityList;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+
+    let outer_block = Block::default()
+        .title("Combatants")
+        .borders(Borders::ALL)
+        .border_style(border_style);
+    let inner = outer_block.inner(area);
+    frame.render_widget(outer_block, area);
+
+    let cols = Layout::horizontal([
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Fill(1),
+    ])
+    .split(inner);
+
+    let scroll_y = battle.entity_scroll as u16;
+
+    let left_lines = faction_lines(battle, battle.snapshot.factions.first().map(String::as_str));
+    let left = Paragraph::new(Text::from(left_lines)).scroll((scroll_y, 0));
+    frame.render_widget(left, cols[0]);
+
+    frame.render_widget(Block::default().borders(Borders::LEFT), cols[1]);
+
+    let right_lines: Vec<Line> = battle
+        .snapshot
+        .factions
+        .iter()
+        .skip(1)
+        .flat_map(|f| faction_lines(battle, Some(f.as_str())))
+        .collect();
+    let right = Paragraph::new(Text::from(right_lines)).scroll((scroll_y, 0));
+    frame.render_widget(right, cols[2]);
+}
+
+fn faction_lines(battle: &BattleState, faction: Option<&str>) -> Vec<Line<'static>> {
+    let Some(faction_name) = faction else {
+        return vec![];
+    };
+    let mut lines = vec![Line::from(Span::styled(
+        faction_name.to_string(),
+        Style::default().add_modifier(Modifier::BOLD),
+    ))];
+    if let Some(participants) = battle.snapshot.participants.get(faction_name) {
+        for p in participants {
+            lines.push(participant_line(p));
+        }
+    }
+    lines
+}
+
+fn participant_line(p: &ParticipantInfo) -> Line<'static> {
+    let hp_ratio = if p.hp_max > 0 {
+        (p.hp_current as f64 / p.hp_max as f64).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let bar_width = 8usize;
+    let filled = (hp_ratio * bar_width as f64).round() as usize;
+    let bar = format!("[{}{}]", "█".repeat(filled), "░".repeat(bar_width - filled));
+    let hp_color = if hp_ratio > 0.5 {
+        Color::Green
+    } else if hp_ratio > 0.25 {
+        Color::Yellow
+    } else {
+        Color::Red
+    };
+    Line::from(vec![
+        Span::raw(format!("{:<12} ", p.name)),
+        Span::styled(bar, Style::default().fg(hp_color)),
+        Span::raw(format!(" {}/{}", p.hp_current, p.hp_max)),
+    ])
+}
+
+fn render_middle_row(frame: &mut Frame, app: &App, battle: &BattleState, area: Rect) {
+    let cols = Layout::horizontal([Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)]).split(area);
+
+    render_abilities_panel(frame, battle, cols[0]);
+    render_message_log(frame, app, battle, cols[1]);
+}
+
+fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
+    let is_focused = battle.focus == BattleFocus::Abilities;
+    let border_style = if is_focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+
+    let items: Vec<ListItem> = battle
+        .snapshot
+        .available_abilities
+        .iter()
+        .enumerate()
+        .map(|(i, ability)| {
+            let cost_str = ability
+                .costs
+                .iter()
+                .map(|c| {
+                    let crate::game::component::Cost::Resource {
+                        resource_id,
+                        amount,
+                    } = c;
+                    format!("{resource_id}:{amount}")
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            let label = if cost_str.is_empty() {
+                ability.name.clone()
+            } else {
+                format!("{} ({})", ability.name, cost_str)
+            };
+            if i == battle.selected_ability_index && is_focused {
+                ListItem::new(label).style(
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                ListItem::new(label)
+            }
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .title("Abilities")
+            .borders(Borders::ALL)
+            .border_style(border_style),
+    );
+    frame.render_widget(list, area);
+}
+
+fn render_message_log(frame: &mut Frame, app: &App, battle: &BattleState, area: Rect) {
+    let panel_height = area.height.saturating_sub(2) as usize;
+
+    let all_lines: Vec<Line> = battle
+        .message_log
+        .iter()
+        .map(|msg| battle_message_to_line(msg))
+        .collect();
+
+    let total_lines = all_lines.len();
+    let max_offset = total_lines.saturating_sub(panel_height);
+    let effective_offset = app.scroll_offset.min(max_offset);
+    let scroll_from_top = max_offset.saturating_sub(effective_offset) as u16;
+
+    let log = Paragraph::new(Text::from(all_lines))
+        .block(Block::default().title("Battle Log").borders(Borders::ALL))
+        .wrap(Wrap { trim: true })
+        .scroll((scroll_from_top, 0));
+    frame.render_widget(log, area);
+}
+
+fn battle_message_to_line(msg: &BattleMessage) -> Line<'_> {
+    match msg {
+        BattleMessage::PhaseChange { .. } => Line::from(Span::styled(
+            msg.to_string(),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC | Modifier::DIM),
+        )),
+        BattleMessage::AbilityCast { .. } => Line::from(Span::styled(
+            msg.to_string(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )),
+        BattleMessage::EntityDied { .. } => Line::from(Span::styled(
+            msg.to_string(),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )),
+        BattleMessage::Meta(_) => Line::from(Span::styled(
+            msg.to_string(),
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::ITALIC),
+        )),
+    }
+}
+
+fn render_status_bar(frame: &mut Frame, battle: &BattleState, area: Rect) {
+    let phase_str = battle.snapshot.phase.to_string();
+
+    let player_faction = battle.snapshot.factions.first();
+    let player_hp = player_faction
+        .and_then(|f| battle.snapshot.participants.get(f))
+        .and_then(|ps| ps.first());
+
+    let status_text = if let Some(p) = player_hp {
+        format!(
+            "HP: {}/{} | [{phase_str}] | ↑↓ Navigate  Tab Switch Focus  Enter Queue  Esc Leave",
+            p.hp_current, p.hp_max
+        )
+    } else {
+        format!("[{phase_str}] | ↑↓ Navigate  Tab Switch Focus  Enter Queue  Esc Leave")
+    };
+
+    let status = Paragraph::new(status_text)
+        .style(Style::default().fg(Color::Green))
+        .block(Block::default().title("Status").borders(Borders::ALL));
+    frame.render_widget(status, area);
+}

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use super::super::components::message_log;
-use super::{agent_conversation, conversation, player_select};
+use super::{agent_conversation, battle, conversation, player_select};
 use crate::game::{Interaction, Movement, TurnAction};
 use crate::network::client::send_interaction;
 use crate::tui::app::{App, AppMessage, GameMode};
@@ -96,6 +96,11 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     if app.mode == GameMode::AgentConversation {
         agent_conversation::render(frame, app);
+        return;
+    }
+
+    if app.mode == GameMode::Battle {
+        battle::render(frame, app);
         return;
     }
 


### PR DESCRIPTION
## Summary

- Adds `GameMode::Battle` with a dedicated `battle.rs` screen: faction panels with HP bars, ability list, scrollable combatant view with vertical divider (player side vs enemy side), and a typed message log
- Wires `BattleUpdate` / `BattleEnded` network events end-to-end so the TUI reflects live phase changes, HP deltas, and cast messages after each battle tick
- Fixes ability queuing: `QueueAbility` now routes to `BattleEngagement.action_queue` instead of the old turn-based `pending_actions`
- Fixes entity name resolution in cast messages — player names now come from `active_players` instead of `config_id` (which was always `None` for players)
- Reduces `max_engage_ms` from 300s to 5s so NPC phases time out quickly rather than stalling the battle for 5 minutes

## Test plan

- [ ] Start server + client, walk into a room with an enemy to trigger a battle
- [ ] Confirm screen switches to Battle mode showing both faction panels with HP bars
- [ ] Press Tab to toggle focus between Abilities and EntityList panels (yellow border indicates focus)
- [ ] Press Up/Down to navigate ability list; press Enter to queue the selected ability against the selected target
- [ ] Confirm cast messages appear in the Battle Log with correct player and enemy names
- [ ] Confirm HP bars update each tick as damage is applied
- [ ] Confirm screen returns to Game mode when battle ends
- [ ] Press Esc to leave battle early

🤖 Generated with [Claude Code](https://claude.com/claude-code)