### PR TITLE
Fixes #158 Load innate abilities when fetching entities from DB

### DIFF
--- a/src/persistence/entity_repo.rs
+++ b/src/persistence/entity_repo.rs
@@ -6,7 +6,7 @@ use crate::game::component::Attribute;
 use crate::game::config::{BattleAiConfig, BattleAiType};
 use crate::game::{Entity, EntityType, Location};
 use crate::persistence::error::PersistenceError;
-use crate::persistence::{faction_relations_repo, faction_repo};
+use crate::persistence::{ability_repo, faction_relations_repo, faction_repo};
 
 type EntityRow = (
     i64,
@@ -108,6 +108,7 @@ pub async fn find_by_id(pool: &SqlitePool, id: i64) -> Result<Option<Entity>, Pe
     if let Some(row) = row {
         let mut entity = build_entity(row);
         load_faction_data(pool, &mut entity).await?;
+        load_ability_data(pool, &mut entity).await?;
         Ok(Some(entity))
     } else {
         Ok(None)
@@ -131,6 +132,7 @@ pub async fn find_by_location(
     for row in rows {
         let mut entity = build_entity(row);
         load_faction_data(pool, &mut entity).await?;
+        load_ability_data(pool, &mut entity).await?;
         entities.push(entity);
     }
     Ok(entities)
@@ -153,6 +155,7 @@ pub async fn find_config_entities_by_dungeon(
     for row in rows {
         let mut entity = build_entity(row);
         load_faction_data(pool, &mut entity).await?;
+        load_ability_data(pool, &mut entity).await?;
         entities.push(entity);
     }
     Ok(entities)
@@ -239,6 +242,14 @@ async fn load_faction_data(pool: &SqlitePool, entity: &mut Entity) -> Result<(),
     let db_relations = faction_relations_repo::find_by_entity(pool, entity.id).await?;
     if !db_relations.factions.is_empty() {
         entity.faction_relations = db_relations;
+    }
+    Ok(())
+}
+
+async fn load_ability_data(pool: &SqlitePool, entity: &mut Entity) -> Result<(), PersistenceError> {
+    let abilities = ability_repo::find_by_entity(pool, entity.id).await?;
+    if !abilities.is_empty() {
+        entity.innate_abilities = abilities;
     }
     Ok(())
 }
@@ -805,5 +816,37 @@ mod tests {
 
         let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
         assert_eq!(found.battle_ai.ai_type, BattleAiType::None);
+    }
+
+    #[tokio::test]
+    async fn find_by_id_loads_innate_abilities() {
+        use crate::game::component::{Ability, AbilityRole};
+        use crate::game::engagement::EngagementType;
+        use crate::persistence::ability_repo;
+
+        let db = Database::connect_in_memory().await.unwrap();
+        setup(&db).await;
+
+        let entity = Entity::new(0, EntityType::Enemy, test_location());
+        let id = insert(db.pool(), &entity).await.unwrap();
+
+        let ability = Ability {
+            id: "strike".to_string(),
+            name: "Strike".to_string(),
+            description: None,
+            effects: vec![],
+            costs: vec![],
+            modifiers: vec![],
+            engagement_types: vec![EngagementType::Battle],
+            role: AbilityRole::Attack,
+        };
+        ability_repo::upsert(db.pool(), &ability).await.unwrap();
+        ability_repo::set_entity_abilities(db.pool(), id, &["strike"])
+            .await
+            .unwrap();
+
+        let found = find_by_id(db.pool(), id).await.unwrap().unwrap();
+        assert_eq!(found.innate_abilities.len(), 1);
+        assert_eq!(found.innate_abilities[0].id, "strike");
     }
 }


### PR DESCRIPTION
Entities fetched from the database were missing their innate abilities because `build_entity` in `entity_repo.rs` only maps the SQL row — it cannot call async repos. This adds a `load_ability_data` async helper (mirroring the existing `load_faction_data` pattern) and calls it in every entity fetch path, so enemies and characters now have their configured abilities available at runtime.

- New `load_ability_data` async helper queries `ability_repo::find_by_entity` and populates `entity.innate_abilities`
- Helper called in all three find functions: `find_by_id`, `find_by_location`, and `find_config_entities_by_dungeon`
- Round-trip test added to verify abilities survive a DB insert + fetch cycle

<details>
<summary>Agent Context</summary>

**Goal**: Populate `Entity::innate_abilities: Vec<Ability>` when loading entities from SQLite (issue #158).

**Root cause**: `build_entity` (sync) constructs an entity from an `EntityRow` tuple and cannot make async calls. The same architectural constraint was already solved for factions via `load_faction_data`, an async helper called after `build_entity` in every find function. This PR mirrors that pattern exactly.

**File changed**: `src/persistence/entity_repo.rs`
- Added `use crate::persistence::ability_repo;` import
- Added `async fn load_ability_data(pool, entity)` after `load_faction_data` (line ~255)
- Called in `find_by_id` (line ~112), `find_by_location` loop (line ~135), `find_config_entities_by_dungeon` loop (line ~158)
- New test `find_by_id_loads_innate_abilities` uses `ability_repo::upsert` + `ability_repo::set_entity_abilities` to set up fixture data, then asserts the fetched entity has the expected ability

**Related**: `src/persistence/ability_repo.rs` — `find_by_entity` joins `abilities` + `entity_abilities` tables; `set_entity_abilities` manages the join table rows. No changes needed there.

**Consequence of the bug**: Enemies added to the dark corridor in PR #156 (Madman with Swing Ax / Scream Nonsense) had abilities stored in the DB but they were never loaded at server start, so battles fell back to default behavior.

**No schema changes**: `entity_abilities` join table and `abilities` table already exist; this PR only fixes the read path.
</details>