### PR TITLE
Add ability browsing lock and waiting indicator during opponent's turn

### DIFF
--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -1,4 +1,4 @@
-use crate::game::engagement::battle::BattleMessage;
+use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::network::event::{BattleSnapshot, ParticipantInfo};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -114,5 +114,59 @@ impl BattleState {
     pub fn dialog_target_id(&self) -> Option<i64> {
         let dialog = self.dialog.as_ref()?;
         dialog.targets.get(dialog.selected_index).map(|p| p.id)
+    }
+
+    pub fn is_player_turn(&self) -> bool {
+        self.snapshot.phase == BattlePhase::AttackerPlanning
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::game::component::Ability;
+    use crate::network::event::BattleSnapshot;
+
+    fn make_snapshot(phase: BattlePhase) -> BattleSnapshot {
+        BattleSnapshot {
+            factions: vec!["player".to_string(), "enemy".to_string()],
+            participants: HashMap::new(),
+            phase,
+            turn_order: vec![],
+            countdown_ticks: 0,
+            max_turn_ticks: 30,
+            available_abilities: vec![],
+        }
+    }
+
+    fn make_state(phase: BattlePhase) -> BattleState {
+        BattleState::new(1, make_snapshot(phase))
+    }
+
+    #[test]
+    fn is_player_turn_true_during_attacker_planning() {
+        assert!(make_state(BattlePhase::AttackerPlanning).is_player_turn());
+    }
+
+    #[test]
+    fn is_player_turn_false_during_defender_response() {
+        assert!(!make_state(BattlePhase::DefenderResponse).is_player_turn());
+    }
+
+    #[test]
+    fn is_player_turn_false_during_innate_effects() {
+        assert!(!make_state(BattlePhase::InnateEffects).is_player_turn());
+    }
+
+    #[test]
+    fn is_player_turn_false_during_resolution() {
+        assert!(!make_state(BattlePhase::Resolution).is_player_turn());
+    }
+
+    #[test]
+    fn is_player_turn_false_during_concluded() {
+        assert!(!make_state(BattlePhase::Concluded).is_player_turn());
     }
 }

--- a/src/tui/screens/battle.rs
+++ b/src/tui/screens/battle.rs
@@ -80,6 +80,9 @@ fn handle_ability_selected(app: &mut App) {
     let Some(battle) = &mut app.battle else {
         return;
     };
+    if !battle.is_player_turn() {
+        return;
+    }
     if battle.focus != BattleFocus::Abilities {
         return;
     }
@@ -318,9 +321,14 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
         })
         .collect();
 
+    let title = if battle.is_player_turn() {
+        "Abilities"
+    } else {
+        "Abilities (waiting\u{2026})"
+    };
     let list = List::new(items).block(
         Block::default()
-            .title("Abilities")
+            .title(title)
             .borders(Borders::ALL)
             .border_style(border_style),
     );


### PR DESCRIPTION
Closes #113. During phases when it is not the player's turn (`DefenderResponse`, `InnateEffects`, `Resolution`, `Concluded`), pressing Enter no longer queues an ability. The ability list remains fully navigable so players can plan ahead.

- New `is_player_turn()` method on `BattleState` derives turn eligibility from `snapshot.phase` (true only during `AttackerPlanning`)
- `handle_ability_selected` returns early when `is_player_turn()` is false, silently suppressing Enter
- Abilities panel title changes to `"Abilities (waiting…)"` when the player cannot act, making the locked state visually obvious
- Five unit tests cover all `BattlePhase` variants against `is_player_turn()`

<details>
<summary>Agent Context</summary>

**Goal:** Prevent players from queuing abilities outside their planning phase while keeping navigation intact.

**Files changed:**
- `src/tui/app/battle_state.rs` — added `is_player_turn() -> bool` and `BattlePhase` import; added `#[cfg(test)] mod tests` with 5 phase-coverage tests
- `src/tui/screens/battle.rs` — early return in `handle_ability_selected` on `!battle.is_player_turn()`; dynamic panel title in `render_abilities_panel`

**Key decisions:**
- `is_player_turn` = `phase == BattlePhase::AttackerPlanning`. The player is always the attacker (factions[0] in both `BattleEngagement` and `BattleSnapshot` is the attacker/player faction), so this is the correct derivation. The issue mentions the "vice-versa" case for generality, but the current data model always places the player at factions[0] = attacker.
- Title string uses `\u{2026}` (…) rather than three dots to be a single Unicode character.
- Up/Down navigation required no changes — it routes through `handle_navigate_up/down` which are unconditional.

**Related:** Issue #113. No follow-up work deferred.

</details>