### PR TITLE
Fixes #143 Add Madman enemy with Swing Ax and Scream Nonsense abilities to the dark corridor

### DIFF
--- a/muds/basic/abilities/scream_nonsense.toml
+++ b/muds/basic/abilities/scream_nonsense.toml
@@ -1,0 +1,6 @@
+name = "Scream Nonsense"
+description = "The madman shrieks incoherently, unnerving everyone nearby."
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+effects = []

--- a/muds/basic/abilities/swing_ax.toml
+++ b/muds/basic/abilities/swing_ax.toml
@@ -1,0 +1,10 @@
+name = "Swing Ax"
+description = "A wild swing with a rusty ax."
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[effects]]
+name = "ax_damage"
+trigger_info = { type = "once" }
+effect_type = { type = "attribute_update", attribute_id = "hp", value = -15 }

--- a/muds/basic/entities/madman.toml
+++ b/muds/basic/entities/madman.toml
@@ -1,0 +1,24 @@
+entity_type = "enemy"
+factions = ["enemy"]
+
+name = "Madman"
+description = "A wild-eyed figure, muttering to himself and clutching a rusted ax. Dangerous and unpredictable."
+innate_abilities = ["swing_ax", "scream_nonsense", "defend"]
+
+[battle_ai]
+ai_type = "simple_random"
+
+[[attributes]]
+definition_id = "hp"
+min_value = 0
+max_value = 65
+current_value = 65
+
+[[attributes]]
+definition_id = "speed"
+min_value = 1
+max_value = 10
+current_value = 4
+
+[faction_relations.factions]
+player = "hostile"

--- a/muds/basic/maps/default/default/dark_corridor.toml
+++ b/muds/basic/maps/default/default/dark_corridor.toml
@@ -1,4 +1,4 @@
-entities = ["entities/zombie"]
+entities = ["entities/zombie", "entities/madman"]
 
 [description]
 standard = "A dark, damp corridor. The stench of decay hangs in the air. Something shambles in the shadows."


### PR DESCRIPTION
Adds the Madman as a second enemy to the basic MUD's dark corridor, giving players a harder fight and more combat variety. Closes #143.

- New `madman.toml` entity config: HP 65, speed 4, faction `enemy`, hostile to players, using `simple_random` battle AI
- Two new ability configs: `swing_ax.toml` (15 HP damage) and `scream_nonsense.toml` (flavor attack, no effects)
- Madman references the existing `defend` ability alongside the two new ones via `innate_abilities`
- `dark_corridor.toml` updated to spawn both the Zombie and the Madman in the same room

<details>
<summary>Agent Context</summary>

**Goal:** Add a second enemy entity to the basic MUD sample — pure config, no Rust changes.

**Files changed:**
- `muds/basic/abilities/swing_ax.toml` (new) — `role = "attack"`, `AttributeUpdate { attribute_id = "hp", value = -15 }`
- `muds/basic/abilities/scream_nonsense.toml` (new) — `role = "attack"`, `effects = []` (flavor only)
- `muds/basic/entities/madman.toml` (new) — modeled after `zombie.toml`; HP max/current = 65 (zombie is 50), speed = 4 (zombie is 3), `innate_abilities = ["swing_ax", "scream_nonsense", "defend"]`
- `muds/basic/maps/default/default/dark_corridor.toml` — `entities` array extended to include `"entities/madman"`

**Ability resolution:** `build_ability_cache` in `src/game/config/map_loader/ability_cache.rs` walks `abilities/` and keys abilities by their path stem. `EntityConfig.innate_abilities: Vec<AbilityReference>` holds string IDs that match those keys. The `defend` ability reused here is `muds/basic/abilities/defend.toml`.

**No Rust changes needed** — the entity config loader (`src/game/config/entity_config.rs`) and map loader pick up new files automatically by directory scan.

**Related:** Closes #143.

</details>