### PR TITLE
Fixes #144 Add starting classes config directory, loader, and sample classes

### DIFF
--- a/muds/basic/classes/cyborg.toml
+++ b/muds/basic/classes/cyborg.toml
@@ -1,0 +1,48 @@
+name = "Cyborg"
+description = "A cybernetically enhanced fighter with integrated energy weapons."
+
+[[attributes]]
+definition_id = "hp"
+min_value = 0
+max_value = 90
+current_value = 90
+
+[[attributes]]
+definition_id = "mp"
+min_value = 0
+max_value = 60
+current_value = 60
+
+[[innate_abilities]]
+id = "heat_beam"
+name = "Heat Beam"
+description = "Fires a focused beam of superheated energy that burns through armor."
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[innate_abilities.effects]]
+name = "heat_damage"
+trigger_info = { type = "once" }
+
+[innate_abilities.effects.effect_type]
+type = "attribute_update"
+attribute_id = "hp"
+value = -15
+
+[[innate_abilities]]
+id = "electric_shot"
+name = "Electric Shot"
+description = "Discharges a bolt of electricity that arcs through the target."
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[innate_abilities.effects]]
+name = "electric_damage"
+trigger_info = { type = "once" }
+
+[innate_abilities.effects.effect_type]
+type = "attribute_update"
+attribute_id = "hp"
+value = -12

--- a/muds/basic/classes/survivor.toml
+++ b/muds/basic/classes/survivor.toml
@@ -1,0 +1,47 @@
+name = "Survivor"
+description = "A scrappy melee brawler who clawed their way through the wasteland."
+
+[[attributes]]
+definition_id = "hp"
+min_value = 0
+max_value = 120
+current_value = 120
+
+[[attributes]]
+definition_id = "mp"
+min_value = 0
+max_value = 20
+current_value = 20
+
+[[innate_abilities]]
+id = "basic_attack"
+name = "Basic Attack"
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[innate_abilities.effects]]
+name = "physical_damage"
+trigger_info = { type = "once" }
+
+[innate_abilities.effects.effect_type]
+type = "attribute_update"
+attribute_id = "hp"
+value = -8
+
+[[innate_abilities]]
+id = "sawed_off_shotgun"
+name = "Sawed-Off Shotgun"
+description = "A rusted sawed-off shotgun — unreliable, but devastating at close range."
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[innate_abilities.effects]]
+name = "shotgun_blast"
+trigger_info = { type = "once" }
+
+[innate_abilities.effects.effect_type]
+type = "attribute_update"
+attribute_id = "hp"
+value = -20

--- a/src/game/config.rs
+++ b/src/game/config.rs
@@ -2,6 +2,7 @@ pub mod ability_config;
 pub mod agent_config;
 pub mod attribute_config;
 pub mod battle_ai_config;
+pub mod class_config;
 pub mod config_path;
 mod dialog_parser;
 pub mod entity_config;
@@ -18,8 +19,10 @@ pub use ability_config::AbilityReference;
 pub use agent_config::{AgentConfig, AgentProviderConfig};
 pub use attribute_config::AttributeConfig;
 pub use battle_ai_config::{BattleAiConfig, BattleAiType};
+pub use class_config::{ClassConfig, load_classes};
 pub use entity_config::{
-    DialogLine, EntityConfig, EntityTypeConfig, PersonaConfig, PlayerResponse, load_entity_configs,
+    DialogLine, EntityConfig, EntityTypeConfig, PersonaConfig, PlayerResponse, StartingAttribute,
+    load_entity_configs,
 };
 pub use faction_config::FactionConfig;
 pub use game_loop_config::GameLoopConfig;

--- a/src/game/config/class_config.rs
+++ b/src/game/config/class_config.rs
@@ -1,0 +1,132 @@
+use crate::game::config::ability_config::Ability;
+use crate::game::config::entity_config::StartingAttribute;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use std::path::Path;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassConfig {
+    pub id: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub attributes: Vec<StartingAttribute>,
+    #[serde(default)]
+    pub innate_abilities: Vec<Ability>,
+}
+
+pub fn load_classes(config_dir: &Path) -> Result<HashMap<String, ClassConfig>, Box<dyn Error>> {
+    let mut configs = HashMap::new();
+    let classes_dir = config_dir.join("classes");
+    if !classes_dir.exists() {
+        return Ok(configs);
+    }
+    for entry in walkdir::WalkDir::new(&classes_dir)
+        .max_depth(1)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("toml"))
+    {
+        let path = entry.path();
+        let content = std::fs::read_to_string(path)?;
+        let mut config: ClassConfig = toml::from_str(&content)?;
+        let id = if let Some(id) = config.id.clone() {
+            id
+        } else {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        };
+        config.id = Some(id.clone());
+        configs.insert(id, config);
+    }
+    Ok(configs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_file(base: &Path, rel: &str, contents: &str) {
+        let path = base.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn load_classes_returns_empty_when_no_classes_dir() {
+        let tmp = TempDir::new().unwrap();
+        let configs = load_classes(tmp.path()).unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn load_classes_finds_toml_files() {
+        let tmp = TempDir::new().unwrap();
+        write_file(tmp.path(), "classes/warrior.toml", r#"name = "Warrior""#);
+        let configs = load_classes(tmp.path()).unwrap();
+        assert_eq!(configs.len(), 1);
+        assert!(configs.contains_key("warrior"));
+    }
+
+    #[test]
+    fn load_classes_uses_id_field_when_present() {
+        let tmp = TempDir::new().unwrap();
+        write_file(
+            tmp.path(),
+            "classes/myfile.toml",
+            r#"
+id = "custom_id"
+name = "Custom"
+"#,
+        );
+        let configs = load_classes(tmp.path()).unwrap();
+        assert!(configs.contains_key("custom_id"));
+        assert!(!configs.contains_key("myfile"));
+    }
+
+    #[test]
+    fn class_config_round_trip() {
+        let toml = r#"
+name = "Survivor"
+description = "A scrappy melee brawler."
+
+[[attributes]]
+definition_id = "hp"
+min_value = 0
+max_value = 120
+current_value = 120
+
+[[innate_abilities]]
+id = "basic_attack"
+name = "Basic Attack"
+engagement_types = ["battle"]
+costs = []
+role = "attack"
+
+[[innate_abilities.effects]]
+name = "physical_damage"
+trigger_info = { type = "once" }
+
+[innate_abilities.effects.effect_type]
+type = "attribute_update"
+attribute_id = "hp"
+value = -8
+"#;
+        let config: ClassConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.name, "Survivor");
+        assert_eq!(config.attributes.len(), 1);
+        assert_eq!(config.attributes[0].definition_id, "hp");
+        assert_eq!(config.attributes[0].max_value, 120);
+        assert_eq!(config.innate_abilities.len(), 1);
+        assert_eq!(config.innate_abilities[0].id, "basic_attack");
+        assert_eq!(config.innate_abilities[0].effects.len(), 1);
+    }
+}

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -6,7 +6,8 @@ use tokio::sync::RwLock;
 use tokio::sync::broadcast;
 
 use crate::game::config::{
-    AttributeConfig, EntityConfig, FactionConfig, MudConfig, ResourceConfig, load_entity_configs,
+    AttributeConfig, ClassConfig, EntityConfig, FactionConfig, MudConfig, ResourceConfig,
+    load_classes, load_entity_configs,
 };
 use crate::game::engagement::Engagements;
 use crate::game::entity::Entity;
@@ -23,6 +24,7 @@ pub struct GameState {
     pub resource_config: ResourceConfig,
     pub mud_config: MudConfig,
     pub entity_configs: HashMap<String, EntityConfig>,
+    pub classes: HashMap<String, ClassConfig>,
     pub active_entities: RwLock<HashMap<i64, Entity>>,
     pub active_dungeons: RwLock<HashSet<(String, String)>>,
     pub engagements: Engagements,
@@ -83,6 +85,12 @@ impl GameState {
             HashMap::new()
         };
 
+        let classes = if let Some(dir) = config_dir {
+            load_classes(dir).unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+
         let (message_tx, _) = broadcast::channel::<PlayerMessage>(512);
 
         Ok(Self {
@@ -91,6 +99,7 @@ impl GameState {
             resource_config,
             mud_config,
             entity_configs,
+            classes,
             active_entities: RwLock::new(HashMap::new()),
             active_dungeons: RwLock::new(HashSet::new()),
             engagements: Engagements::new(),


### PR DESCRIPTION
Establishes the foundational config layer for player starting classes. This is a data-only change — no player creation or TUI changes are included.

- New `ClassConfig` struct in `src/game/config/class_config.rs` with fields for name, description, starting attributes, and innate abilities (full `Ability` structs, not references)
- `load_classes(config_dir)` loader that walks `<config_dir>/classes/*.toml`, deriving the class id from the file stem when no explicit `id` field is set
- `GameState` gains a `classes: HashMap<String, ClassConfig>` field, populated at server startup alongside `entity_configs`
- Two sample classes in `muds/basic/classes/`: `survivor.toml` (120 HP / 20 MP, melee brawler with `basic_attack` and `sawed_off_shotgun`) and `cyborg.toml` (90 HP / 60 MP, cyber fighter with `heat_beam` and `electric_shot`)

<details>
<summary>Agent Context</summary>

**Goal:** Add the config-layer foundation for player starting classes so later issues can build on it (class selection during player creation, applying starting attributes/abilities, etc.).

**Files changed:**
- `src/game/config/class_config.rs` (new) — `ClassConfig` struct + `load_classes()` + 4 unit tests
- `src/game/config.rs` — added `pub mod class_config`, re-exports for `ClassConfig`, `load_classes`, and also newly re-exports `StartingAttribute` from `entity_config`
- `src/game/game_state.rs` — added `classes: HashMap<String, ClassConfig>` field; `load()` calls `load_classes(dir).unwrap_or_default()` when a config dir is present
- `muds/basic/classes/survivor.toml` (new)
- `muds/basic/classes/cyborg.toml` (new)

**Pattern followed:** Mirrors `entity_config.rs` / `load_entity_configs()` exactly — same walkdir usage, same id-derivation logic (explicit `id` field wins; falls back to file stem rather than the full relative path used by entity configs).

**Key decisions:**
- `innate_abilities` uses `Vec<Ability>` (full struct) rather than `Vec<AbilityReference>` — classes inline their ability definitions rather than pointing to shared ability files, which keeps class configs self-contained.
- `max_depth(1)` on the WalkDir — no subdirectory nesting needed for classes; flat `classes/` directory is sufficient.
- `StartingAttribute` is reused directly from `entity_config.rs` (already `pub`) rather than duplicated.

**Ability TOML structure:** Effects use TOML's inline table for `trigger_info` and a separate `[innate_abilities.effects.effect_type]` section per the `Effect` / `EffectType` serde tags (`tag = "type"`).

**Deferred / out of scope:** Class selection in player creation flow, applying class attributes/abilities to new entities — those are follow-up issues.

**Related:** Closes #144.
</details>