### PR TITLE
Fixes #119 Fix battle lifecycle on client disconnect and add attack command to join active battles

### DIFF
--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -2,6 +2,7 @@ pub mod abilities;
 pub mod ai;
 pub mod loot;
 pub mod message;
+pub mod participants;
 pub mod phase;
 pub mod queued_ability;
 pub mod resolution;

--- a/src/game/engagement/battle/participants.rs
+++ b/src/game/engagement/battle/participants.rs
@@ -1,0 +1,58 @@
+use std::collections::HashMap;
+
+use crate::game::engagement::EngagementType;
+use crate::game::engagement::engagements::Engagements;
+
+/// Add an entity to an existing battle engagement under the given faction.
+/// Returns false if the engagement does not exist or has no battle.
+pub async fn add_entity(
+    engagements: &Engagements,
+    engagement_id: i64,
+    faction: &str,
+    entity_id: i64,
+) -> bool {
+    let mut map = engagements.engagements_by_id.write().await;
+    let Some(engagement) = map.get_mut(&engagement_id) else {
+        return false;
+    };
+    let Some(battle) = &mut engagement.battle else {
+        return false;
+    };
+    battle.add_entity(faction, entity_id);
+    if !engagement.entity_ids.contains(&entity_id) {
+        engagement.entity_ids.push(entity_id);
+    }
+    true
+}
+
+/// Remove an entity from whichever battle it currently belongs to.
+/// Returns `Some((engagement_id, surviving_faction_count))` or `None` if not in any battle.
+pub async fn remove_entity(engagements: &Engagements, entity_id: i64) -> Option<(i64, usize)> {
+    let mut map = engagements.engagements_by_id.write().await;
+    for engagement in map.values_mut() {
+        if engagement.engagement_type != EngagementType::Battle {
+            continue;
+        }
+        if !engagement.entity_ids.contains(&entity_id) {
+            continue;
+        }
+        if let Some(battle) = &mut engagement.battle {
+            battle.remove_entity(entity_id);
+            engagement.entity_ids.retain(|&id| id != entity_id);
+            let count = battle.surviving_faction_count();
+            return Some((engagement.id, count));
+        }
+    }
+    None
+}
+
+/// Return the factions and participant map for a battle engagement, or `None`.
+pub async fn snapshot(
+    engagements: &Engagements,
+    engagement_id: i64,
+) -> Option<(Vec<String>, HashMap<String, Vec<i64>>)> {
+    let map = engagements.engagements_by_id.read().await;
+    let engagement = map.get(&engagement_id)?;
+    let battle = engagement.battle.as_ref()?;
+    Some((battle.factions.clone(), battle.participants.clone()))
+}

--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -121,6 +121,13 @@ impl BattleEngagement {
         }
     }
 
+    pub fn add_entity(&mut self, faction: &str, entity_id: i64) {
+        self.participants
+            .entry(faction.to_string())
+            .or_default()
+            .push(entity_id);
+    }
+
     pub fn remove_entity(&mut self, entity_id: i64) {
         for ids in self.participants.values_mut() {
             ids.retain(|&id| id != entity_id);

--- a/src/game/engagement/engagements.rs
+++ b/src/game/engagement/engagements.rs
@@ -12,7 +12,7 @@ use crate::game::engagement::TurnAction;
 use crate::game::engagement::battle::{BattleAiContext, BattlePhase, BattleTick};
 
 pub struct Engagements {
-    engagements_by_id: RwLock<HashMap<i64, Engagement>>,
+    pub(in crate::game::engagement) engagements_by_id: RwLock<HashMap<i64, Engagement>>,
     next_id: AtomicI64,
 }
 

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -11,6 +11,7 @@ use tracing;
 use crate::game::component::interaction::Movement;
 use crate::game::engagement::TurnAction;
 use crate::game::engagement::battle;
+use crate::game::messaging;
 use crate::game::player::Player;
 use crate::game::{GameState, Interaction};
 use crate::persistence::Database;
@@ -54,8 +55,11 @@ async fn dispatch_interaction(
         conv @ (Interaction::StartConversation { .. } | Interaction::EndConversation) => {
             dispatch_conversation(game_state, player, conv).await;
         }
-        Interaction::JoinBattle { engagement_id } | Interaction::LeaveBattle { engagement_id } => {
-            tracing::debug!(engagement_id, "battle interaction");
+        Interaction::JoinBattle { .. } => {
+            dispatch_join_battle(game_state, player).await;
+        }
+        Interaction::LeaveBattle { .. } => {
+            dispatch_leave_battle(game_state, player).await;
         }
     }
 }
@@ -148,4 +152,79 @@ async fn dispatch_conversation(
         }
         _ => {}
     }
+}
+
+async fn dispatch_join_battle(game_state: &Arc<GameState>, player: &Player) {
+    let room_id = {
+        let entities = game_state.active_entities.read().await;
+        entities
+            .get(&player.entity_id)
+            .map(|e| e.location.room_id.clone())
+    };
+    let Some(room_id) = room_id else {
+        return;
+    };
+
+    let Some(engagement_id) = game_state.engagements.find_battle_for_room(&room_id).await else {
+        messaging::message(
+            &game_state.message_tx,
+            player.id,
+            "There is no active battle here.",
+        );
+        return;
+    };
+
+    let faction = {
+        let entities = game_state.active_entities.read().await;
+        entities
+            .get(&player.entity_id)
+            .and_then(|e| e.factions.iter().next().cloned())
+            .unwrap_or_else(|| "player".to_string())
+    };
+
+    battle::participants::add_entity(
+        &game_state.engagements,
+        engagement_id,
+        &faction,
+        player.entity_id,
+    )
+    .await;
+
+    let Some((factions, participants)) =
+        battle::participants::snapshot(&game_state.engagements, engagement_id).await
+    else {
+        return;
+    };
+
+    let max_turn_ticks = (game_state.mud_config.game_loop.max_engage_ms
+        / game_state.mud_config.game_loop.tick_rate_ms)
+        .max(1);
+
+    let started_msg = room_threats::build_battle_started_message(
+        game_state,
+        player,
+        engagement_id,
+        &factions,
+        &participants,
+        max_turn_ticks,
+    )
+    .await;
+
+    messaging::battle_started(&game_state.message_tx, player.id, started_msg);
+    messaging::message(&game_state.message_tx, player.id, "You join the battle!");
+}
+
+async fn dispatch_leave_battle(game_state: &Arc<GameState>, player: &Player) {
+    let Some((engagement_id, surviving)) =
+        battle::participants::remove_entity(&game_state.engagements, player.entity_id).await
+    else {
+        return;
+    };
+
+    if surviving <= 1 {
+        game_state.engagements.conclude_battle(engagement_id).await;
+        game_state.engagements.remove(engagement_id).await;
+    }
+
+    messaging::battle_ended(&game_state.message_tx, player.id, engagement_id);
 }

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -118,7 +118,7 @@ async fn start_battle(
     );
 }
 
-async fn build_battle_started_message(
+pub(super) async fn build_battle_started_message(
     game_state: &Arc<GameState>,
     player: &Player,
     engagement_id: i64,
@@ -205,7 +205,7 @@ fn resolve_entity_name(
         .unwrap_or_else(|| format!("Entity {entity_id}"))
 }
 
-fn hp_attribute_id(attribute_config: &crate::game::config::AttributeConfig) -> String {
+pub(super) fn hp_attribute_id(attribute_config: &crate::game::config::AttributeConfig) -> String {
     attribute_config
         .attributes
         .iter()

--- a/src/network/server/handlers.rs
+++ b/src/network/server/handlers.rs
@@ -78,6 +78,7 @@ pub async fn sse_handler(
     let guard = SseCleanupGuard {
         client_id: query.client_id,
         connections: state.connections.clone(),
+        game_state: state.game_state.clone(),
     };
     let stream = GuardedStream {
         inner,

--- a/src/network/server/state.rs
+++ b/src/network/server/state.rs
@@ -6,6 +6,7 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use crate::game::GameState;
+use crate::game::engagement::battle;
 use crate::network::event::NetworkEvent;
 use crate::network::session::ServerSession;
 use crate::persistence::Database;
@@ -35,17 +36,41 @@ pub struct AppState {
 pub struct SseCleanupGuard {
     pub client_id: String,
     pub connections: Arc<RwLock<HashMap<String, ConnectedClient>>>,
+    pub game_state: Arc<GameState>,
 }
 
 impl Drop for SseCleanupGuard {
     fn drop(&mut self) {
         let client_id = self.client_id.clone();
         let connections = self.connections.clone();
+        let game_state = self.game_state.clone();
         tokio::spawn(async move {
             connections.write().await.remove(&client_id);
             info!(client_id = %client_id, "SSE disconnected — session ended");
+            cleanup_player_battle(&game_state, &client_id).await;
+            game_state.active_players.write().await.remove(&client_id);
         });
     }
+}
+
+async fn cleanup_player_battle(game_state: &GameState, client_id: &str) {
+    let entity_id = {
+        let players = game_state.active_players.read().await;
+        let Some(player) = players.get(client_id) else {
+            return;
+        };
+        player.entity_id
+    };
+
+    if let Some((engagement_id, surviving)) =
+        battle::participants::remove_entity(&game_state.engagements, entity_id).await
+        && surviving <= 1
+    {
+        game_state.engagements.conclude_battle(engagement_id).await;
+        game_state.engagements.remove(engagement_id).await;
+    }
+
+    game_state.active_entities.write().await.remove(&entity_id);
 }
 
 // Stream wrapper that keeps the guard alive until the stream is dropped.

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -6,6 +6,7 @@ pub enum Command {
     Help,
     Talk(Option<String>),
     Choose(String),
+    Attack,
     #[allow(dead_code)]
     Enter(String),
     Unknown,
@@ -22,6 +23,7 @@ pub fn parse(input: &str) -> Command {
         "w" | "west" => Command::Move(Direction::West),
         "l" | "look" => Command::Look,
         "h" | "help" => Command::Help,
+        "a" | "attack" => Command::Attack,
         "t" | "talk" | "say" => Command::Talk(None),
         _ => {
             if lower.starts_with("talk ") {

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -27,58 +27,70 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
         }
         (_, KeyCode::Enter) => {
             let input: String = app.input.drain(..).collect();
-            let cmd = commands::parse(&input);
-            let url = app.connection.server_url.as_deref();
-            let client_id = app.connection.client_id.as_deref();
-            match cmd {
-                commands::Command::Move(direction) => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let interaction = Interaction::Movement(Movement::TryDirection(direction));
-                        let _ = send_interaction(url, client_id, &interaction).await;
-                    }
-                }
-                commands::Command::Look => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(url, client_id, &Interaction::Look).await;
-                    }
-                }
-                commands::Command::Help => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(url, client_id, &Interaction::Help).await;
-                    }
-                }
-                commands::Command::Talk(msg) => {
-                    let has_initial = msg.is_some();
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let _ = send_interaction(
-                            url,
-                            client_id,
-                            &Interaction::StartConversation {
-                                initial_message: msg,
-                            },
-                        )
-                        .await;
-                        if has_initial {
-                            app.agent_responding = true;
-                        }
-                    }
-                }
-                commands::Command::Choose(choice) => {
-                    if let (Some(url), Some(client_id)) = (url, client_id) {
-                        let action =
-                            Interaction::EngagementAction(TurnAction::SelectDialogChoice {
-                                choice,
-                            });
-                        let _ = send_interaction(url, client_id, &action).await;
-                    }
-                }
-                _ => {}
-            }
+            dispatch_command(app, &input).await;
             app.messages.push(AppMessage::normal(input));
             app.scroll_offset = 0;
         }
         (_, KeyCode::PageUp) => app.scroll_up(),
         (_, KeyCode::PageDown) => app.scroll_down(),
+        _ => {}
+    }
+}
+
+async fn dispatch_command(app: &mut App, input: &str) {
+    let cmd = commands::parse(input);
+    let url = app.connection.server_url.as_deref();
+    let client_id = app.connection.client_id.as_deref();
+    match cmd {
+        commands::Command::Move(direction) => {
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let interaction = Interaction::Movement(Movement::TryDirection(direction));
+                let _ = send_interaction(url, client_id, &interaction).await;
+            }
+        }
+        commands::Command::Look => {
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let _ = send_interaction(url, client_id, &Interaction::Look).await;
+            }
+        }
+        commands::Command::Help => {
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let _ = send_interaction(url, client_id, &Interaction::Help).await;
+            }
+        }
+        commands::Command::Talk(msg) => {
+            let has_initial = msg.is_some();
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let _ = send_interaction(
+                    url,
+                    client_id,
+                    &Interaction::StartConversation {
+                        initial_message: msg,
+                    },
+                )
+                .await;
+                if has_initial {
+                    app.agent_responding = true;
+                }
+            }
+        }
+        commands::Command::Choose(choice) => {
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let action =
+                    Interaction::EngagementAction(TurnAction::SelectDialogChoice { choice });
+                let _ = send_interaction(url, client_id, &action).await;
+            }
+        }
+        commands::Command::Attack => {
+            if let (Some(url), Some(client_id)) = (url, client_id) {
+                let _ = send_interaction(
+                    url,
+                    client_id,
+                    &Interaction::JoinBattle { engagement_id: 0 },
+                )
+                .await;
+            }
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
Fixes two gaps in the battle lifecycle: battles were left running indefinitely when a client disconnected mid-fight, and players entering a room with an active battle had no command to join it. Closes #119.

- Client disconnect now removes the player's entity from any active battle and concludes the engagement if only one faction survives
- New `attack` / `a` command sends `Interaction::JoinBattle`, adding the player to the room's active battle and sending them a `BattleStarted` event to transition the TUI
- `Interaction::JoinBattle` and `Interaction::LeaveBattle` are now fully implemented — previously no-ops in the interaction dispatcher
- New `battle::participants` module in `src/game/engagement/battle/participants.rs` houses the `add_entity`, `remove_entity`, and `snapshot` free functions, keeping battle-specific logic inside `engagement/battle/`

<details>
<summary>Agent Context</summary>

**Goal:** Fix #119 — two related gaps in battle lifecycle: (1) no cleanup on client disconnect, (2) no way to join an already-running battle.

**Disconnect cleanup (`src/network/server/state.rs`):**
- `SseCleanupGuard` gained a `game_state: Arc<GameState>` field
- `Drop` impl now spawns `cleanup_player_battle`, which looks up the player by `client_id` in `active_players`, calls `battle::participants::remove_entity` to remove the entity from any active battle, concludes + removes the engagement if `surviving_faction_count <= 1`, then removes from `active_players` and `active_entities`
- `sse_handler` in `src/network/server/handlers.rs` passes `state.game_state.clone()` to the guard

**Join command (`src/tui/commands.rs`, `src/tui/screens/game.rs`):**
- Added `Command::Attack` variant; parses `"attack"` / `"a"`
- `dispatch_command` (extracted from `handle_key` to fix clippy cognitive complexity) handles `Command::Attack` by sending `Interaction::JoinBattle { engagement_id: 0 }` — the server ignores the client-provided id and resolves the room's active battle itself

**Interaction dispatch (`src/game/interaction.rs`):**
- `dispatch_join_battle`: reads player's room → `find_battle_for_room` → `battle::participants::add_entity` → `battle::participants::snapshot` → sends `BattleStartedMessage` via `messaging::battle_started` so the client transitions to battle TUI. Sends "There is no active battle here." if no battle found.
- `dispatch_leave_battle`: calls `battle::participants::remove_entity` → concludes+removes engagement if surviving ≤ 1 → sends `BattleEnded`
- `build_battle_started_message` and `hp_attribute_id` in `room_threats.rs` promoted to `pub(super)` so `interaction.rs` can reuse them for the join flow

**New module (`src/game/engagement/battle/participants.rs`):**
- `add_entity(engagements, engagement_id, faction, entity_id) -> bool`
- `remove_entity(engagements, entity_id) -> Option<(i64, usize)>`
- `snapshot(engagements, engagement_id) -> Option<(Vec<String>, HashMap<String, Vec<i64>>)>`
- These take `&Engagements` directly; `Engagements::engagements_by_id` was widened to `pub(in crate::game::engagement)` so the `battle` sibling submodule can access it
- `BattleEngagement::add_entity(faction, entity_id)` added to `battle/state.rs` as the primitive

**Related:** `Interaction::JoinBattle` was plumbed in #98 but left as a no-op. The `attack` command is distinct from the `a` (attack ability) shortcut in the battle screen — `a` in game mode triggers join; ability queuing uses different `TurnAction` interactions.

**Deferred:** The "flee" UX (explicit `LeaveBattle` from the TUI) is wired server-side but has no dedicated TUI command yet.
</details>