### PR TITLE
Implement per-target effect resolution pipeline in battle Resolution phase

### DIFF
--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -2,6 +2,7 @@ pub mod loot;
 pub mod message;
 pub mod phase;
 pub mod queued_ability;
+pub mod resolution;
 pub mod tick;
 
 use std::collections::HashMap;

--- a/src/game/engagement/battle/resolution.rs
+++ b/src/game/engagement/battle/resolution.rs
@@ -1,0 +1,303 @@
+use std::collections::HashMap;
+
+use crate::game::component::effect::{Effect, EffectType, TriggerInfo};
+use crate::game::entity::Entity;
+
+use super::BattleMessage;
+
+pub fn resolve_effects(
+    target_id: i64,
+    effects: Vec<Effect>,
+    entities: &mut HashMap<i64, Entity>,
+) -> Vec<BattleMessage> {
+    let Some(entity) = entities.get_mut(&target_id) else {
+        return vec![];
+    };
+
+    // Shield effects intercept incoming effects before they reach the entity.
+    let (shield_effects, incoming_effects): (Vec<Effect>, Vec<Effect>) = effects
+        .into_iter()
+        .partition(|e| matches!(e.effect_type, EffectType::AttributeShield { .. }));
+
+    let mut once_shields = collect_shield_effects(shield_effects, entity);
+
+    for effect in &incoming_effects {
+        if let (
+            TriggerInfo::Once,
+            EffectType::AttributeUpdate {
+                attribute_id,
+                value,
+            },
+        ) = (&effect.trigger_info, &effect.effect_type)
+        {
+            apply_attribute_update(entity, attribute_id, *value, &mut once_shields);
+        }
+    }
+
+    vec![]
+}
+
+/// Splits shield effects by trigger: OverTime shields are stubbed into `active_effects` for
+/// future handling; Once shields are returned for inline absorption this pass.
+fn collect_shield_effects(shield_effects: Vec<Effect>, entity: &mut Entity) -> Vec<Effect> {
+    let mut once_shields = Vec::new();
+    for shield in shield_effects {
+        match shield.trigger_info {
+            TriggerInfo::OverTime { .. } => entity.active_effects.push(shield),
+            TriggerInfo::Once => once_shields.push(shield),
+        }
+    }
+    once_shields
+}
+
+fn apply_attribute_update(
+    entity: &mut Entity,
+    attribute_id: &str,
+    value: i64,
+    once_shields: &mut Vec<Effect>,
+) {
+    let adjusted = absorb_with_shields(once_shields, attribute_id, value);
+    if let Some(attr) = entity.attributes.get_mut(attribute_id) {
+        attr.current_value = (attr.current_value + adjusted)
+            .max(attr.min_value)
+            .min(attr.max_value);
+    }
+}
+
+fn absorb_with_shields(once_shields: &mut Vec<Effect>, attribute_id: &str, value: i64) -> i64 {
+    if value >= 0 {
+        return value;
+    }
+    let mut remaining = value;
+    let mut consumed = Vec::new();
+    for (i, shield) in once_shields.iter_mut().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+        if let EffectType::AttributeShield {
+            attribute_id: shield_attr,
+            absorb_amount,
+        } = &mut shield.effect_type
+        {
+            if shield_attr != attribute_id {
+                continue;
+            }
+            let absorbed = (*absorb_amount).min(remaining.unsigned_abs() as i64);
+            remaining = (remaining + absorbed).min(0);
+            *absorb_amount = (*absorb_amount - absorbed).max(0);
+            if *absorb_amount == 0 {
+                consumed.push(i);
+            }
+        }
+    }
+    for i in consumed.into_iter().rev() {
+        once_shields.remove(i);
+    }
+    remaining
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::Ability;
+    use crate::game::component::Attribute;
+    use crate::game::component::Location;
+    use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+    use crate::game::engagement::EngagementType;
+    use crate::game::entity::{Entity, EntityType};
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn hp_attribute(current: i64) -> Attribute {
+        Attribute::new("hp".to_string(), 0, 100, current)
+    }
+
+    fn damage_effect(value: i64) -> Effect {
+        Effect {
+            name: "damage".to_string(),
+            effect_type: EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription::default(),
+        }
+    }
+
+    fn shield_effect(absorb_amount: i64, trigger: TriggerInfo) -> Effect {
+        Effect {
+            name: "damage_reduction".to_string(),
+            effect_type: EffectType::AttributeShield {
+                attribute_id: "hp".to_string(),
+                absorb_amount,
+            },
+            trigger_info: trigger,
+            description: EffectDescription::default(),
+        }
+    }
+
+    fn attack_ability(damage: i64) -> Ability {
+        Ability {
+            id: "attack".to_string(),
+            name: "Attack".to_string(),
+            description: None,
+            effects: vec![damage_effect(damage)],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+        }
+    }
+
+    fn single_entity(hp: i64) -> HashMap<i64, Entity> {
+        let mut entities = HashMap::new();
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity.attributes.insert("hp".to_string(), hp_attribute(hp));
+        entities.insert(1, entity);
+        entities
+    }
+
+    #[test]
+    fn shield_absorbs_partial_damage_and_is_consumed() {
+        let mut entities = single_entity(100);
+        // Shield and damage come through the same resolution pass
+        resolve_effects(
+            1,
+            vec![shield_effect(5, TriggerInfo::Once), damage_effect(-10)],
+            &mut entities,
+        );
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 95);
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn over_time_shield_is_stubbed_and_not_applied() {
+        let mut entities = single_entity(100);
+        let over_time_shield = shield_effect(
+            5,
+            TriggerInfo::OverTime {
+                start: 0,
+                end: None,
+                rate: 1,
+            },
+        );
+
+        resolve_effects(1, vec![over_time_shield, damage_effect(-10)], &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        // OverTime shield pushed to active_effects but not applied — full damage lands
+        assert_eq!(entity.attributes["hp"].current_value, 90);
+        assert_eq!(entity.active_effects.len(), 1);
+    }
+
+    #[test]
+    fn shield_does_not_affect_positive_attribute_updates() {
+        let mut entities = single_entity(50);
+        let effects = vec![shield_effect(5, TriggerInfo::Once), damage_effect(10)];
+
+        resolve_effects(1, effects, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 60);
+        // Shield is still present since heals don't trigger it
+        // (shield was in same-pass effects, not active_effects — it's simply not consumed)
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn defend_and_attack_in_same_pass_shield_intercepts() {
+        let mut entities = single_entity(100);
+
+        // Simulate: defend (shield 5) + attack (-10) queued for same target in same resolution pass
+        let effects = vec![shield_effect(5, TriggerInfo::Once), damage_effect(-10)];
+
+        resolve_effects(1, effects, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        // Shield absorbed 5, 5 damage gets through
+        assert_eq!(entity.attributes["hp"].current_value, 95);
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn shield_fully_absorbs_attack() {
+        let mut entities = single_entity(100);
+        let effects = vec![shield_effect(20, TriggerInfo::Once), damage_effect(-10)];
+
+        resolve_effects(1, effects, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 100);
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn shield_depletes_across_multiple_hits_until_exhausted() {
+        let mut entities = single_entity(100);
+        let effects = vec![
+            shield_effect(8, TriggerInfo::Once),
+            damage_effect(-5),
+            damage_effect(-5),
+        ];
+
+        resolve_effects(1, effects, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        // Shield absorbs 5 from first hit (3 remaining), then 3 from second (exhausted),
+        // leaving 2 damage through
+        assert_eq!(entity.attributes["hp"].current_value, 98);
+        assert!(entity.active_effects.is_empty());
+    }
+
+    #[test]
+    fn absorb_clamps_to_zero_not_positive() {
+        let mut entities = single_entity(100);
+        let effects = vec![shield_effect(20, TriggerInfo::Once), damage_effect(-10)];
+
+        resolve_effects(1, effects, &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.attributes["hp"].current_value, 100);
+    }
+
+    #[test]
+    fn unknown_target_is_noop() {
+        let mut entities: HashMap<i64, Entity> = HashMap::new();
+        let messages = resolve_effects(99, vec![damage_effect(-10)], &mut entities);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn applying_shield_effect_directly_adds_to_active_effects_via_over_time() {
+        // Verifies OverTime shields are stored for future use
+        let mut entities = single_entity(100);
+        let over_time_shield = shield_effect(
+            5,
+            TriggerInfo::OverTime {
+                start: 0,
+                end: None,
+                rate: 1,
+            },
+        );
+
+        resolve_effects(1, vec![over_time_shield], &mut entities);
+
+        let entity = entities.get(&1).unwrap();
+        assert_eq!(entity.active_effects.len(), 1);
+        assert_eq!(entity.attributes["hp"].current_value, 100);
+    }
+
+    #[test]
+    fn attack_ability_effects_resolve_correctly() {
+        let mut entities = single_entity(100);
+        resolve_effects(1, attack_ability(-10).effects, &mut entities);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 90);
+    }
+}

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::game::component::{Ability, AttributeType, EffectType, TriggerInfo};
+use crate::game::component::{Ability, AttributeType};
 use crate::game::config::AttributeConfig;
 use crate::game::engagement::TurnOrder;
 use crate::game::entity::Entity;
@@ -9,6 +9,7 @@ use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
 use crate::game::{GameState, messaging};
 
 use super::loot;
+use super::resolution;
 use super::{
     BattleMessage, BattlePhase, BattleTick, QueuedAbility, entity_innate_battle_abilities,
 };
@@ -163,10 +164,14 @@ async fn apply_battle_effects(
     cast_messages: &mut Vec<BattleMessage>,
 ) {
     let mut entities = game_state.active_entities.write().await;
+    let mut target_effects = HashMap::new();
 
     for (entity_id, abilities) in innate_jobs {
         for ability in abilities {
-            apply_once_effects(ability, *entity_id, &mut entities);
+            target_effects
+                .entry(*entity_id)
+                .or_insert_with(Vec::new)
+                .extend(ability.effects.clone());
         }
     }
 
@@ -176,18 +181,26 @@ async fn apply_battle_effects(
     }
 
     for &caster_id in speed_sorted_casters {
-        if let Some(abilities) = by_caster.remove(&caster_id) {
-            for qa in &abilities {
-                apply_once_effects(&qa.ability, qa.target_id, &mut entities);
-                cast_messages.push(ability_cast_message(qa, entity_names));
-            }
+        for qa in by_caster.remove(&caster_id).unwrap_or_default() {
+            cast_messages.push(ability_cast_message(&qa, entity_names));
+            target_effects
+                .entry(qa.target_id)
+                .or_insert_with(Vec::new)
+                .extend(qa.ability.effects.clone());
         }
     }
     for abilities in by_caster.into_values() {
-        for qa in &abilities {
-            apply_once_effects(&qa.ability, qa.target_id, &mut entities);
-            cast_messages.push(ability_cast_message(qa, entity_names));
+        for qa in abilities {
+            cast_messages.push(ability_cast_message(&qa, entity_names));
+            target_effects
+                .entry(qa.target_id)
+                .or_insert_with(Vec::new)
+                .extend(qa.ability.effects.clone());
         }
+    }
+
+    for (target_id, effects) in target_effects {
+        resolution::resolve_effects(target_id, effects, &mut entities);
     }
 }
 
@@ -202,59 +215,6 @@ fn ability_cast_message(qa: &QueuedAbility, entity_names: &HashMap<i64, String>)
             .cloned()
             .unwrap_or_else(|| "Unknown".to_string()),
         ability_name: qa.ability.name.clone(),
-    }
-}
-
-fn absorb_with_shields(entity: &mut Entity, attribute_id: &str, value: i64) -> i64 {
-    if value >= 0 {
-        return value;
-    }
-    let mut remaining = value;
-    let mut consumed_once = Vec::new();
-    for (i, effect) in entity.active_effects.iter().enumerate() {
-        if let EffectType::AttributeShield {
-            attribute_id: shield_attr,
-            absorb_amount,
-        } = &effect.effect_type
-            && shield_attr == attribute_id
-        {
-            remaining = (remaining + absorb_amount).min(0);
-            if matches!(effect.trigger_info, TriggerInfo::Once) {
-                consumed_once.push(i);
-            }
-        }
-    }
-    for i in consumed_once.into_iter().rev() {
-        entity.active_effects.remove(i);
-    }
-    remaining
-}
-
-fn apply_once_effects(ability: &Ability, target_id: i64, entities: &mut HashMap<i64, Entity>) {
-    let Some(entity) = entities.get_mut(&target_id) else {
-        return;
-    };
-    for effect in &ability.effects {
-        match (&effect.trigger_info, &effect.effect_type) {
-            (
-                TriggerInfo::Once,
-                EffectType::AttributeUpdate {
-                    attribute_id,
-                    value,
-                },
-            ) => {
-                let adjusted = absorb_with_shields(entity, attribute_id, *value);
-                if let Some(attr) = entity.attributes.get_mut(attribute_id) {
-                    attr.current_value = (attr.current_value + adjusted)
-                        .max(attr.min_value)
-                        .min(attr.max_value);
-                }
-            }
-            (_, EffectType::AttributeShield { .. }) => {
-                entity.active_effects.push(effect.clone());
-            }
-            _ => {}
-        }
     }
 }
 
@@ -368,163 +328,5 @@ async fn build_battle_update(
         messages: params.messages,
         countdown_ticks: params.countdown_ticks,
         max_turn_ticks: params.max_turn_ticks,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::game::component::Ability;
-    use crate::game::component::Attribute;
-    use crate::game::component::Location;
-    use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
-    use crate::game::engagement::EngagementType;
-    use crate::game::entity::{Entity, EntityType};
-
-    fn test_location() -> Location {
-        Location {
-            world_id: "w".to_string(),
-            dungeon_id: "d".to_string(),
-            room_id: "r".to_string(),
-        }
-    }
-
-    fn hp_attribute(current: i64) -> Attribute {
-        Attribute::new("hp".to_string(), 0, 100, current)
-    }
-
-    fn attack_ability(damage: i64) -> Ability {
-        Ability {
-            id: "attack".to_string(),
-            name: "Attack".to_string(),
-            description: None,
-            effects: vec![Effect {
-                name: "damage".to_string(),
-                effect_type: EffectType::AttributeUpdate {
-                    attribute_id: "hp".to_string(),
-                    value: damage,
-                },
-                trigger_info: TriggerInfo::Once,
-                description: EffectDescription::default(),
-            }],
-            engagement_types: vec![EngagementType::Battle],
-            costs: vec![],
-            modifiers: vec![],
-        }
-    }
-
-    fn shield_effect(absorb_amount: i64, trigger: TriggerInfo) -> Effect {
-        Effect {
-            name: "damage_reduction".to_string(),
-            effect_type: EffectType::AttributeShield {
-                attribute_id: "hp".to_string(),
-                absorb_amount,
-            },
-            trigger_info: trigger,
-            description: EffectDescription::default(),
-        }
-    }
-
-    #[test]
-    fn shield_absorbs_partial_damage_and_is_consumed() {
-        let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let mut entity = Entity::new(1, EntityType::Player, test_location());
-        entity
-            .attributes
-            .insert("hp".to_string(), hp_attribute(100));
-        entity
-            .active_effects
-            .push(shield_effect(5, TriggerInfo::Once));
-        entities.insert(1, entity);
-
-        apply_once_effects(&attack_ability(-10), 1, &mut entities);
-
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 95);
-        assert!(entity.active_effects.is_empty());
-    }
-
-    #[test]
-    fn over_time_shield_absorbs_and_is_not_consumed() {
-        let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let mut entity = Entity::new(1, EntityType::Player, test_location());
-        entity
-            .attributes
-            .insert("hp".to_string(), hp_attribute(100));
-        entity.active_effects.push(shield_effect(
-            5,
-            TriggerInfo::OverTime {
-                start: 0,
-                end: None,
-                rate: 1,
-            },
-        ));
-        entities.insert(1, entity);
-
-        apply_once_effects(&attack_ability(-10), 1, &mut entities);
-
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 95);
-        assert_eq!(entity.active_effects.len(), 1);
-    }
-
-    #[test]
-    fn shield_does_not_affect_positive_attribute_updates() {
-        let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let mut entity = Entity::new(1, EntityType::Player, test_location());
-        entity.attributes.insert("hp".to_string(), hp_attribute(50));
-        entity
-            .active_effects
-            .push(shield_effect(5, TriggerInfo::Once));
-        entities.insert(1, entity);
-
-        apply_once_effects(&attack_ability(10), 1, &mut entities);
-
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 60);
-        assert_eq!(entity.active_effects.len(), 1);
-    }
-
-    #[test]
-    fn applying_shield_ability_adds_to_active_effects() {
-        let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let mut entity = Entity::new(1, EntityType::Player, test_location());
-        entity
-            .attributes
-            .insert("hp".to_string(), hp_attribute(100));
-        entities.insert(1, entity);
-
-        let defend_ability = Ability {
-            id: "defend".to_string(),
-            name: "Defend".to_string(),
-            description: None,
-            effects: vec![shield_effect(5, TriggerInfo::Once)],
-            engagement_types: vec![EngagementType::Battle],
-            costs: vec![],
-            modifiers: vec![],
-        };
-        apply_once_effects(&defend_ability, 1, &mut entities);
-
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.active_effects.len(), 1);
-        assert_eq!(entity.attributes["hp"].current_value, 100);
-    }
-
-    #[test]
-    fn absorb_with_shields_clamps_to_zero_not_positive() {
-        let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let mut entity = Entity::new(1, EntityType::Player, test_location());
-        entity
-            .attributes
-            .insert("hp".to_string(), hp_attribute(100));
-        entity
-            .active_effects
-            .push(shield_effect(20, TriggerInfo::Once));
-        entities.insert(1, entity);
-
-        apply_once_effects(&attack_ability(-10), 1, &mut entities);
-
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 100);
     }
 }


### PR DESCRIPTION
Replaces the immediate per-ability effect application in the battle Resolution phase with a proper pipeline that accumulates all effects per target entity before resolving them, so shields queued in the same pass correctly intercept incoming attacks.

- New `resolution.rs` module with a `resolve_effects` function that partitions effects into shield effects and incoming effects, applies Once shields as absorbers, and stubs OverTime shields into `entity.active_effects` for future handling
- `apply_battle_effects` in `tick.rs` now accumulates a per-target `HashMap<i64, Vec<Effect>>` from innate jobs and the speed-ordered resolution queue before calling `resolve_effects` per target
- Shield depletion is now correct across multiple hits in the same pass: `absorb_amount` is reduced incrementally and the shield is removed only when exhausted
- Old `apply_once_effects` and `absorb_with_shields` helpers removed from `tick.rs`; tests migrated and expanded in `resolution.rs`

<details>
<summary>Agent Context</summary>

Closes #127. Prerequisite #126 (battle tick logic moved to `battle/tick.rs`) is already merged.

**Files changed:**
- `src/game/engagement/battle/resolution.rs` (new) — public `resolve_effects(target_id, effects, entities) -> Vec<BattleMessage>`; private helpers `collect_shield_effects`, `apply_attribute_update`, `absorb_with_shields`
- `src/game/engagement/battle.rs` — added `pub mod resolution;`
- `src/game/engagement/battle/tick.rs` — refactored `apply_battle_effects` to build `target_effects: HashMap<i64, Vec<Effect>>` then dispatch to `resolution::resolve_effects`; removed `apply_once_effects`, `absorb_with_shields`, and their tests

**Key decisions:**
- `entity.active_effects` is now reserved for OverTime effects only; Once shields no longer persist there — they are absorbed inline and discarded within the same resolution pass
- OverTime shields encountered in the resolution queue are pushed to `entity.active_effects` as a stub for future implementation; they do not absorb damage during Resolution
- `absorb_with_shields` receives only Once shields (already filtered by `collect_shield_effects`), so depletion logic simply reduces `absorb_amount` and removes when it reaches 0 — no trigger-type check needed inside that function
- Cast messages (`BattleMessage::AbilityCast`) are still collected per `QueuedAbility` in speed order before the per-target accumulation, preserving existing message ordering
- `resolve_effects` returns `Vec<BattleMessage>` for future extensibility (e.g., shield-hit messages), currently always empty

**Effect types and locations:**
- `Effect`, `EffectType`, `TriggerInfo` — `src/game/component/effect.rs`
- `Entity.active_effects: Vec<Effect>` — `src/game/entity.rs`
- `QueuedAbility { caster_id, ability, target_id }` — `src/game/engagement/battle/queued_ability.rs`
- `BattleMessage` — `src/game/engagement/battle/message.rs`

**Test coverage in `resolution.rs`:** shield partial absorption, full absorption, depletion across multiple hits in one pass, defend+attack same-pass interception, OverTime shield stubbing, heals bypass shields, unknown target is noop.
</details>