### PR TITLE
Fixes #146 Add class selection TUI screen to new player creation flow

### DIFF
--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -8,6 +8,6 @@ mod sse;
 pub use game::send_interaction;
 pub use info::get_server_info;
 pub use ping::run_ping_loop;
-pub use player::{create_player, list_players, select_player};
+pub use player::{create_player, list_classes, list_players, select_player};
 pub use session::{end_session, start_session};
 pub use sse::connect_sse;

--- a/src/network/client/player.rs
+++ b/src/network/client/player.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use crate::network::event::{PlayerInfo, PlayerListResponse};
+use crate::network::event::{ClassInfo, ClassListResponse, PlayerInfo, PlayerListResponse};
 
 pub async fn list_players(
     url: &str,
@@ -34,6 +34,17 @@ pub async fn create_player(
         .json::<PlayerInfo>()
         .await?;
     Ok(resp)
+}
+
+pub async fn list_classes(url: &str) -> Result<Vec<ClassInfo>, Box<dyn std::error::Error>> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{url}/players/classes"))
+        .send()
+        .await?
+        .json::<ClassListResponse>()
+        .await?;
+    Ok(resp.classes)
 }
 
 pub async fn select_player(

--- a/src/network/event.rs
+++ b/src/network/event.rs
@@ -28,6 +28,18 @@ pub struct PlayerListResponse {
     pub players: Vec<PlayerInfo>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassInfo {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassListResponse {
+    pub classes: Vec<ClassInfo>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParticipantInfo {
     pub id: i64,

--- a/src/network/server/handlers.rs
+++ b/src/network/server/handlers.rs
@@ -1,6 +1,8 @@
 pub mod player;
 
-pub use player::{player_create_handler, player_list_handler, player_select_handler};
+pub use player::{
+    player_classes_handler, player_create_handler, player_list_handler, player_select_handler,
+};
 
 use serde::Deserialize;
 

--- a/src/network/server/handlers/player.rs
+++ b/src/network/server/handlers/player.rs
@@ -9,9 +9,26 @@ use tracing::info;
 use crate::game::component::{Ability, Attribute};
 use crate::game::config::class_config::ClassConfig;
 use crate::game::{Entity, EntityType, Location, Player};
-use crate::network::event::{NetworkEvent, PlayerInfo, PlayerListResponse};
+use crate::network::event::{
+    ClassInfo, ClassListResponse, NetworkEvent, PlayerInfo, PlayerListResponse,
+};
 use crate::network::server::state::{AppState, PlayerCreateBody, PlayerListBody, PlayerSelectBody};
 use crate::persistence::{ability_repo, entity_repo, player_repo};
+
+pub async fn player_classes_handler(State(state): State<Arc<AppState>>) -> Json<ClassListResponse> {
+    info!("GET /players/classes");
+    let classes = state
+        .game_state
+        .classes
+        .iter()
+        .map(|(id, c)| ClassInfo {
+            id: id.clone(),
+            name: c.name.clone(),
+            description: c.description.clone(),
+        })
+        .collect();
+    Json(ClassListResponse { classes })
+}
 
 pub async fn player_list_handler(
     State(state): State<Arc<AppState>>,

--- a/src/network/server/router.rs
+++ b/src/network/server/router.rs
@@ -4,9 +4,9 @@ use axum::Router;
 use axum::routing::{get, post};
 
 use super::handlers::{
-    maps_reload_handler, ping_handler, player_create_handler, player_list_handler,
-    player_select_handler, send_interaction_handler, server_info_handler, session_end_handler,
-    session_start_handler, sse_handler,
+    maps_reload_handler, ping_handler, player_classes_handler, player_create_handler,
+    player_list_handler, player_select_handler, send_interaction_handler, server_info_handler,
+    session_end_handler, session_start_handler, sse_handler,
 };
 use super::state::AppState;
 
@@ -17,6 +17,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/ping", post(ping_handler))
         .route("/session/start", post(session_start_handler))
         .route("/session/end", post(session_end_handler))
+        .route("/players/classes", get(player_classes_handler))
         .route("/players/list", post(player_list_handler))
         .route("/players/create", post(player_create_handler))
         .route("/players/select", post(player_select_handler))

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,7 +5,7 @@ mod network_event_handler;
 pub use battle_state::{BattleFocus, BattleState};
 pub use conversation_state::ConversationState;
 
-use crate::network::event::PlayerInfo;
+use crate::network::event::{ClassInfo, PlayerInfo};
 
 #[derive(Debug, Clone)]
 pub struct AppMessage {
@@ -45,11 +45,19 @@ pub struct ConnectionState {
 }
 
 #[derive(Debug, Clone, Default)]
+pub struct ClassSelectState {
+    pub classes: Vec<ClassInfo>,
+    pub selected_index: usize,
+    pub active: bool,
+}
+
+#[derive(Debug, Clone, Default)]
 pub struct PlayerSelectState {
     pub players: Vec<PlayerInfo>,
     pub selected_index: usize,
     pub creating_player: bool,
     pub player_name_input: String,
+    pub class_select: ClassSelectState,
 }
 
 pub struct App {
@@ -148,6 +156,38 @@ impl App {
     pub fn cancel_create(&mut self) {
         self.player_select.creating_player = false;
         self.player_select.player_name_input.clear();
+    }
+
+    pub fn start_class_select(&mut self, classes: Vec<ClassInfo>) {
+        self.player_select.class_select.classes = classes;
+        self.player_select.class_select.selected_index = 0;
+        self.player_select.class_select.active = true;
+        self.player_select.creating_player = false;
+    }
+
+    pub fn cancel_class_select(&mut self) {
+        self.player_select.class_select.active = false;
+        self.player_select.creating_player = true;
+    }
+
+    pub fn class_select_next(&mut self) {
+        let total = self.player_select.class_select.classes.len();
+        if total > 0 {
+            self.player_select.class_select.selected_index =
+                (self.player_select.class_select.selected_index + 1) % total;
+        }
+    }
+
+    pub fn class_select_prev(&mut self) {
+        let total = self.player_select.class_select.classes.len();
+        if total > 0 {
+            self.player_select.class_select.selected_index =
+                if self.player_select.class_select.selected_index == 0 {
+                    total - 1
+                } else {
+                    self.player_select.class_select.selected_index - 1
+                };
+        }
     }
 }
 

--- a/src/tui/screens/player_select.rs
+++ b/src/tui/screens/player_select.rs
@@ -7,7 +7,7 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, Paragraph},
 };
 
-use crate::network::client::{create_player, select_player};
+use crate::network::client::{create_player, list_classes, select_player};
 use crate::tui::app::{App, GameMode};
 
 pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
@@ -16,32 +16,13 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
         return;
     }
 
+    if app.player_select.class_select.active {
+        handle_class_select_key(app, code).await;
+        return;
+    }
+
     if app.player_select.creating_player {
-        match code {
-            KeyCode::Esc => app.cancel_create(),
-            KeyCode::Backspace => {
-                app.player_select.player_name_input.pop();
-            }
-            KeyCode::Enter => {
-                let name = app.player_select.player_name_input.trim().to_string();
-                if !name.is_empty()
-                    && let (Some(url), Some(client_id)) = (
-                        app.connection.server_url.clone(),
-                        app.connection.client_id.clone(),
-                    )
-                    && let Ok(info) = create_player(&url, &client_id, &name, None).await
-                {
-                    let player_id = info.id;
-                    app.player_select.players.push(info);
-                    app.cancel_create();
-                    if select_player(&url, &client_id, player_id).await.is_ok() {
-                        app.mode = GameMode::Game;
-                    }
-                }
-            }
-            KeyCode::Char(c) => app.player_select.player_name_input.push(c),
-            _ => {}
-        }
+        handle_name_input_key(app, code).await;
         return;
     }
 
@@ -71,7 +52,122 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
     }
 }
 
+async fn handle_name_input_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Esc => app.cancel_create(),
+        KeyCode::Backspace => {
+            app.player_select.player_name_input.pop();
+        }
+        KeyCode::Enter => {
+            let name = app.player_select.player_name_input.trim().to_string();
+            if !name.is_empty()
+                && let (Some(url), Some(client_id)) = (
+                    app.connection.server_url.clone(),
+                    app.connection.client_id.clone(),
+                )
+                && let Ok(classes) = list_classes(&url).await
+            {
+                if classes.is_empty() {
+                    create_and_select(app, &url, &client_id, &name, None).await;
+                } else {
+                    app.start_class_select(classes);
+                }
+            }
+        }
+        KeyCode::Char(c) => app.player_select.player_name_input.push(c),
+        _ => {}
+    }
+}
+
+async fn handle_class_select_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Esc => app.cancel_class_select(),
+        KeyCode::Up => app.class_select_prev(),
+        KeyCode::Down => app.class_select_next(),
+        KeyCode::Enter => {
+            if let (Some(url), Some(client_id)) = (
+                app.connection.server_url.clone(),
+                app.connection.client_id.clone(),
+            ) {
+                let name = app.player_select.player_name_input.trim().to_string();
+                let class_id = app
+                    .player_select
+                    .class_select
+                    .classes
+                    .get(app.player_select.class_select.selected_index)
+                    .map(|c| c.id.clone());
+                if let Some(class_id) = class_id {
+                    create_and_select(app, &url, &client_id, &name, Some(&class_id)).await;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+async fn create_and_select(
+    app: &mut App,
+    url: &str,
+    client_id: &str,
+    name: &str,
+    class_id: Option<&str>,
+) {
+    if let Ok(info) = create_player(url, client_id, name, class_id).await {
+        let player_id = info.id;
+        app.player_select.players.push(info);
+        app.cancel_create();
+        if select_player(url, client_id, player_id).await.is_ok() {
+            app.mode = GameMode::Game;
+        }
+    }
+}
+
 pub fn render(frame: &mut Frame, app: &App) {
+    if app.player_select.class_select.active {
+        render_class_select(frame, app);
+    } else {
+        render_player_select(frame, app);
+    }
+}
+
+fn render_class_select(frame: &mut Frame, app: &App) {
+    let areas = Layout::vertical([Constraint::Fill(1), Constraint::Length(5)]).split(frame.area());
+
+    let title = "Select a Class (↑↓ to navigate, Enter to select, Esc to go back)";
+    let items: Vec<ListItem> = app
+        .player_select
+        .class_select
+        .classes
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let style = if i == app.player_select.class_select.selected_index {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(Span::styled(c.name.clone(), style)))
+        })
+        .collect();
+
+    let list = List::new(items).block(Block::default().title(title).borders(Borders::ALL));
+    frame.render_widget(list, areas[0]);
+
+    let description = app
+        .player_select
+        .class_select
+        .classes
+        .get(app.player_select.class_select.selected_index)
+        .and_then(|c| c.description.as_deref())
+        .unwrap_or("No description.");
+    let desc_widget = Paragraph::new(description)
+        .block(Block::default().title("Description").borders(Borders::ALL));
+    frame.render_widget(desc_widget, areas[1]);
+}
+
+fn render_player_select(frame: &mut Frame, app: &App) {
     let areas = Layout::vertical([Constraint::Fill(1), Constraint::Length(3)]).split(frame.area());
 
     let title = "Select a Player (↑↓ to navigate, Enter to select, Esc to cancel create)";


### PR DESCRIPTION
Adds an intermediate class selection screen to the new player creation flow. Previously, players were created with no class (hardcoded `None`); now after entering a name they browse available classes with descriptions before the player is committed to the server. Closes #146.

- New `GET /players/classes` server endpoint reads from `GameState.classes` and returns class names, IDs, and descriptions
- `ClassSelectState` added to `PlayerSelectState` tracks the active class list, selection index, and whether the screen is visible
- TUI key handling in `player_select.rs` gains a class-select branch (↑↓ navigate, Enter confirm, Esc return to name input with name preserved); falls back to immediate creation with `class_id: None` if the server returns no classes
- `render_class_select` renders a class list panel with a description panel below, following the same style as the existing player list

<details>
<summary>Agent Context</summary>

**Goal:** Insert a class selection step between name entry and player creation in the TUI new-player flow.

**Depends on:** Issue #144 (class config), Issue #145 (class_id in player create) — both already merged. `create_player` already accepted `class_id: Option<&str>` and the server already handled it via `resolve_class_data`; the only missing piece was UI + the classes endpoint.

**New server endpoint:** `GET /players/classes` in `src/network/server/handlers/player.rs` (`player_classes_handler`). Iterates `state.game_state.classes: HashMap<String, ClassConfig>` using the HashMap key as the class id (already resolved from file stem or explicit `id` field). Registered in `src/network/server/router.rs`.

**New network types** in `src/network/event.rs`: `ClassInfo { id, name, description: Option<String> }` and `ClassListResponse { classes: Vec<ClassInfo> }`.

**New client function** `list_classes(url)` in `src/network/client/player.rs`: GET to `/players/classes`, re-exported from `src/network/client.rs`.

**App state changes** in `src/tui/app.rs`: `ClassSelectState { classes, selected_index, active }` nested inside `PlayerSelectState.class_select`. New `App` methods: `start_class_select`, `cancel_class_select`, `class_select_next`, `class_select_prev`.

**TUI flow** (`src/tui/screens/player_select.rs`):
- `handle_key` dispatches to `handle_class_select_key` first (when `class_select.active`), then `handle_name_input_key` (when `creating_player`), then normal list navigation.
- Name entry Enter: fetches classes; if empty list → calls `create_and_select` with `None`; if non-empty → `start_class_select`.
- Class select Enter: reads `player_name_input` (preserved across transition) + selected class id → `create_and_select`.
- Esc from class select: `cancel_class_select` sets `creating_player = true`, restores name input with name intact.
- Shared `create_and_select` async fn avoids duplication between the no-classes path and the class-select confirm path.

**Rendering:** `render` routes to `render_class_select` or `render_player_select`. Class select layout: `Fill(1)` list + `Length(5)` description panel. Uses same `Color::Yellow + BOLD` highlight style as player list.

**Edge case:** Server with no classes configured → `list_classes` returns empty vec → skip class select, create with `class_id: None` (pre-existing behavior).

**Not in scope:** Persisting class association on the `Player` struct (class is applied once at creation time via entity attributes + abilities tables).
</details>