### PR TITLE
Fixes #134 Refactor resolve_effects into a simple effect-type router

### DIFF
--- a/src/game/component/effect.rs
+++ b/src/game/component/effect.rs
@@ -29,6 +29,16 @@ pub enum EffectType {
     },
 }
 
+impl EffectType {
+    pub fn resolution_order(&self) -> u8 {
+        match self {
+            EffectType::AttributeShield { .. } => 0,
+            EffectType::AttributeUpdate { .. } => 1,
+            EffectType::EntitySpawn { .. } => 2,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct EffectDescription {
     pub start_description: Option<String>,

--- a/src/game/engagement/battle/resolution.rs
+++ b/src/game/engagement/battle/resolution.rs
@@ -5,64 +5,62 @@ use crate::game::entity::Entity;
 
 use super::BattleMessage;
 
+#[derive(Default)]
+struct ResolutionContext {
+    once_shields: Vec<Effect>,
+}
+
 pub fn resolve_effects(
     target_id: i64,
-    effects: Vec<Effect>,
+    mut effects: Vec<Effect>,
     entities: &mut HashMap<i64, Entity>,
 ) -> Vec<BattleMessage> {
     let Some(entity) = entities.get_mut(&target_id) else {
         return vec![];
     };
-
-    // Shield effects intercept incoming effects before they reach the entity.
-    let (shield_effects, incoming_effects): (Vec<Effect>, Vec<Effect>) = effects
-        .into_iter()
-        .partition(|e| matches!(e.effect_type, EffectType::AttributeShield { .. }));
-
-    let mut once_shields = collect_shield_effects(shield_effects, entity);
-
-    for effect in &incoming_effects {
-        if let (
-            TriggerInfo::Once,
-            EffectType::AttributeUpdate {
-                attribute_id,
-                value,
-            },
-        ) = (&effect.trigger_info, &effect.effect_type)
-        {
-            apply_attribute_update(entity, attribute_id, *value, &mut once_shields);
-        }
+    effects.sort_by_key(|e| e.effect_type.resolution_order());
+    let mut context = ResolutionContext::default();
+    for effect in &effects {
+        resolve_effect(effect, entity, &mut context);
     }
-
     vec![]
 }
 
-/// Splits shield effects by trigger: OverTime shields are stubbed into `active_effects` for
-/// future handling; Once shields are returned for inline absorption this pass.
-fn collect_shield_effects(shield_effects: Vec<Effect>, entity: &mut Entity) -> Vec<Effect> {
-    let mut once_shields = Vec::new();
-    for shield in shield_effects {
-        match shield.trigger_info {
-            TriggerInfo::OverTime { .. } => entity.active_effects.push(shield),
-            TriggerInfo::Once => once_shields.push(shield),
-        }
+fn resolve_effect(effect: &Effect, entity: &mut Entity, context: &mut ResolutionContext) {
+    match &effect.effect_type {
+        EffectType::AttributeShield { .. } => apply_attribute_shield(effect, entity, context),
+        EffectType::AttributeUpdate { .. } => apply_attribute_update(effect, entity, context),
+        EffectType::EntitySpawn { .. } => apply_entity_spawn(effect, entity, context),
     }
-    once_shields
 }
 
-fn apply_attribute_update(
-    entity: &mut Entity,
-    attribute_id: &str,
-    value: i64,
-    once_shields: &mut Vec<Effect>,
-) {
-    let adjusted = absorb_with_shields(once_shields, attribute_id, value);
+fn apply_attribute_shield(effect: &Effect, entity: &mut Entity, context: &mut ResolutionContext) {
+    match effect.trigger_info {
+        TriggerInfo::Once => context.once_shields.push(effect.clone()),
+        TriggerInfo::OverTime { .. } => entity.active_effects.push(effect.clone()),
+    }
+}
+
+fn apply_attribute_update(effect: &Effect, entity: &mut Entity, context: &mut ResolutionContext) {
+    let EffectType::AttributeUpdate {
+        attribute_id,
+        value,
+    } = &effect.effect_type
+    else {
+        return;
+    };
+    if effect.trigger_info != TriggerInfo::Once {
+        return;
+    }
+    let adjusted = absorb_with_shields(&mut context.once_shields, attribute_id, *value);
     if let Some(attr) = entity.attributes.get_mut(attribute_id) {
         attr.current_value = (attr.current_value + adjusted)
             .max(attr.min_value)
             .min(attr.max_value);
     }
 }
+
+fn apply_entity_spawn(_effect: &Effect, _entity: &mut Entity, _context: &mut ResolutionContext) {}
 
 fn absorb_with_shields(once_shields: &mut Vec<Effect>, attribute_id: &str, value: i64) -> i64 {
     if value >= 0 {


### PR DESCRIPTION
Refactors `resolve_effects` in the battle resolution pipeline into a clean effect-type router, moving all business logic out of the top-level dispatcher and into dedicated `apply_*` functions. Closes #134.

- `EffectType::resolution_order()` method declares each variant's processing priority (`AttributeShield=0`, `AttributeUpdate=1`, `EntitySpawn=2`) — new effect types slot in by picking a number here
- `resolve_effects` now sorts effects by `resolution_order()` and routes each through a single-pass `resolve_effect` dispatcher with no inline business logic
- `apply_attribute_shield` and `apply_attribute_update` each own their own `TriggerInfo` handling; `collect_shield_effects` is removed
- `ResolutionContext` carries shared state (`once_shields`) between apply methods; `apply_entity_spawn` stub added for the unhandled variant

<details>
<summary>Agent Context</summary>

**Goal:** Make `resolve_effects` a pure match-on-`EffectType` dispatcher with no inline business logic, and generalise effect ordering so future variants can declare their own processing phase without touching the router.

**Files changed:**
- `src/game/component/effect.rs` — added `impl EffectType { pub fn resolution_order(&self) -> u8 }` with a match over all three variants
- `src/game/engagement/battle/resolution.rs` — full refactor; `collect_shield_effects` deleted

**Key decisions:**
- Used a sort-then-single-pass approach (sort by `resolution_order()`, then one loop through `resolve_effect`) rather than the two-pass filter approach mentioned in the issue. This is more general: adding a new phase requires only updating `resolution_order()`, not adding another filter pass to `resolve_effects`.
- `ResolutionContext` holds `once_shields: Vec<Effect>` — the only shared state needed across apply methods so far. Extend it as new cross-method state arises.
- `apply_attribute_update` guards on `TriggerInfo::Once` and early-returns for `OverTime` (stubbed); the shield absorption invariant is preserved because shields sort to position 0 and populate `context.once_shields` before any `AttributeUpdate` at position 1 is processed.

**Related:** #134, #129 (introduced this module)

**All 370 existing tests pass unchanged.**

</details>