### PR TITLE
Add ability role filtering and defending indicator to battle TUI

### DIFF
--- a/muds/basic/mud.toml
+++ b/muds/basic/mud.toml
@@ -1,6 +1,6 @@
 [game_loop]
 tick_rate_ms = 500
-max_engage_ms = 5000
+max_engage_ms = 60_000
 world_update_ms = 600000
 
 [spawn]

--- a/src/game/component/ability.rs
+++ b/src/game/component/ability.rs
@@ -8,6 +8,7 @@ pub enum AbilityRole {
     #[default]
     Attack,
     Defend,
+    World,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -6,7 +6,7 @@ use tracing;
 use crate::game::component::attribute_definition::AttributeType;
 use crate::game::component::faction_relations::FactionRelation;
 use crate::game::engagement::battle::{
-    BattlePhase, default_attack_ability, entity_innate_battle_abilities,
+    BattlePhase, default_attack_ability, default_defend_ability, entity_innate_battle_abilities,
 };
 use crate::game::entity::Entity;
 use crate::game::messaging::{BattleParticipantInfo, BattleStartedMessage};
@@ -138,6 +138,7 @@ async fn build_battle_started_message(
         .unwrap_or_default();
     if available_abilities.is_empty() {
         available_abilities.push(default_attack_ability());
+        available_abilities.push(default_defend_ability());
     }
 
     let mut turn_order: Vec<i64> = participants.values().flatten().copied().collect();

--- a/src/persistence/ability_repo.rs
+++ b/src/persistence/ability_repo.rs
@@ -122,12 +122,14 @@ fn ability_role_to_str(role: &AbilityRole) -> &'static str {
     match role {
         AbilityRole::Attack => "attack",
         AbilityRole::Defend => "defend",
+        AbilityRole::World => "world",
     }
 }
 
 fn ability_role_from_str(s: &str) -> AbilityRole {
     match s {
         "defend" => AbilityRole::Defend,
+        "world" => AbilityRole::World,
         _ => AbilityRole::Attack,
     }
 }

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -44,6 +44,9 @@ impl BattleState {
     }
 
     pub fn filtered_abilities(&self) -> Vec<&Ability> {
+        if !self.is_player_turn() {
+            return vec![];
+        }
         match &self.snapshot.phase {
             BattlePhase::Planning { .. } => self
                 .snapshot
@@ -62,6 +65,9 @@ impl BattleState {
     }
 
     pub fn ability_role_label(&self) -> Option<&str> {
+        if !self.is_player_turn() {
+            return None;
+        }
         match &self.snapshot.phase {
             BattlePhase::Planning { .. } => Some("Attack"),
             BattlePhase::Response { .. } => Some("Defend"),

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -1,3 +1,4 @@
+use crate::game::component::ability::{Ability, AbilityRole};
 use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::network::event::{BattleSnapshot, ParticipantInfo};
 
@@ -24,6 +25,7 @@ pub struct BattleState {
     pub entity_scroll: usize,
     pub focus: BattleFocus,
     pub dialog: Option<TargetDialog>,
+    pub has_queued_defend: bool,
 }
 
 impl BattleState {
@@ -37,18 +39,45 @@ impl BattleState {
             entity_scroll: 0,
             focus: BattleFocus::Abilities,
             dialog: None,
+            has_queued_defend: false,
+        }
+    }
+
+    pub fn filtered_abilities(&self) -> Vec<&Ability> {
+        match &self.snapshot.phase {
+            BattlePhase::Planning { .. } => self
+                .snapshot
+                .available_abilities
+                .iter()
+                .filter(|a| a.role == AbilityRole::Attack)
+                .collect(),
+            BattlePhase::Response { .. } => self
+                .snapshot
+                .available_abilities
+                .iter()
+                .filter(|a| a.role == AbilityRole::Defend)
+                .collect(),
+            _ => vec![],
+        }
+    }
+
+    pub fn ability_role_label(&self) -> Option<&str> {
+        match &self.snapshot.phase {
+            BattlePhase::Planning { .. } => Some("Attack"),
+            BattlePhase::Response { .. } => Some("Defend"),
+            _ => None,
         }
     }
 
     pub fn select_next_ability(&mut self) {
-        let len = self.snapshot.available_abilities.len();
+        let len = self.filtered_abilities().len();
         if len > 0 {
             self.selected_ability_index = (self.selected_ability_index + 1) % len;
         }
     }
 
     pub fn select_prev_ability(&mut self) {
-        let len = self.snapshot.available_abilities.len();
+        let len = self.filtered_abilities().len();
         if len > 0 {
             self.selected_ability_index = (self.selected_ability_index + len - 1) % len;
         }

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -1,4 +1,4 @@
-use crate::game::engagement::battle::BattleMessage;
+use crate::game::engagement::battle::{BattleMessage, BattlePhase};
 use crate::game::messaging::ConversationKind;
 use crate::network::NetworkEvent;
 use crate::network::event::BattleSnapshot;
@@ -124,6 +124,12 @@ impl App {
         };
         if battle.engagement_id != engagement_id {
             return;
+        }
+        if battle.snapshot.phase != snapshot.phase {
+            battle.selected_ability_index = 0;
+            if matches!(&snapshot.phase, BattlePhase::Planning { .. }) {
+                battle.has_queued_defend = false;
+            }
         }
         battle.snapshot.participants = snapshot.participants;
         battle.snapshot.phase = snapshot.phase;

--- a/src/tui/screens/battle/keys.rs
+++ b/src/tui/screens/battle/keys.rs
@@ -1,5 +1,6 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 
+use crate::game::engagement::battle::BattlePhase;
 use crate::game::{Interaction, TurnAction};
 use crate::network::client::send_interaction;
 use crate::tui::app::{App, BattleFocus, GameMode};
@@ -78,8 +79,7 @@ fn handle_ability_selected(app: &mut App) {
         return;
     }
     let ability_id = battle
-        .snapshot
-        .available_abilities
+        .filtered_abilities()
         .get(battle.selected_ability_index)
         .map(|a| a.id.clone());
     if let Some(ability_id) = ability_id {
@@ -114,6 +114,9 @@ async fn handle_dialog_confirm(app: &mut App) {
         let _ = send_interaction(&url, &client_id, &action).await;
     }
     if let Some(battle) = &mut app.battle {
+        if matches!(&battle.snapshot.phase, BattlePhase::Response { .. }) {
+            battle.has_queued_defend = true;
+        }
         battle.close_target_dialog();
     }
 }

--- a/src/tui/screens/battle/render.rs
+++ b/src/tui/screens/battle/render.rs
@@ -126,9 +126,8 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
         Style::default()
     };
 
-    let items: Vec<ListItem> = battle
-        .snapshot
-        .available_abilities
+    let filtered = battle.filtered_abilities();
+    let items: Vec<ListItem> = filtered
         .iter()
         .enumerate()
         .map(|(i, ability)| {
@@ -161,10 +160,18 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
         })
         .collect();
 
-    let title = if battle.is_player_turn() {
-        "Abilities"
-    } else {
-        "Abilities (waiting\u{2026})"
+    let title = match battle.ability_role_label() {
+        Some("Defend") if battle.has_queued_defend => Line::from(vec![
+            Span::raw("Abilities [Defend] "),
+            Span::styled(
+                "\u{25cf} Defending",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Some(label) => Line::from(format!("Abilities [{label}]")),
+        None => Line::from("Abilities (waiting\u{2026})"),
     };
     let list = List::new(items).block(
         Block::default()


### PR DESCRIPTION
Adds phase-aware ability filtering to the battle abilities panel and a visible defending indicator so players know which abilities are relevant and when their defend action has been registered. Also fixes a bug where the default defend ability was never included in the player's ability set.

- Abilities panel now filters by role based on the current phase, showing only attack abilities during Planning and only defend abilities during Response, with the title updated to `Abilities [Attack]` or `Abilities [Defend]` accordingly
- A cyan bold `● Defending` badge appears in the panel title after the player queues a defend ability during the Response phase, clearing when the next Planning phase begins
- `AbilityRole::World` variant added to exclude non-battle abilities from battle phase filtering
- Fixed the battle start message builder to include `default_defend_ability()` in the fallback ability list alongside `default_attack_ability()`, so players without configured innate abilities can defend

<details>
<summary>Agent Context</summary>

Closes #116.

**Goal:** Wire the existing `AbilityRole` field on `Ability` into the TUI so the abilities panel is context-sensitive per battle phase, and give the player a clear visual signal after queuing a defend.

**Key files changed:**
- `src/game/component/ability.rs` — Added `World` variant to `AbilityRole` enum (serializes as `"world"`)
- `src/persistence/ability_repo.rs` — Updated `ability_role_to_str` / `ability_role_from_str` to handle `World`
- `src/tui/app/battle_state.rs` — Added `has_queued_defend: bool` field; `filtered_abilities() -> Vec<&Ability>` (filters available_abilities by role for the current phase); `ability_role_label() -> Option<&str>`; updated `select_next/prev_ability` to navigate within the filtered list
- `src/tui/screens/battle/render.rs` — `render_abilities_panel` now iterates `filtered_abilities()` and uses a `Line`-typed block title with a styled cyan `● Defending` span when `has_queued_defend` is true
- `src/tui/screens/battle/keys.rs` — `handle_ability_selected` indexes into `filtered_abilities()` instead of raw `available_abilities`; `handle_dialog_confirm` sets `has_queued_defend = true` when confirming during `BattlePhase::Response`
- `src/tui/app/network_event_handler.rs` — `handle_battle_update` resets `selected_ability_index = 0` on any phase change and clears `has_queued_defend` when transitioning to `BattlePhase::Planning`
- `src/game/interaction/room_threats.rs` — `build_battle_started_message` fallback now pushes both `default_attack_ability()` and `default_defend_ability()` when a player has no configured innate abilities

**Architectural notes:**
- `available_abilities` in `BattleSnapshot` is populated once at battle start and not updated during `BattleUpdate` events; role filtering is therefore done at render/navigation time in the TUI
- `filtered_abilities()` is the single source of truth for the visible list — both render and key handling use it, so indices remain consistent
- `has_queued_defend` is client-side optimistic state; it does not wait for server confirmation, matching the existing pattern for action feedback
- The `World` variant is reserved for future non-battle ability contexts; it is filtered out of all battle phase views by the `filtered_abilities()` logic
- `muds/basic/mud.toml`: `max_engage_ms` bumped from 5000 to 60_000 (this was a pre-existing local change, not part of the issue)

**Bug fixed:** `room_threats.rs` fallback only added `default_attack_ability()`, leaving players with no defend option during the Response phase when no innate abilities were configured on the entity.
</details>