### PR TITLE
Add default defend ability and AttributeShield effect type

### DIFF
--- a/src/game/component/effect.rs
+++ b/src/game/component/effect.rs
@@ -19,6 +19,10 @@ pub enum EffectType {
         attribute_id: String,
         value: i64,
     },
+    AttributeShield {
+        attribute_id: String,
+        absorb_amount: i64,
+    },
     EntitySpawn {
         entity_id: String,
         location: Option<Location>,
@@ -61,6 +65,22 @@ mod tests {
                 start_description: Some("You feel better.".to_string()),
                 end_description: None,
             },
+        };
+        let json = serde_json::to_string(&effect).unwrap();
+        let restored: Effect = serde_json::from_str(&json).unwrap();
+        assert_eq!(effect, restored);
+    }
+
+    #[test]
+    fn attribute_shield_serde_round_trip() {
+        let effect = Effect {
+            name: "damage_reduction".to_string(),
+            effect_type: EffectType::AttributeShield {
+                attribute_id: "hp".to_string(),
+                absorb_amount: 5,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription::default(),
         };
         let json = serde_json::to_string(&effect).unwrap();
         let restored: Effect = serde_json::from_str(&json).unwrap();

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -247,6 +247,26 @@ pub fn entity_innate_battle_abilities(entity: &crate::game::entity::Entity) -> V
     battle_abilities(entity)
 }
 
+pub fn default_defend_ability() -> Ability {
+    Ability {
+        id: "defend".to_string(),
+        name: "Defend".to_string(),
+        description: Some("Brace for impact, reducing incoming damage by 5.".to_string()),
+        effects: vec![Effect {
+            name: "damage_reduction".to_string(),
+            effect_type: EffectType::AttributeShield {
+                attribute_id: "hp".to_string(),
+                absorb_amount: 5,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription::default(),
+        }],
+        engagement_types: vec![EngagementType::Battle],
+        costs: vec![],
+        modifiers: vec![],
+    }
+}
+
 pub fn default_attack_ability() -> Ability {
     Ability {
         id: "attack".to_string(),
@@ -443,6 +463,22 @@ mod tests {
         let tick = eng.tick(1, 30);
         assert_eq!(eng.turn_phase, BattlePhase::Concluded);
         assert!(tick.messages.is_empty());
+    }
+
+    #[test]
+    fn default_defend_ability_has_correct_structure() {
+        let ability = default_defend_ability();
+        assert_eq!(ability.id, "defend");
+        assert_eq!(ability.name, "Defend");
+        assert_eq!(ability.effects.len(), 1);
+        assert!(matches!(
+            ability.effects[0].effect_type,
+            EffectType::AttributeShield {
+                ref attribute_id,
+                absorb_amount: 5,
+            } if attribute_id == "hp"
+        ));
+        assert!(matches!(ability.effects[0].trigger_info, TriggerInfo::Once));
     }
 
     #[test]

--- a/src/game/engagement/processing.rs
+++ b/src/game/engagement/processing.rs
@@ -109,6 +109,7 @@ async fn handle_battle_tick(
     if surviving <= 1 {
         loot::resolve_loot(&all_ids);
         game_state.engagements.conclude_battle(engagement_id).await;
+        clear_active_effects(game_state, &all_ids).await;
         for &pid in &player_ids {
             messaging::battle_ended(&game_state.message_tx, pid, engagement_id);
         }
@@ -240,21 +241,55 @@ fn ability_cast_message(
     }
 }
 
+fn absorb_with_shields(entity: &mut Entity, attribute_id: &str, value: i64) -> i64 {
+    if value >= 0 {
+        return value;
+    }
+    let mut remaining = value;
+    let mut consumed_once = Vec::new();
+    for (i, effect) in entity.active_effects.iter().enumerate() {
+        if let EffectType::AttributeShield {
+            attribute_id: shield_attr,
+            absorb_amount,
+        } = &effect.effect_type
+            && shield_attr == attribute_id
+        {
+            remaining = (remaining + absorb_amount).min(0);
+            if matches!(effect.trigger_info, TriggerInfo::Once) {
+                consumed_once.push(i);
+            }
+        }
+    }
+    for i in consumed_once.into_iter().rev() {
+        entity.active_effects.remove(i);
+    }
+    remaining
+}
+
 fn apply_once_effects(ability: &Ability, target_id: i64, entities: &mut HashMap<i64, Entity>) {
     let Some(entity) = entities.get_mut(&target_id) else {
         return;
     };
     for effect in &ability.effects {
-        if let TriggerInfo::Once = effect.trigger_info
-            && let EffectType::AttributeUpdate {
-                attribute_id,
-                value,
-            } = &effect.effect_type
-            && let Some(attr) = entity.attributes.get_mut(attribute_id)
-        {
-            attr.current_value = (attr.current_value + value)
-                .max(attr.min_value)
-                .min(attr.max_value);
+        match (&effect.trigger_info, &effect.effect_type) {
+            (
+                TriggerInfo::Once,
+                EffectType::AttributeUpdate {
+                    attribute_id,
+                    value,
+                },
+            ) => {
+                let adjusted = absorb_with_shields(entity, attribute_id, *value);
+                if let Some(attr) = entity.attributes.get_mut(attribute_id) {
+                    attr.current_value = (attr.current_value + adjusted)
+                        .max(attr.min_value)
+                        .min(attr.max_value);
+                }
+            }
+            (_, EffectType::AttributeShield { .. }) => {
+                entity.active_effects.push(effect.clone());
+            }
+            _ => {}
         }
     }
 }
@@ -289,6 +324,15 @@ fn is_entity_dead(entity_id: i64, entities: &HashMap<i64, Entity>, hp_def_ids: &
             .get(hp_id)
             .is_some_and(|attr| attr.current_value <= attr.min_value)
     })
+}
+
+async fn clear_active_effects(game_state: &Arc<GameState>, entity_ids: &[i64]) {
+    let mut entities = game_state.active_entities.write().await;
+    for &id in entity_ids {
+        if let Some(entity) = entities.get_mut(&id) {
+            entity.active_effects.clear();
+        }
+    }
 }
 
 async fn find_participant_player_ids(game_state: &Arc<GameState>, entity_ids: &[i64]) -> Vec<i64> {
@@ -360,5 +404,163 @@ async fn build_battle_update(
         messages: params.messages,
         countdown_ticks: params.countdown_ticks,
         max_turn_ticks: params.max_turn_ticks,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::Ability;
+    use crate::game::component::Attribute;
+    use crate::game::component::Location;
+    use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+    use crate::game::engagement::EngagementType;
+    use crate::game::entity::{Entity, EntityType};
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn hp_attribute(current: i64) -> Attribute {
+        Attribute::new("hp".to_string(), 0, 100, current)
+    }
+
+    fn attack_ability(damage: i64) -> Ability {
+        Ability {
+            id: "attack".to_string(),
+            name: "Attack".to_string(),
+            description: None,
+            effects: vec![Effect {
+                name: "damage".to_string(),
+                effect_type: EffectType::AttributeUpdate {
+                    attribute_id: "hp".to_string(),
+                    value: damage,
+                },
+                trigger_info: TriggerInfo::Once,
+                description: EffectDescription::default(),
+            }],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+        }
+    }
+
+    fn shield_effect(absorb_amount: i64, trigger: TriggerInfo) -> Effect {
+        Effect {
+            name: "damage_reduction".to_string(),
+            effect_type: EffectType::AttributeShield {
+                attribute_id: "hp".to_string(),
+                absorb_amount,
+            },
+            trigger_info: trigger,
+            description: EffectDescription::default(),
+        }
+    }
+
+    #[test]
+    fn shield_absorbs_partial_damage_and_is_consumed() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity
+            .attributes
+            .insert("hp".to_string(), hp_attribute(100));
+        entity
+            .active_effects
+            .push(shield_effect(5, TriggerInfo::Once));
+        entities.insert(1, entity);
+
+        apply_once_effects(&attack_ability(-10), 1, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 95);
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn over_time_shield_absorbs_and_is_not_consumed() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity
+            .attributes
+            .insert("hp".to_string(), hp_attribute(100));
+        entity.active_effects.push(shield_effect(
+            5,
+            TriggerInfo::OverTime {
+                start: 0,
+                end: None,
+                rate: 1,
+            },
+        ));
+        entities.insert(1, entity);
+
+        apply_once_effects(&attack_ability(-10), 1, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 95);
+        assert_eq!(entity.active_effects.len(), 1);
+    }
+
+    #[test]
+    fn shield_does_not_affect_positive_attribute_updates() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity.attributes.insert("hp".to_string(), hp_attribute(50));
+        entity
+            .active_effects
+            .push(shield_effect(5, TriggerInfo::Once));
+        entities.insert(1, entity);
+
+        apply_once_effects(&attack_ability(10), 1, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 60);
+        assert_eq!(entity.active_effects.len(), 1);
+    }
+
+    #[test]
+    fn applying_shield_ability_adds_to_active_effects() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity
+            .attributes
+            .insert("hp".to_string(), hp_attribute(100));
+        entities.insert(1, entity);
+
+        let defend_ability = Ability {
+            id: "defend".to_string(),
+            name: "Defend".to_string(),
+            description: None,
+            effects: vec![shield_effect(5, TriggerInfo::Once)],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+        };
+        apply_once_effects(&defend_ability, 1, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.active_effects.len(), 1);
+        assert_eq!(entity.attributes["hp"].current_value, 100);
+    }
+
+    #[test]
+    fn absorb_with_shields_clamps_to_zero_not_positive() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity
+            .attributes
+            .insert("hp".to_string(), hp_attribute(100));
+        entity
+            .active_effects
+            .push(shield_effect(20, TriggerInfo::Once));
+        entities.insert(1, entity);
+
+        apply_once_effects(&attack_ability(-10), 1, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 100);
     }
 }

--- a/src/game/entity.rs
+++ b/src/game/entity.rs
@@ -8,6 +8,7 @@ use crate::game::component::Attribute;
 use crate::game::component::FactionRelations;
 use crate::game::component::Interaction;
 use crate::game::component::Location;
+use crate::game::component::effect::Effect;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EntityType {
@@ -35,6 +36,8 @@ pub struct Entity {
     pub factions: HashSet<String>,
     #[serde(default)]
     pub faction_relations: FactionRelations,
+    #[serde(skip)]
+    pub active_effects: Vec<Effect>,
 }
 
 impl Entity {
@@ -63,6 +66,7 @@ impl Entity {
             ai: None,
             factions,
             faction_relations,
+            active_effects: Vec::new(),
         }
     }
 }

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -116,7 +116,8 @@ async fn dispatch_queue_ability(
             .iter()
             .find(|a| a.id == ability_id)
             .cloned()
-            .or_else(|| (ability_id == "attack").then(battle::default_attack_ability));
+            .or_else(|| (ability_id == "attack").then(battle::default_attack_ability))
+            .or_else(|| (ability_id == "defend").then(battle::default_defend_ability));
         (ability, entity.attributes.clone())
     };
     let Some(ability) = ability_opt else {


### PR DESCRIPTION
Closes #115. Adds a `default_defend_ability()` to the battle system that reduces incoming HP damage by 5, backed by a new `AttributeShield` effect type that intercepts negative `AttributeUpdate` effects before they apply to an entity's attributes.

- New `EffectType::AttributeShield { attribute_id, absorb_amount }` variant intercepts and reduces incoming negative attribute updates
- `Entity.active_effects` field stores runtime shield state (skipped in serde) so shields persist across resolution steps within a turn
- `default_defend_ability()` mirrors `default_attack_ability()` and is available as a fallback when queuing a "defend" action
- `TriggerInfo::Once` shields are consumed after one hit; `OverTime` shields persist until the battle concludes and are cleared on battle end

<details>
<summary>Agent Context</summary>

Implements issue #115. The chosen approach is `EffectType::AttributeShield` (over adding `incoming_modifiers` to `Entity`) — it keeps the interception logic self-contained in the processing layer and fits cleanly into the existing `EffectType` enum pattern.

**Files changed:**
- `src/game/component/effect.rs` — Added `AttributeShield { attribute_id, absorb_amount }` to `EffectType`
- `src/game/entity.rs` — Added `#[serde(skip)] pub active_effects: Vec<Effect>` runtime field; initialized to `Vec::new()` in `Entity::new()`
- `src/game/engagement/battle.rs` — Added `default_defend_ability()` returning an HP `AttributeShield` with `absorb_amount: 5` and `TriggerInfo::Once`
- `src/game/engagement/processing.rs` — `apply_once_effects` now routes `AttributeShield` to `entity.active_effects` and passes negative `AttributeUpdate` deltas through `absorb_with_shields` first; `clear_active_effects` runs at battle conclusion
- `src/game/interaction.rs` — Added `"defend"` fallback in `dispatch_queue_ability` alongside the existing `"attack"` fallback

**Key decisions:**
- `active_effects` is `#[serde(skip)]` because it is purely runtime battle state — no persistence needed
- Shield absorption clamps to zero so a large shield cannot flip a damage delta into a heal
- Speed-order semantics are preserved: if the attacker resolves before the defender queues defend, the shield isn't in place — intentional RPG design
- `OverTime` shields absorb every hit and are only cleared when the battle ends via `clear_active_effects`

**Tests added:** serde round-trip for `AttributeShield`; `default_defend_ability` structure test; five `processing.rs` unit tests covering partial absorption, over-time persistence, positive-value pass-through, shield application, and over-absorption clamping.
</details>