### PR TITLE
Add turn timer countdown to battle status bar

### DIFF
--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -22,6 +22,7 @@ pub struct BattleTick {
     pub phase: BattlePhase,
     pub factions: Vec<String>,
     pub participants: HashMap<String, Vec<i64>>,
+    pub ticks_in_phase: u64,
 }
 
 pub struct BattleEngagement {
@@ -209,6 +210,7 @@ impl BattleEngagement {
             phase: self.turn_phase.clone(),
             factions: self.factions.clone(),
             participants: self.participants.clone(),
+            ticks_in_phase: self.ticks_in_phase,
         }
     }
 }

--- a/src/game/engagement/processing.rs
+++ b/src/game/engagement/processing.rs
@@ -90,16 +90,17 @@ async fn handle_battle_tick(
         .update_battle_participants(engagement_id, &dead_ids)
         .await;
 
-    let update = build_battle_update(
-        game_state,
-        &result.factions,
-        &result.participants,
-        result.phase,
-        all_tick_messages,
-        max_engage_ticks,
+    let countdown_ticks = max_engage_ticks.saturating_sub(result.ticks_in_phase);
+    let params = BattleUpdateParams {
         engagement_id,
-    )
-    .await;
+        factions: result.factions,
+        participants: result.participants,
+        phase: result.phase,
+        messages: all_tick_messages,
+        countdown_ticks,
+        max_turn_ticks: max_engage_ticks,
+    };
+    let update = build_battle_update(game_state, params).await;
 
     for &pid in &player_ids {
         messaging::battle_update(&game_state.message_tx, pid, update.clone());
@@ -299,20 +300,26 @@ async fn find_participant_player_ids(game_state: &Arc<GameState>, entity_ids: &[
         .collect()
 }
 
-async fn build_battle_update(
-    game_state: &Arc<GameState>,
-    factions: &[String],
-    participants: &HashMap<String, Vec<i64>>,
+struct BattleUpdateParams {
+    engagement_id: i64,
+    factions: Vec<String>,
+    participants: HashMap<String, Vec<i64>>,
     phase: crate::game::engagement::battle::BattlePhase,
     messages: Vec<BattleMessage>,
+    countdown_ticks: u64,
     max_turn_ticks: u64,
-    engagement_id: i64,
+}
+
+async fn build_battle_update(
+    game_state: &Arc<GameState>,
+    params: BattleUpdateParams,
 ) -> BattleUpdateMessage {
     let entities = game_state.active_entities.read().await;
     let players = game_state.active_players.read().await;
     let hp_attr_id = messaging::hp_attribute_id(&game_state.attribute_config);
 
-    let participant_infos = participants
+    let participant_infos = params
+        .participants
         .iter()
         .map(|(faction, ids)| {
             let infos = ids
@@ -346,11 +353,12 @@ async fn build_battle_update(
         .collect();
 
     BattleUpdateMessage {
-        engagement_id,
-        factions: factions.to_vec(),
+        engagement_id: params.engagement_id,
+        factions: params.factions,
         participants: participant_infos,
-        phase,
-        messages,
-        max_turn_ticks,
+        phase: params.phase,
+        messages: params.messages,
+        countdown_ticks: params.countdown_ticks,
+        max_turn_ticks: params.max_turn_ticks,
     }
 }

--- a/src/game/messaging.rs
+++ b/src/game/messaging.rs
@@ -40,6 +40,7 @@ pub struct BattleUpdateMessage {
     pub participants: HashMap<String, Vec<BattleParticipantInfo>>,
     pub phase: BattlePhase,
     pub messages: Vec<BattleMessage>,
+    pub countdown_ticks: u64,
     pub max_turn_ticks: u64,
 }
 

--- a/src/network/server/message_relay.rs
+++ b/src/network/server/message_relay.rs
@@ -111,7 +111,7 @@ fn battle_update_snapshot(data: BattleUpdateMessage) -> BattleSnapshot {
         participants,
         phase: data.phase,
         turn_order: vec![],
-        countdown_ticks: 0,
+        countdown_ticks: data.countdown_ticks,
         max_turn_ticks: data.max_turn_ticks,
         available_abilities: vec![],
     }

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -127,6 +127,8 @@ impl App {
         }
         battle.snapshot.participants = snapshot.participants;
         battle.snapshot.phase = snapshot.phase;
+        battle.snapshot.countdown_ticks = snapshot.countdown_ticks;
+        battle.snapshot.max_turn_ticks = snapshot.max_turn_ticks;
         battle.message_log.extend(messages);
     }
 }

--- a/src/tui/screens/battle.rs
+++ b/src/tui/screens/battle.rs
@@ -7,7 +7,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 
-use crate::game::engagement::battle::BattleMessage;
+use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::game::{Interaction, TurnAction};
 use crate::network::client::send_interaction;
 use crate::network::event::ParticipantInfo;
@@ -389,13 +389,24 @@ fn render_status_bar(frame: &mut Frame, battle: &BattleState, area: Rect) {
         "↑↓ Navigate  Tab Switch Focus  Enter Select Ability  Esc Leave".to_string()
     };
 
+    let timer_str = match battle.snapshot.phase {
+        BattlePhase::AttackerPlanning | BattlePhase::DefenderResponse => {
+            let remaining = battle.snapshot.countdown_ticks;
+            let max = battle.snapshot.max_turn_ticks.max(1);
+            let filled = ((remaining * 10) / max).min(10) as usize;
+            let bar = format!("{}{}", "█".repeat(filled), "░".repeat(10 - filled));
+            format!(" | [{bar}] {remaining}")
+        }
+        _ => String::new(),
+    };
+
     let status_text = if let Some(p) = player_hp {
         format!(
-            "HP: {}/{} | [{phase_str}] | {hints}",
+            "HP: {}/{}{timer_str} | [{phase_str}] | {hints}",
             p.hp_current, p.hp_max
         )
     } else {
-        format!("[{phase_str}] | {hints}")
+        format!("[{phase_str}]{timer_str} | {hints}")
     };
 
     let status = Paragraph::new(status_text)


### PR DESCRIPTION
Wires up the per-tick turn countdown so the battle status bar shows how many ticks remain during planning phases. Previously `countdown_ticks` was hardcoded to zero across the server-to-client pipeline.

- `BattleTick` now exposes `ticks_in_phase` so callers can compute the remaining countdown
- `BattleUpdateMessage` carries `countdown_ticks`, propagated through `message_relay` and the TUI update handler
- Status bar displays a `[████░░░░░░] 24` progress bar only during `AttackerPlanning` and `DefenderResponse` phases; hidden during `InnateEffects`, `Resolution`, and `Concluded`

<details>
<summary>Agent Context</summary>

Closes #112. The `BattleSnapshot` struct in `src/network/event.rs` already had `countdown_ticks: u64` and `max_turn_ticks: u64` fields, but the data pipeline was broken at multiple points:

1. `src/game/engagement/battle.rs` — `BattleTick` did not expose `ticks_in_phase`; added as a public field, populated after phase-transition logic runs in `tick()`.
2. `src/game/messaging.rs` — `BattleUpdateMessage` lacked `countdown_ticks`; added the field.
3. `src/game/engagement/processing.rs` — `handle_battle_tick` now computes `countdown_ticks = max_engage_ticks.saturating_sub(result.ticks_in_phase)` and passes it via a new `BattleUpdateParams` struct (refactor was required to fix a `clippy::too_many_arguments` warning on `build_battle_update`).
4. `src/network/server/message_relay.rs` — `battle_update_snapshot()` hardcoded `countdown_ticks: 0`; now copies from `data.countdown_ticks`.
5. `src/tui/app/network_event_handler.rs` — `handle_battle_update` only propagated `participants` and `phase`; now also updates `countdown_ticks` and `max_turn_ticks`.
6. `src/tui/screens/battle.rs` — `render_status_bar` updated with a progress bar rendered using Unicode block characters. Phase matching uses `BattlePhase::AttackerPlanning | BattlePhase::DefenderResponse`; all other phases produce an empty string.

Phase logic note: `ticks_in_phase` is captured after all transition logic runs, so when `InnateEffects` transitions to `AttackerPlanning` and resets `ticks_in_phase = 0`, the countdown starts at max (full bar). Planning phases decrement correctly each tick. No changes to phase transitions or timing config.

</details>