### PR TITLE
Fixes #123 Generalize battle phases to support multi-faction turn order

### DIFF
--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -32,6 +32,7 @@ pub struct BattleEngagement {
     action_queue: HashMap<i64, Vec<QueuedAbility>>,
     ticks_in_phase: u64,
     pending_costs: HashMap<i64, Vec<(String, i64)>>,
+    planning_faction_index: usize,
 }
 
 impl BattleEngagement {
@@ -43,6 +44,7 @@ impl BattleEngagement {
             action_queue: HashMap::new(),
             ticks_in_phase: 0,
             pending_costs: HashMap::new(),
+            planning_faction_index: 0,
         }
     }
 
@@ -50,19 +52,25 @@ impl BattleEngagement {
         self.participants.values().flatten().copied().collect()
     }
 
-    pub fn attacker_ids(&self) -> Vec<i64> {
+    fn planning_faction(&self) -> &str {
         self.factions
-            .first()
-            .and_then(|f| self.participants.get(f))
+            .get(self.planning_faction_index)
+            .map(String::as_str)
+            .unwrap_or_default()
+    }
+
+    pub fn planning_ids(&self) -> Vec<i64> {
+        self.participants
+            .get(self.planning_faction())
             .cloned()
             .unwrap_or_default()
     }
 
-    pub fn defender_ids(&self) -> Vec<i64> {
-        let attacker_faction = self.factions.first().map(String::as_str);
+    pub fn responding_ids(&self) -> Vec<i64> {
+        let planning = self.planning_faction();
         self.participants
             .iter()
-            .filter(|(f, _)| Some(f.as_str()) != attacker_faction)
+            .filter(|(f, _)| f.as_str() != planning)
             .flat_map(|(_, ids)| ids.iter().copied())
             .collect()
     }
@@ -150,31 +158,38 @@ impl BattleEngagement {
         match self.turn_phase.clone() {
             BattlePhase::InnateEffects => {
                 innate_entity_ids = all_participant_ids.clone();
+                let faction = self.planning_faction().to_string();
+                let next = BattlePhase::Planning {
+                    faction: faction.clone(),
+                };
                 messages.push(BattleMessage::PhaseChange {
-                    phase: BattlePhase::AttackerPlanning,
+                    phase: next.clone(),
                 });
-                self.turn_phase = BattlePhase::AttackerPlanning;
+                self.turn_phase = next;
                 self.ticks_in_phase = 0;
             }
-            BattlePhase::AttackerPlanning => {
+            BattlePhase::Planning { faction } => {
                 self.ticks_in_phase += 1;
-                let attacker_ids = self.attacker_ids();
-                let all_submitted = attacker_ids
+                let planning_ids = self.planning_ids();
+                let all_submitted = planning_ids
                     .iter()
                     .all(|id| self.action_queue.contains_key(id));
                 if all_submitted || self.ticks_in_phase >= max_engage_ticks {
+                    let next = BattlePhase::Response {
+                        faction: faction.clone(),
+                    };
                     messages.push(BattleMessage::PhaseChange {
-                        phase: BattlePhase::DefenderResponse,
+                        phase: next.clone(),
                     });
-                    self.turn_phase = BattlePhase::DefenderResponse;
+                    self.turn_phase = next;
                     self.ticks_in_phase = 0;
                 }
             }
-            BattlePhase::DefenderResponse => {
+            BattlePhase::Response { .. } => {
                 self.ticks_in_phase += 1;
-                let defender_ids = self.defender_ids();
-                let all_submitted = defender_ids.is_empty()
-                    || defender_ids
+                let responding_ids = self.responding_ids();
+                let all_submitted = responding_ids.is_empty()
+                    || responding_ids
                         .iter()
                         .all(|id| self.action_queue.contains_key(id));
                 if all_submitted || self.ticks_in_phase >= max_engage_ticks {
@@ -192,6 +207,10 @@ impl BattleEngagement {
                     .flat_map(|(_, abilities)| abilities)
                     .collect();
                 self.pending_costs.clear();
+                if !self.factions.is_empty() {
+                    self.planning_faction_index =
+                        (self.planning_faction_index + 1) % self.factions.len();
+                }
                 messages.push(BattleMessage::PhaseChange {
                     phase: BattlePhase::InnateEffects,
                 });
@@ -280,15 +299,15 @@ mod tests {
     }
 
     #[test]
-    fn attacker_ids_returns_first_faction() {
+    fn planning_ids_returns_current_planning_faction() {
         let eng = make_engagement();
-        assert_eq!(eng.attacker_ids(), vec![1]);
+        assert_eq!(eng.planning_ids(), vec![1]);
     }
 
     #[test]
-    fn defender_ids_returns_non_first_factions() {
+    fn responding_ids_returns_non_planning_factions() {
         let eng = make_engagement();
-        let mut ids = eng.defender_ids();
+        let mut ids = eng.responding_ids();
         ids.sort();
         assert_eq!(ids, vec![2, 3]);
     }
@@ -311,47 +330,62 @@ mod tests {
     }
 
     #[test]
-    fn tick_innate_effects_transitions_to_attacker_planning() {
+    fn tick_innate_effects_transitions_to_planning() {
         let mut eng = make_engagement();
         let tick = eng.tick(1, 30);
-        assert_eq!(eng.turn_phase, BattlePhase::AttackerPlanning);
+        assert_eq!(
+            eng.turn_phase,
+            BattlePhase::Planning {
+                faction: "player".into()
+            }
+        );
         assert!(!tick.innate_entity_ids.is_empty());
         assert!(tick.messages.iter().any(|m| matches!(
             m,
             BattleMessage::PhaseChange {
-                phase: BattlePhase::AttackerPlanning
+                phase: BattlePhase::Planning { .. }
             }
         )));
     }
 
     #[test]
-    fn tick_attacker_planning_waits_for_timeout() {
+    fn tick_planning_waits_for_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 30); // InnateEffects → AttackerPlanning
+        eng.tick(1, 30); // InnateEffects → Planning
         let tick = eng.tick(1, 30);
-        assert_eq!(eng.turn_phase, BattlePhase::AttackerPlanning);
+        assert_eq!(
+            eng.turn_phase,
+            BattlePhase::Planning {
+                faction: "player".into()
+            }
+        );
         assert!(tick.messages.is_empty());
     }
 
     #[test]
-    fn tick_attacker_planning_advances_on_timeout() {
+    fn tick_planning_advances_on_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // InnateEffects → AttackerPlanning
-        let tick = eng.tick(1, 1); // timeout
-        assert_eq!(eng.turn_phase, BattlePhase::DefenderResponse);
+        eng.tick(1, 1); // InnateEffects → Planning{player}
+        let tick = eng.tick(1, 1); // timeout → Response{player}
+        assert_eq!(
+            eng.turn_phase,
+            BattlePhase::Response {
+                faction: "player".into()
+            }
+        );
         assert!(tick.messages.iter().any(|m| matches!(
             m,
             BattleMessage::PhaseChange {
-                phase: BattlePhase::DefenderResponse
+                phase: BattlePhase::Response { .. }
             }
         )));
     }
 
     #[test]
-    fn tick_defender_response_advances_on_timeout() {
+    fn tick_response_advances_on_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // InnateEffects → AttackerPlanning
-        eng.tick(1, 1); // timeout → DefenderResponse
+        eng.tick(1, 1); // InnateEffects → Planning
+        eng.tick(1, 1); // timeout → Response
         let tick = eng.tick(1, 1); // timeout → Resolution
         assert_eq!(eng.turn_phase, BattlePhase::Resolution);
         assert!(tick.messages.iter().any(|m| matches!(
@@ -365,8 +399,8 @@ mod tests {
     #[test]
     fn tick_resolution_drains_queue_and_resets() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // → AttackerPlanning
-        eng.tick(1, 1); // → DefenderResponse
+        eng.tick(1, 1); // → Planning
+        eng.tick(1, 1); // → Response
         eng.tick(1, 1); // → Resolution
         let tick = eng.tick(1, 1); // Resolution → InnateEffects
         assert_eq!(eng.turn_phase, BattlePhase::InnateEffects);
@@ -374,6 +408,30 @@ mod tests {
             m,
             BattleMessage::PhaseChange {
                 phase: BattlePhase::InnateEffects
+            }
+        )));
+    }
+
+    #[test]
+    fn tick_resolution_advances_planning_faction_index() {
+        let mut eng = make_engagement();
+        assert_eq!(eng.planning_faction_index, 0);
+        eng.tick(1, 1); // → Planning{player}
+        eng.tick(1, 1); // → Response{player}
+        eng.tick(1, 1); // → Resolution
+        eng.tick(1, 1); // Resolution → InnateEffects (index advances to 1)
+        assert_eq!(eng.planning_faction_index, 1);
+        let tick = eng.tick(1, 1); // InnateEffects → Planning{enemy}
+        assert_eq!(
+            eng.turn_phase,
+            BattlePhase::Planning {
+                faction: "enemy".into()
+            }
+        );
+        assert!(tick.messages.iter().any(|m| matches!(
+            m,
+            BattleMessage::PhaseChange {
+                phase: BattlePhase::Planning { .. }
             }
         )));
     }

--- a/src/game/engagement/battle/phase.rs
+++ b/src/game/engagement/battle/phase.rs
@@ -3,11 +3,11 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum BattlePhase {
     InnateEffects,
-    AttackerPlanning,
-    DefenderResponse,
+    Planning { faction: String },
+    Response { faction: String },
     Resolution,
     Concluded,
 }
@@ -15,11 +15,11 @@ pub enum BattlePhase {
 impl fmt::Display for BattlePhase {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
-            BattlePhase::InnateEffects => "Innate Effects",
-            BattlePhase::AttackerPlanning => "Attacker Planning",
-            BattlePhase::DefenderResponse => "Defender Response",
-            BattlePhase::Resolution => "Resolution",
-            BattlePhase::Concluded => "Concluded",
+            BattlePhase::InnateEffects => "Innate Effects".to_string(),
+            BattlePhase::Planning { faction } => format!("{faction} Planning"),
+            BattlePhase::Response { faction } => format!("Response to {faction}"),
+            BattlePhase::Resolution => "Resolution".to_string(),
+            BattlePhase::Concluded => "Concluded".to_string(),
         };
         write!(f, "{s}")
     }
@@ -33,12 +33,18 @@ mod tests {
     fn display_formats_human_readable() {
         assert_eq!(BattlePhase::InnateEffects.to_string(), "Innate Effects");
         assert_eq!(
-            BattlePhase::AttackerPlanning.to_string(),
-            "Attacker Planning"
+            BattlePhase::Planning {
+                faction: "player".into()
+            }
+            .to_string(),
+            "player Planning"
         );
         assert_eq!(
-            BattlePhase::DefenderResponse.to_string(),
-            "Defender Response"
+            BattlePhase::Response {
+                faction: "enemy".into()
+            }
+            .to_string(),
+            "Response to enemy"
         );
         assert_eq!(BattlePhase::Resolution.to_string(), "Resolution");
         assert_eq!(BattlePhase::Concluded.to_string(), "Concluded");
@@ -48,8 +54,12 @@ mod tests {
     fn serde_round_trip() {
         let phases = [
             BattlePhase::InnateEffects,
-            BattlePhase::AttackerPlanning,
-            BattlePhase::DefenderResponse,
+            BattlePhase::Planning {
+                faction: "player".into(),
+            },
+            BattlePhase::Response {
+                faction: "enemy".into(),
+            },
             BattlePhase::Resolution,
             BattlePhase::Concluded,
         ];

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -286,7 +286,9 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(
             results[0].phase,
-            crate::game::engagement::battle::BattlePhase::AttackerPlanning
+            crate::game::engagement::battle::BattlePhase::Planning {
+                faction: "player".into()
+            }
         );
     }
 

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -117,7 +117,12 @@ impl BattleState {
     }
 
     pub fn is_player_turn(&self) -> bool {
-        self.snapshot.phase == BattlePhase::AttackerPlanning
+        let player_faction = self.snapshot.factions.first().map(String::as_str);
+        match &self.snapshot.phase {
+            BattlePhase::Planning { faction } => Some(faction.as_str()) == player_faction,
+            BattlePhase::Response { faction } => Some(faction.as_str()) != player_faction,
+            _ => false,
+        }
     }
 }
 
@@ -126,7 +131,6 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::game::component::Ability;
     use crate::network::event::BattleSnapshot;
 
     fn make_snapshot(phase: BattlePhase) -> BattleSnapshot {
@@ -146,13 +150,45 @@ mod tests {
     }
 
     #[test]
-    fn is_player_turn_true_during_attacker_planning() {
-        assert!(make_state(BattlePhase::AttackerPlanning).is_player_turn());
+    fn is_player_turn_true_when_player_faction_is_planning() {
+        assert!(
+            make_state(BattlePhase::Planning {
+                faction: "player".into()
+            })
+            .is_player_turn()
+        );
     }
 
     #[test]
-    fn is_player_turn_false_during_defender_response() {
-        assert!(!make_state(BattlePhase::DefenderResponse).is_player_turn());
+    fn is_player_turn_false_when_other_faction_is_planning() {
+        assert!(
+            !make_state(BattlePhase::Planning {
+                faction: "enemy".into()
+            })
+            .is_player_turn()
+        );
+    }
+
+    #[test]
+    fn is_player_turn_true_when_defending_against_enemy_plan() {
+        // Response { faction: "enemy" } means enemy planned; player (factions[0]) is defending
+        assert!(
+            make_state(BattlePhase::Response {
+                faction: "enemy".into()
+            })
+            .is_player_turn()
+        );
+    }
+
+    #[test]
+    fn is_player_turn_false_when_player_planned_and_enemy_defends() {
+        // Response { faction: "player" } means player planned; enemy is defending, not the player
+        assert!(
+            !make_state(BattlePhase::Response {
+                faction: "player".into()
+            })
+            .is_player_turn()
+        );
     }
 
     #[test]

--- a/src/tui/screens/battle.rs
+++ b/src/tui/screens/battle.rs
@@ -397,8 +397,8 @@ fn render_status_bar(frame: &mut Frame, battle: &BattleState, area: Rect) {
         "↑↓ Navigate  Tab Switch Focus  Enter Select Ability  Esc Leave".to_string()
     };
 
-    let timer_str = match battle.snapshot.phase {
-        BattlePhase::AttackerPlanning | BattlePhase::DefenderResponse => {
+    let timer_str = match &battle.snapshot.phase {
+        BattlePhase::Planning { .. } | BattlePhase::Response { .. } => {
             let remaining = battle.snapshot.countdown_ticks;
             let max = battle.snapshot.max_turn_ticks.max(1);
             let filled = ((remaining * 10) / max).min(10) as usize;


### PR DESCRIPTION
## Summary

- Replaces hard-coded `AttackerPlanning`/`DefenderResponse` `BattlePhase` variants with `Planning { faction: String }` and `Response { faction: String }`, where `faction` always identifies the currently-planning faction
- Adds `planning_faction_index` to `BattleEngagement` that advances after each `Resolution`, cycling every registered faction through its offensive turn
- `is_player_turn()` returns `true` both when the player's faction is planning **and** when the player is defending in the `Response` sub-phase (fixing ability selection during the response phase)
- Phase display updated to `"{faction} Planning"` / `"Response to {faction}"` so the status bar makes clear who is acting vs. who is being responded to

## Test plan

- [x] `cargo fmt && cargo test && cargo clippy` — 323 tests, zero warnings
- [ ] Start server, connect client, trigger combat and verify:
  - Status bar shows `[player Planning]` on player's offensive turn
  - Status bar shows `[Response to player]` while enemy defends
  - Status bar shows `[enemy Planning]` on enemy's offensive turn
  - Status bar shows `[Response to enemy]` while player defends (and ability selection is enabled)
  - Abilities panel shows "Abilities" title during both Planning and Response sub-phases for the local player
  - Countdown timer appears during both Planning and Response sub-phases
  - After resolution, the next faction's Planning phase begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)