### PR TITLE
Add battle entity AI config and simple_random AI implementation (#114)

### DIFF
--- a/migrations/14_battle_ai.sql
+++ b/migrations/14_battle_ai.sql
@@ -1,0 +1,2 @@
+ALTER TABLE entities ADD COLUMN battle_ai_type TEXT NOT NULL DEFAULT 'none';
+ALTER TABLE abilities ADD COLUMN role TEXT NOT NULL DEFAULT 'attack';

--- a/muds/basic/entities/zombie.toml
+++ b/muds/basic/entities/zombie.toml
@@ -1,6 +1,9 @@
 entity_type = "enemy"
 factions = ["enemy"]
 
+[battle_ai]
+ai_type = "simple_random"
+
 [[attributes]]
 definition_id = "hp"
 min_value = 0

--- a/src/game/component/ability.rs
+++ b/src/game/component/ability.rs
@@ -2,6 +2,14 @@ use crate::game::component::effect::Effect;
 use crate::game::engagement::EngagementType;
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum AbilityRole {
+    #[default]
+    Attack,
+    Defend,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum Cost {
@@ -33,6 +41,8 @@ pub struct Ability {
     pub costs: Vec<Cost>,
     #[serde(default)]
     pub modifiers: Vec<Modifier>,
+    #[serde(default)]
+    pub role: AbilityRole,
 }
 
 #[cfg(test)]
@@ -104,6 +114,7 @@ mod tests {
                 amount: 5,
             }],
             modifiers: vec![],
+            role: AbilityRole::Attack,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -132,6 +143,7 @@ mod tests {
                     operator: Operator::Add,
                 },
             ],
+            role: AbilityRole::Attack,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -156,6 +168,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             costs: vec![],
             modifiers: vec![],
+            role: AbilityRole::Attack,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();

--- a/src/game/config.rs
+++ b/src/game/config.rs
@@ -1,5 +1,6 @@
 pub mod agent_config;
 pub mod attribute_config;
+pub mod battle_ai_config;
 mod dialog_parser;
 pub mod entity_config;
 pub mod env_resolver;
@@ -13,6 +14,7 @@ pub mod resource_config;
 
 pub use agent_config::{AgentConfig, AgentProviderConfig};
 pub use attribute_config::AttributeConfig;
+pub use battle_ai_config::{BattleAiConfig, BattleAiType};
 pub use entity_config::{
     DialogLine, EntityConfig, EntityTypeConfig, PersonaConfig, PlayerResponse, load_entity_configs,
 };

--- a/src/game/config/battle_ai_config.rs
+++ b/src/game/config/battle_ai_config.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BattleAiType {
+    #[default]
+    None,
+    SimpleRandom,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BattleAiConfig {
+    #[serde(default)]
+    pub ai_type: BattleAiType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn battle_ai_type_default_is_none() {
+        assert_eq!(BattleAiType::default(), BattleAiType::None);
+    }
+
+    #[test]
+    fn battle_ai_config_default_is_none() {
+        let config = BattleAiConfig::default();
+        assert_eq!(config.ai_type, BattleAiType::None);
+    }
+
+    #[test]
+    fn battle_ai_type_none_serde_round_trip() {
+        let ai_type = BattleAiType::None;
+        let json = serde_json::to_string(&ai_type).unwrap();
+        assert_eq!(json, r#""none""#);
+        let restored: BattleAiType = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, BattleAiType::None);
+    }
+
+    #[test]
+    fn battle_ai_type_simple_random_serde_round_trip() {
+        let ai_type = BattleAiType::SimpleRandom;
+        let json = serde_json::to_string(&ai_type).unwrap();
+        assert_eq!(json, r#""simple_random""#);
+        let restored: BattleAiType = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, BattleAiType::SimpleRandom);
+    }
+
+    #[test]
+    fn battle_ai_config_serde_round_trip() {
+        let config = BattleAiConfig {
+            ai_type: BattleAiType::SimpleRandom,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: BattleAiConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.ai_type, BattleAiType::SimpleRandom);
+    }
+
+    #[test]
+    fn battle_ai_config_deserializes_without_ai_type_field() {
+        let json = r#"{}"#;
+        let config: BattleAiConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.ai_type, BattleAiType::None);
+    }
+
+    #[test]
+    fn battle_ai_config_toml_round_trip() {
+        let toml = r#"ai_type = "simple_random""#;
+        let config: BattleAiConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.ai_type, BattleAiType::SimpleRandom);
+    }
+}

--- a/src/game/config/entity_config.rs
+++ b/src/game/config/entity_config.rs
@@ -1,6 +1,7 @@
 use crate::game::component::Ability;
 use crate::game::component::FactionRelations;
 use crate::game::component::effect::Effect;
+use crate::game::config::battle_ai_config::BattleAiConfig;
 use crate::game::config::dialog_parser::parse_dialog_markdown;
 use crate::game::config::persona_parser::{PersonaFile, parse_persona_markdown};
 use serde::{Deserialize, Serialize};
@@ -78,6 +79,8 @@ pub struct EntityConfig {
     pub factions: Vec<String>,
     #[serde(default)]
     pub faction_relations: Option<FactionRelations>,
+    #[serde(default)]
+    pub battle_ai: BattleAiConfig,
 }
 
 pub fn load_entity_config(path: &Path) -> Result<EntityConfig, Box<dyn Error>> {

--- a/src/game/config/map_loader.rs
+++ b/src/game/config/map_loader.rs
@@ -198,6 +198,7 @@ async fn sync_entity(
         config.description.as_deref(),
     )
     .await?;
+    entity_repo::update_battle_ai_type(pool, entity_id, &config.battle_ai.ai_type).await?;
     if is_new {
         for effect in &config.entity_effects {
             entity_effect_repo::insert(pool, entity_id, effect).await?;
@@ -290,6 +291,7 @@ fn effective_faction_relations(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::config::BattleAiConfig;
     use crate::game::{Description, Dungeon, EntityConfig, Room, World};
     use crate::persistence::database::Database;
 
@@ -411,6 +413,7 @@ mod tests {
             innate_abilities: vec![],
             factions: vec![],
             faction_relations: None,
+            battle_ai: BattleAiConfig::default(),
         };
         let mut map = HashMap::new();
         map.insert("entities/innkeeper".to_string(), config);
@@ -444,6 +447,7 @@ mod tests {
             innate_abilities: vec![],
             factions: vec![],
             faction_relations: None,
+            battle_ai: BattleAiConfig::default(),
         };
         let mut map = HashMap::new();
         map.insert("entities/innkeeper".to_string(), config);
@@ -577,6 +581,7 @@ mod tests {
                 innate_abilities: vec![],
                 factions: vec![],
                 faction_relations: None,
+                battle_ai: BattleAiConfig::default(),
             },
         );
         let universe = make_universe_with_entity();
@@ -603,6 +608,7 @@ mod tests {
             innate_abilities: vec![],
             factions: vec![],
             faction_relations: None,
+            battle_ai: BattleAiConfig::default(),
         };
         let mut map = HashMap::new();
         map.insert("entities/zombie".to_string(), config);

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -1,4 +1,5 @@
 pub mod abilities;
+pub mod ai;
 pub mod loot;
 pub mod message;
 pub mod phase;
@@ -12,6 +13,7 @@ use std::collections::HashMap;
 pub use abilities::{
     default_attack_ability, default_defend_ability, entity_innate_battle_abilities,
 };
+pub use ai::{BattleAiContext, run_battle_ai};
 pub use message::BattleMessage;
 pub use phase::BattlePhase;
 pub use queued_ability::QueuedAbility;

--- a/src/game/engagement/battle/abilities.rs
+++ b/src/game/engagement/battle/abilities.rs
@@ -1,4 +1,5 @@
 use crate::game::component::Ability;
+use crate::game::component::ability::AbilityRole;
 use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
 use crate::game::engagement::EngagementType;
 use crate::game::entity::Entity;
@@ -14,6 +15,28 @@ fn battle_abilities(entity: &Entity) -> Vec<Ability> {
 
 pub fn entity_innate_battle_abilities(entity: &Entity) -> Vec<Ability> {
     battle_abilities(entity)
+}
+
+pub fn battle_attack_abilities(entity: &Entity) -> Vec<Ability> {
+    entity
+        .innate_abilities
+        .iter()
+        .filter(|a| {
+            a.engagement_types.contains(&EngagementType::Battle) && a.role == AbilityRole::Attack
+        })
+        .cloned()
+        .collect()
+}
+
+pub fn battle_defend_abilities(entity: &Entity) -> Vec<Ability> {
+    entity
+        .innate_abilities
+        .iter()
+        .filter(|a| {
+            a.engagement_types.contains(&EngagementType::Battle) && a.role == AbilityRole::Defend
+        })
+        .cloned()
+        .collect()
 }
 
 pub fn default_defend_ability() -> Ability {
@@ -33,6 +56,7 @@ pub fn default_defend_ability() -> Ability {
         engagement_types: vec![EngagementType::Battle],
         costs: vec![],
         modifiers: vec![],
+        role: AbilityRole::Defend,
     }
 }
 
@@ -53,14 +77,38 @@ pub fn default_attack_ability() -> Ability {
         engagement_types: vec![EngagementType::Battle],
         costs: vec![],
         modifiers: vec![],
+        role: AbilityRole::Attack,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::game::component::Location;
     use crate::game::component::effect::{EffectType, TriggerInfo};
+    use crate::game::entity::EntityType;
 
     use super::*;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn make_ability(id: &str, role: AbilityRole) -> Ability {
+        Ability {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            effects: vec![],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+            role,
+        }
+    }
 
     #[test]
     fn default_defend_ability_has_correct_structure() {
@@ -76,5 +124,43 @@ mod tests {
             } if attribute_id == "hp"
         ));
         assert!(matches!(ability.effects[0].trigger_info, TriggerInfo::Once));
+    }
+
+    #[test]
+    fn battle_attack_abilities_returns_only_attack_role() {
+        let mut entity = Entity::new(1, EntityType::Enemy, test_location());
+        entity.innate_abilities = vec![
+            make_ability("slash", AbilityRole::Attack),
+            make_ability("shield", AbilityRole::Defend),
+        ];
+        let attacks = battle_attack_abilities(&entity);
+        assert_eq!(attacks.len(), 1);
+        assert_eq!(attacks[0].id, "slash");
+    }
+
+    #[test]
+    fn battle_defend_abilities_returns_only_defend_role() {
+        let mut entity = Entity::new(1, EntityType::Enemy, test_location());
+        entity.innate_abilities = vec![
+            make_ability("slash", AbilityRole::Attack),
+            make_ability("shield", AbilityRole::Defend),
+        ];
+        let defends = battle_defend_abilities(&entity);
+        assert_eq!(defends.len(), 1);
+        assert_eq!(defends[0].id, "shield");
+    }
+
+    #[test]
+    fn battle_attack_abilities_empty_when_none_match() {
+        let mut entity = Entity::new(1, EntityType::Enemy, test_location());
+        entity.innate_abilities = vec![make_ability("shield", AbilityRole::Defend)];
+        assert!(battle_attack_abilities(&entity).is_empty());
+    }
+
+    #[test]
+    fn battle_defend_abilities_empty_when_none_match() {
+        let mut entity = Entity::new(1, EntityType::Enemy, test_location());
+        entity.innate_abilities = vec![make_ability("slash", AbilityRole::Attack)];
+        assert!(battle_defend_abilities(&entity).is_empty());
     }
 }

--- a/src/game/engagement/battle/ai.rs
+++ b/src/game/engagement/battle/ai.rs
@@ -1,0 +1,183 @@
+pub mod simple_random;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::game::GameState;
+use crate::game::component::Ability;
+use crate::game::component::Attribute;
+use crate::game::config::BattleAiType;
+use crate::game::entity::Entity;
+
+use super::BattlePhase;
+
+pub type AiAction = (i64, Ability, i64, HashMap<String, Attribute>);
+
+pub struct BattleAiContext {
+    pub engagement_id: i64,
+    pub phase: BattlePhase,
+    pub planning_ids: Vec<i64>,
+    pub responding_ids: Vec<i64>,
+}
+
+pub async fn run_battle_ai(game_state: &Arc<GameState>) {
+    let contexts = game_state.engagements.get_battle_ai_contexts().await;
+    for ctx in contexts {
+        run_ai_for_context(game_state, &ctx).await;
+    }
+}
+
+async fn run_ai_for_context(game_state: &Arc<GameState>, ctx: &BattleAiContext) {
+    let actions = {
+        let entities = game_state.active_entities.read().await;
+        collect_actions(ctx, &entities)
+    };
+    for (entity_id, ability, target_id, attrs) in actions {
+        game_state
+            .engagements
+            .queue_battle_ability(entity_id, ability, target_id, &attrs)
+            .await;
+    }
+}
+
+fn collect_actions(ctx: &BattleAiContext, entities: &HashMap<i64, Entity>) -> Vec<AiAction> {
+    match &ctx.phase {
+        BattlePhase::Planning { .. } => ctx
+            .planning_ids
+            .iter()
+            .filter_map(|&id| route_attack(entities.get(&id)?, &ctx.responding_ids))
+            .collect(),
+        BattlePhase::Response { .. } => ctx
+            .responding_ids
+            .iter()
+            .filter_map(|&id| route_defend(entities.get(&id)?))
+            .collect(),
+        _ => vec![],
+    }
+}
+
+fn route_attack(entity: &Entity, targets: &[i64]) -> Option<AiAction> {
+    match entity.battle_ai.ai_type {
+        BattleAiType::None => None,
+        BattleAiType::SimpleRandom => simple_random::plan_attack(entity, targets),
+    }
+}
+
+fn route_defend(entity: &Entity) -> Option<AiAction> {
+    match entity.battle_ai.ai_type {
+        BattleAiType::None => None,
+        BattleAiType::SimpleRandom => simple_random::plan_defend(entity),
+    }
+}
+
+pub fn pick_random<T>(items: &[T]) -> Option<&T> {
+    if items.is_empty() {
+        None
+    } else {
+        Some(&items[fastrand::usize(..items.len())])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::game::component::Location;
+    use crate::game::config::BattleAiConfig;
+    use crate::game::entity::{Entity, EntityType};
+
+    use super::*;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn make_entity(id: i64, ai_type: BattleAiType) -> Entity {
+        let mut e = Entity::new(id, EntityType::Enemy, test_location());
+        e.battle_ai = BattleAiConfig { ai_type };
+        e
+    }
+
+    fn make_entities(list: Vec<Entity>) -> HashMap<i64, Entity> {
+        list.into_iter().map(|e| (e.id, e)).collect()
+    }
+
+    fn planning_ctx(planning_ids: Vec<i64>, responding_ids: Vec<i64>) -> BattleAiContext {
+        BattleAiContext {
+            engagement_id: 1,
+            phase: BattlePhase::Planning {
+                faction: "enemy".to_string(),
+            },
+            planning_ids,
+            responding_ids,
+        }
+    }
+
+    fn response_ctx(planning_ids: Vec<i64>, responding_ids: Vec<i64>) -> BattleAiContext {
+        BattleAiContext {
+            engagement_id: 1,
+            phase: BattlePhase::Response {
+                faction: "enemy".to_string(),
+            },
+            planning_ids,
+            responding_ids,
+        }
+    }
+
+    #[test]
+    fn collect_actions_planning_simple_random_queues_attack() {
+        let entities = make_entities(vec![make_entity(1, BattleAiType::SimpleRandom)]);
+        let ctx = planning_ctx(vec![1], vec![2]);
+        let actions = collect_actions(&ctx, &entities);
+        assert_eq!(actions.len(), 1);
+        let (eid, _, target, _) = &actions[0];
+        assert_eq!(*eid, 1);
+        assert_eq!(*target, 2);
+    }
+
+    #[test]
+    fn collect_actions_response_simple_random_queues_defend() {
+        let entities = make_entities(vec![make_entity(2, BattleAiType::SimpleRandom)]);
+        let ctx = response_ctx(vec![1], vec![2]);
+        let actions = collect_actions(&ctx, &entities);
+        assert_eq!(actions.len(), 1);
+        let (eid, _, target, _) = &actions[0];
+        assert_eq!(*eid, 2);
+        assert_eq!(*target, 2);
+    }
+
+    #[test]
+    fn collect_actions_none_type_is_skipped() {
+        let entities = make_entities(vec![make_entity(1, BattleAiType::None)]);
+        let ctx = planning_ctx(vec![1], vec![2]);
+        assert!(collect_actions(&ctx, &entities).is_empty());
+    }
+
+    #[test]
+    fn collect_actions_non_planning_phase_returns_empty() {
+        let entities = make_entities(vec![make_entity(1, BattleAiType::SimpleRandom)]);
+        let ctx = BattleAiContext {
+            engagement_id: 1,
+            phase: BattlePhase::Resolution,
+            planning_ids: vec![1],
+            responding_ids: vec![2],
+        };
+        assert!(collect_actions(&ctx, &entities).is_empty());
+    }
+
+    #[test]
+    fn pick_random_returns_none_for_empty() {
+        let items: Vec<i32> = vec![];
+        assert!(pick_random(&items).is_none());
+    }
+
+    #[test]
+    fn pick_random_returns_item_for_single_element() {
+        let items = vec![42_i32];
+        assert_eq!(pick_random(&items), Some(&42));
+    }
+}

--- a/src/game/engagement/battle/ai/simple_random.rs
+++ b/src/game/engagement/battle/ai/simple_random.rs
@@ -1,0 +1,119 @@
+use crate::game::engagement::battle::abilities::{
+    battle_attack_abilities, battle_defend_abilities,
+};
+use crate::game::engagement::battle::{default_attack_ability, default_defend_ability};
+use crate::game::entity::Entity;
+
+use super::AiAction;
+use super::pick_random;
+
+pub fn plan_attack(entity: &Entity, targets: &[i64]) -> Option<AiAction> {
+    let &target_id = pick_random(targets)?;
+    let attacks = battle_attack_abilities(entity);
+    let ability = pick_random(&attacks)
+        .cloned()
+        .unwrap_or_else(default_attack_ability);
+    Some((entity.id, ability, target_id, entity.attributes.clone()))
+}
+
+pub fn plan_defend(entity: &Entity) -> Option<AiAction> {
+    let defends = battle_defend_abilities(entity);
+    let ability = pick_random(&defends)
+        .cloned()
+        .unwrap_or_else(default_defend_ability);
+    Some((entity.id, ability, entity.id, entity.attributes.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::Ability;
+    use crate::game::component::Location;
+    use crate::game::component::ability::AbilityRole;
+    use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+    use crate::game::engagement::EngagementType;
+    use crate::game::entity::EntityType;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn make_ability(id: &str, role: AbilityRole) -> Ability {
+        Ability {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            effects: vec![Effect {
+                name: "dmg".to_string(),
+                effect_type: EffectType::AttributeUpdate {
+                    attribute_id: "hp".to_string(),
+                    value: -5,
+                },
+                trigger_info: TriggerInfo::Once,
+                description: EffectDescription::default(),
+            }],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+            role,
+        }
+    }
+
+    fn make_enemy(id: i64) -> Entity {
+        Entity::new(id, EntityType::Enemy, test_location())
+    }
+
+    #[test]
+    fn plan_attack_returns_attack_with_target() {
+        let mut entity = make_enemy(1);
+        entity.innate_abilities = vec![make_ability("slash", AbilityRole::Attack)];
+        let targets = vec![2_i64];
+        let (eid, ability, target, _) = plan_attack(&entity, &targets).unwrap();
+        assert_eq!(eid, 1);
+        assert_eq!(ability.id, "slash");
+        assert_eq!(target, 2);
+    }
+
+    #[test]
+    fn plan_attack_falls_back_to_default_when_no_attack_abilities() {
+        let entity = make_enemy(1);
+        let targets = vec![2_i64];
+        let (_, ability, target, _) = plan_attack(&entity, &targets).unwrap();
+        assert_eq!(ability.id, "attack");
+        assert_eq!(target, 2);
+    }
+
+    #[test]
+    fn plan_attack_returns_none_when_no_targets() {
+        let entity = make_enemy(1);
+        assert!(plan_attack(&entity, &[]).is_none());
+    }
+
+    #[test]
+    fn plan_defend_returns_defend_targeting_self() {
+        let mut entity = make_enemy(1);
+        entity.innate_abilities = vec![make_ability("shield", AbilityRole::Defend)];
+        let (eid, ability, target, _) = plan_defend(&entity).unwrap();
+        assert_eq!(eid, 1);
+        assert_eq!(ability.id, "shield");
+        assert_eq!(target, 1);
+    }
+
+    #[test]
+    fn plan_defend_falls_back_to_default_when_no_defend_abilities() {
+        let entity = make_enemy(1);
+        let (_, ability, target, _) = plan_defend(&entity).unwrap();
+        assert_eq!(ability.id, "defend");
+        assert_eq!(target, 1);
+    }
+
+    #[test]
+    fn plan_defend_always_returns_some() {
+        let entity = make_enemy(42);
+        assert!(plan_defend(&entity).is_some());
+    }
+}

--- a/src/game/engagement/battle/queued_ability.rs
+++ b/src/game/engagement/battle/queued_ability.rs
@@ -10,6 +10,7 @@ pub struct QueuedAbility {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::component::ability::AbilityRole;
     use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
     use crate::game::engagement::EngagementType;
 
@@ -30,6 +31,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             costs: vec![],
             modifiers: vec![],
+            role: AbilityRole::Attack,
         }
     }
 

--- a/src/game/engagement/battle/resolution.rs
+++ b/src/game/engagement/battle/resolution.rs
@@ -102,6 +102,7 @@ mod tests {
     use crate::game::component::Ability;
     use crate::game::component::Attribute;
     use crate::game::component::Location;
+    use crate::game::component::ability::AbilityRole;
     use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
     use crate::game::engagement::EngagementType;
     use crate::game::entity::{Entity, EntityType};
@@ -151,6 +152,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             costs: vec![],
             modifiers: vec![],
+            role: AbilityRole::Attack,
         }
     }
 

--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -220,6 +220,7 @@ impl BattleEngagement {
 
 #[cfg(test)]
 mod tests {
+    use crate::game::component::ability::AbilityRole;
     use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
     use crate::game::component::{Ability, Attribute, Cost};
     use crate::game::engagement::EngagementType;
@@ -424,6 +425,7 @@ mod tests {
                 amount: 10,
             }],
             modifiers: vec![],
+            role: AbilityRole::Attack,
         };
         let attrs: HashMap<String, Attribute> = HashMap::new(); // no mp
         assert!(!eng.queue_ability(1, ability, 2, &attrs));

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -9,7 +9,7 @@ use crate::game::engagement::Engagement;
 use crate::game::engagement::EngagementType;
 use crate::game::engagement::ResolvedAction;
 use crate::game::engagement::TurnAction;
-use crate::game::engagement::battle::{BattlePhase, BattleTick};
+use crate::game::engagement::battle::{BattleAiContext, BattlePhase, BattleTick};
 
 pub struct Engagements {
     engagements_by_id: RwLock<HashMap<i64, Engagement>>,
@@ -168,6 +168,27 @@ impl Engagements {
             }
         }
         false
+    }
+
+    /// Return AI context for every battle currently in Planning or Response phase.
+    pub async fn get_battle_ai_contexts(&self) -> Vec<BattleAiContext> {
+        let map = self.engagements_by_id.read().await;
+        map.values()
+            .filter_map(|e| {
+                let battle = e.battle.as_ref()?;
+                match &battle.turn_phase {
+                    BattlePhase::Planning { .. } | BattlePhase::Response { .. } => {
+                        Some(BattleAiContext {
+                            engagement_id: e.id,
+                            phase: battle.turn_phase.clone(),
+                            planning_ids: battle.planning_ids(),
+                            responding_ids: battle.responding_ids(),
+                        })
+                    }
+                    _ => None,
+                }
+            })
+            .collect()
     }
 
     /// Mark a battle engagement as concluded.

--- a/src/game/engagement/processing.rs
+++ b/src/game/engagement/processing.rs
@@ -33,4 +33,5 @@ pub async fn process(game_state: &Arc<GameState>, _tick: u64) {
     }
 
     battle::process_ticks(game_state, max_engage_ticks).await;
+    battle::run_battle_ai(game_state).await;
 }

--- a/src/game/entity.rs
+++ b/src/game/entity.rs
@@ -9,6 +9,7 @@ use crate::game::component::FactionRelations;
 use crate::game::component::Interaction;
 use crate::game::component::Location;
 use crate::game::component::effect::Effect;
+use crate::game::config::BattleAiConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EntityType {
@@ -32,6 +33,8 @@ pub struct Entity {
     pub description: Option<String>,
     #[serde(skip)]
     pub ai: Option<EntityAI>,
+    #[serde(default)]
+    pub battle_ai: BattleAiConfig,
     #[serde(default)]
     pub factions: HashSet<String>,
     #[serde(default)]
@@ -64,6 +67,7 @@ impl Entity {
             config_id: None,
             description: None,
             ai: None,
+            battle_ai: BattleAiConfig::default(),
             factions,
             faction_relations,
             active_effects: Vec::new(),

--- a/src/persistence/ability_repo.rs
+++ b/src/persistence/ability_repo.rs
@@ -1,12 +1,14 @@
 use sqlx::SqlitePool;
 
 use crate::game::component::Ability;
+use crate::game::component::ability::AbilityRole;
 use crate::persistence::error::PersistenceError;
 
 type AbilityRow = (
     String,
     String,
     Option<String>,
+    String,
     String,
     String,
     String,
@@ -19,10 +21,11 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
     let modifiers_json = serde_json::to_string(&ability.modifiers).unwrap_or_default();
     let engagement_types_json =
         serde_json::to_string(&ability.engagement_types).unwrap_or_default();
+    let role_str = ability_role_to_str(&ability.role);
     sqlx::query(
         "INSERT OR REPLACE INTO abilities \
-         (id, name, description, effects_json, costs_json, modifiers_json, engagement_types_json) \
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
+         (id, name, description, effects_json, costs_json, modifiers_json, engagement_types_json, role) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&ability.id)
     .bind(&ability.name)
@@ -31,6 +34,7 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
     .bind(&costs_json)
     .bind(&modifiers_json)
     .bind(&engagement_types_json)
+    .bind(role_str)
     .execute(pool)
     .await?;
     Ok(())
@@ -42,7 +46,7 @@ pub async fn find_by_entity(
 ) -> Result<Vec<Ability>, PersistenceError> {
     let rows: Vec<AbilityRow> = sqlx::query_as(
         "SELECT a.id, a.name, a.description, a.effects_json, a.costs_json, \
-             a.modifiers_json, a.engagement_types_json \
+             a.modifiers_json, a.engagement_types_json, a.role \
              FROM abilities a \
              JOIN entity_abilities ea ON a.id = ea.ability_id \
              WHERE ea.entity_id = ?",
@@ -54,7 +58,16 @@ pub async fn find_by_entity(
     Ok(rows
         .into_iter()
         .map(
-            |(id, name, description, effects_json, costs_json, modifiers_json, et_json)| {
+            |(
+                id,
+                name,
+                description,
+                effects_json,
+                costs_json,
+                modifiers_json,
+                et_json,
+                role_str,
+            )| {
                 let effects = serde_json::from_str(&effects_json).unwrap_or_else(|e| {
                     tracing::warn!("Failed to deserialize effects for ability {id}: {e}");
                     vec![]
@@ -79,6 +92,7 @@ pub async fn find_by_entity(
                     costs,
                     modifiers,
                     engagement_types,
+                    role: ability_role_from_str(&role_str),
                 }
             },
         )
@@ -102,6 +116,20 @@ pub async fn set_entity_abilities(
             .await?;
     }
     Ok(())
+}
+
+fn ability_role_to_str(role: &AbilityRole) -> &'static str {
+    match role {
+        AbilityRole::Attack => "attack",
+        AbilityRole::Defend => "defend",
+    }
+}
+
+fn ability_role_from_str(s: &str) -> AbilityRole {
+    match s {
+        "defend" => AbilityRole::Defend,
+        _ => AbilityRole::Attack,
+    }
 }
 
 #[cfg(test)]
@@ -148,6 +176,20 @@ mod tests {
             costs: vec![],
             modifiers: vec![],
             engagement_types: vec![EngagementType::Battle],
+            role: AbilityRole::Attack,
+        }
+    }
+
+    fn defend_ability() -> Ability {
+        Ability {
+            id: "defend".to_string(),
+            name: "Defend".to_string(),
+            description: None,
+            effects: vec![],
+            costs: vec![],
+            modifiers: vec![],
+            engagement_types: vec![EngagementType::Battle],
+            role: AbilityRole::Defend,
         }
     }
 
@@ -166,6 +208,22 @@ mod tests {
         assert_eq!(abilities[0].id, "attack");
         assert_eq!(abilities[0].effects.len(), 1);
         assert_eq!(abilities[0].engagement_types, vec![EngagementType::Battle]);
+        assert_eq!(abilities[0].role, AbilityRole::Attack);
+    }
+
+    #[tokio::test]
+    async fn upsert_preserves_defend_role() {
+        let db = Database::connect_in_memory().await.unwrap();
+        let entity_id = setup(&db).await;
+        let ability = defend_ability();
+        upsert(db.pool(), &ability).await.unwrap();
+        set_entity_abilities(db.pool(), entity_id, &["defend"])
+            .await
+            .unwrap();
+
+        let abilities = find_by_entity(db.pool(), entity_id).await.unwrap();
+        assert_eq!(abilities.len(), 1);
+        assert_eq!(abilities[0].role, AbilityRole::Defend);
     }
 
     #[tokio::test]

--- a/src/persistence/entity_repo.rs
+++ b/src/persistence/entity_repo.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use sqlx::SqlitePool;
 
 use crate::game::component::Attribute;
+use crate::game::config::{BattleAiConfig, BattleAiType};
 use crate::game::{Entity, EntityType, Location};
 use crate::persistence::error::PersistenceError;
 use crate::persistence::{faction_relations_repo, faction_repo};
@@ -16,6 +17,7 @@ type EntityRow = (
     Option<String>,
     Option<String>,
     Option<String>,
+    String,
 );
 
 pub async fn insert(pool: &SqlitePool, entity: &Entity) -> Result<i64, PersistenceError> {
@@ -92,7 +94,7 @@ pub async fn insert_config_entity_if_missing(
 
 pub async fn find_by_id(pool: &SqlitePool, id: i64) -> Result<Option<Entity>, PersistenceError> {
     let row: Option<EntityRow> = sqlx::query_as(
-        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description FROM entities WHERE id = ?",
+        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description, battle_ai_type FROM entities WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(pool)
@@ -112,7 +114,7 @@ pub async fn find_by_location(
     location: &Location,
 ) -> Result<Vec<Entity>, PersistenceError> {
     let rows: Vec<EntityRow> = sqlx::query_as(
-        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description FROM entities WHERE world_id = ? AND dungeon_id = ? AND room_id = ?",
+        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description, battle_ai_type FROM entities WHERE world_id = ? AND dungeon_id = ? AND room_id = ?",
     )
     .bind(&location.world_id)
     .bind(&location.dungeon_id)
@@ -135,7 +137,7 @@ pub async fn find_config_entities_by_dungeon(
     dungeon_id: &str,
 ) -> Result<Vec<Entity>, PersistenceError> {
     let rows: Vec<EntityRow> = sqlx::query_as(
-        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description FROM entities WHERE config_id IS NOT NULL AND world_id = ? AND dungeon_id = ?",
+        "SELECT id, entity_type, world_id, dungeon_id, room_id, config_id, attributes, description, battle_ai_type FROM entities WHERE config_id IS NOT NULL AND world_id = ? AND dungeon_id = ?",
     )
     .bind(world_id)
     .bind(dungeon_id)
@@ -152,7 +154,7 @@ pub async fn find_config_entities_by_dungeon(
 }
 
 fn build_entity(
-    (id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description): EntityRow,
+    (id, et, world_id, dungeon_id, room_id, config_id, attrs_json, description, battle_ai_type): EntityRow,
 ) -> Entity {
     let attributes = attrs_json
         .and_then(|json| match serde_json::from_str(&json) {
@@ -175,7 +177,37 @@ fn build_entity(
     entity.config_id = config_id;
     entity.attributes = attributes;
     entity.description = description;
+    entity.battle_ai = BattleAiConfig {
+        ai_type: battle_ai_type_from_str(&battle_ai_type),
+    };
     entity
+}
+
+pub async fn update_battle_ai_type(
+    pool: &SqlitePool,
+    entity_id: i64,
+    ai_type: &BattleAiType,
+) -> Result<(), PersistenceError> {
+    sqlx::query("UPDATE entities SET battle_ai_type = ? WHERE id = ?")
+        .bind(battle_ai_type_to_str(ai_type))
+        .bind(entity_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+fn battle_ai_type_to_str(ai_type: &BattleAiType) -> &'static str {
+    match ai_type {
+        BattleAiType::None => "none",
+        BattleAiType::SimpleRandom => "simple_random",
+    }
+}
+
+fn battle_ai_type_from_str(s: &str) -> BattleAiType {
+    match s {
+        "simple_random" => BattleAiType::SimpleRandom,
+        _ => BattleAiType::None,
+    }
 }
 
 async fn load_faction_data(pool: &SqlitePool, entity: &mut Entity) -> Result<(), PersistenceError> {
@@ -638,5 +670,52 @@ mod tests {
         let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
         assert_eq!(found.attributes.len(), 1);
         assert_eq!(found.attributes["str"].current_value, 15);
+    }
+
+    #[tokio::test]
+    async fn insert_and_find_preserves_default_battle_ai_type() {
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert_eq!(found.battle_ai.ai_type, BattleAiType::None);
+    }
+
+    #[tokio::test]
+    async fn update_battle_ai_type_persists_simple_random() {
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        update_battle_ai_type(db.pool(), id, &BattleAiType::SimpleRandom)
+            .await
+            .unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert_eq!(found.battle_ai.ai_type, BattleAiType::SimpleRandom);
+    }
+
+    #[tokio::test]
+    async fn update_battle_ai_type_can_reset_to_none() {
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        update_battle_ai_type(db.pool(), id, &BattleAiType::SimpleRandom)
+            .await
+            .unwrap();
+        update_battle_ai_type(db.pool(), id, &BattleAiType::None)
+            .await
+            .unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert_eq!(found.battle_ai.ai_type, BattleAiType::None);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `BattleAiType` / `BattleAiConfig` to `game/config/` with a `None` default and a `SimpleRandom` variant; wired into `EntityConfig`, `Entity`, `entity_repo`, and SQLite migration `14_battle_ai.sql`
- Adds `AbilityRole` (Attack/Defend) to `Ability` struct; persisted in abilities table via migration and `ability_repo`
- Implements `battle/ai.rs` router + `battle/ai/simple_random.rs` — queues a random attack during Planning phase and a random defend during Response phase, falling back to default abilities when none are configured
- `processing.rs` calls `run_battle_ai` after each `process_ticks` so AI entities never stall the phase timer
- Enables `simple_random` AI on `muds/basic/entities/zombie.toml`

## Test plan

- [ ] `cargo test` — 362 tests pass
- [ ] `cargo clippy` — no warnings
- [ ] Start a server with the basic mud config; spawn a zombie; enter battle — zombie should queue actions each Planning and Response phase without stalling the timer
- [ ] Verify a player entity (no `battle_ai` set) is unaffected — `BattleAiType::None` is the default and is skipped by the AI router

🤖 Generated with [Claude Code](https://claude.com/claude-code)