### PR TITLE
Fixes #174 Use AbilityReference in ClassConfig instead of inline Ability definitions

### DIFF
--- a/muds/basic/classes/cyborg.toml
+++ b/muds/basic/classes/cyborg.toml
@@ -1,5 +1,6 @@
 name = "Cyborg"
 description = "A cybernetically enhanced fighter with integrated energy weapons."
+innate_abilities = ["heat_beam", "electric_shot", "defend"]
 
 [[attributes]]
 definition_id = "hp"
@@ -12,5 +13,3 @@ definition_id = "mp"
 min_value = 0
 max_value = 60
 current_value = 60
-
-innate_abilities = ["heat_beam", "electric_shot"]

--- a/muds/basic/classes/cyborg.toml
+++ b/muds/basic/classes/cyborg.toml
@@ -13,36 +13,4 @@ min_value = 0
 max_value = 60
 current_value = 60
 
-[[innate_abilities]]
-id = "heat_beam"
-name = "Heat Beam"
-description = "Fires a focused beam of superheated energy that burns through armor."
-engagement_types = ["battle"]
-costs = []
-role = "attack"
-
-[[innate_abilities.effects]]
-name = "heat_damage"
-trigger_info = { type = "once" }
-
-[innate_abilities.effects.effect_type]
-type = "attribute_update"
-attribute_id = "hp"
-value = -15
-
-[[innate_abilities]]
-id = "electric_shot"
-name = "Electric Shot"
-description = "Discharges a bolt of electricity that arcs through the target."
-engagement_types = ["battle"]
-costs = []
-role = "attack"
-
-[[innate_abilities.effects]]
-name = "electric_damage"
-trigger_info = { type = "once" }
-
-[innate_abilities.effects.effect_type]
-type = "attribute_update"
-attribute_id = "hp"
-value = -12
+innate_abilities = ["heat_beam", "electric_shot"]

--- a/muds/basic/classes/survivor.toml
+++ b/muds/basic/classes/survivor.toml
@@ -13,35 +13,4 @@ min_value = 0
 max_value = 20
 current_value = 20
 
-[[innate_abilities]]
-id = "basic_attack"
-name = "Basic Attack"
-engagement_types = ["battle"]
-costs = []
-role = "attack"
-
-[[innate_abilities.effects]]
-name = "physical_damage"
-trigger_info = { type = "once" }
-
-[innate_abilities.effects.effect_type]
-type = "attribute_update"
-attribute_id = "hp"
-value = -8
-
-[[innate_abilities]]
-id = "sawed_off_shotgun"
-name = "Sawed-Off Shotgun"
-description = "A rusted sawed-off shotgun — unreliable, but devastating at close range."
-engagement_types = ["battle"]
-costs = []
-role = "attack"
-
-[[innate_abilities.effects]]
-name = "shotgun_blast"
-trigger_info = { type = "once" }
-
-[innate_abilities.effects.effect_type]
-type = "attribute_update"
-attribute_id = "hp"
-value = -20
+innate_abilities = ["basic_attack", "sawed_off_shotgun"]

--- a/muds/basic/classes/survivor.toml
+++ b/muds/basic/classes/survivor.toml
@@ -1,5 +1,6 @@
 name = "Survivor"
 description = "A scrappy melee brawler who clawed their way through the wasteland."
+innate_abilities = ["basic_attack", "sawed_off_shotgun", "defend"]
 
 [[attributes]]
 definition_id = "hp"
@@ -12,5 +13,3 @@ definition_id = "mp"
 min_value = 0
 max_value = 20
 current_value = 20
-
-innate_abilities = ["basic_attack", "sawed_off_shotgun"]

--- a/src/game/config.rs
+++ b/src/game/config.rs
@@ -28,8 +28,8 @@ pub use faction_config::FactionConfig;
 pub use game_loop_config::GameLoopConfig;
 pub use map_config::load_map;
 pub use map_loader::{
-    load_entities_into_db, load_factions_into_db, load_map_into_db, load_resources_into_db,
-    should_auto_load, sync_universe_config,
+    load_abilities, load_entities_into_db, load_factions_into_db, load_map_into_db,
+    load_resources_into_db, should_auto_load, sync_universe_config,
 };
 pub use mud_config::{MudConfig, SpawnConfig};
 pub use persona_parser::{

--- a/src/game/config/class_config.rs
+++ b/src/game/config/class_config.rs
@@ -1,4 +1,4 @@
-use crate::game::config::ability_config::Ability;
+use crate::game::config::ability_config::AbilityReference;
 use crate::game::config::entity_config::StartingAttribute;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -14,7 +14,7 @@ pub struct ClassConfig {
     #[serde(default)]
     pub attributes: Vec<StartingAttribute>,
     #[serde(default)]
-    pub innate_abilities: Vec<Ability>,
+    pub innate_abilities: Vec<AbilityReference>,
 }
 
 pub fn load_classes(config_dir: &Path) -> Result<HashMap<String, ClassConfig>, Box<dyn Error>> {
@@ -97,28 +97,13 @@ name = "Custom"
         let toml = r#"
 name = "Survivor"
 description = "A scrappy melee brawler."
+innate_abilities = ["basic_attack"]
 
 [[attributes]]
 definition_id = "hp"
 min_value = 0
 max_value = 120
 current_value = 120
-
-[[innate_abilities]]
-id = "basic_attack"
-name = "Basic Attack"
-engagement_types = ["battle"]
-costs = []
-role = "attack"
-
-[[innate_abilities.effects]]
-name = "physical_damage"
-trigger_info = { type = "once" }
-
-[innate_abilities.effects.effect_type]
-type = "attribute_update"
-attribute_id = "hp"
-value = -8
 "#;
         let config: ClassConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.name, "Survivor");
@@ -126,7 +111,6 @@ value = -8
         assert_eq!(config.attributes[0].definition_id, "hp");
         assert_eq!(config.attributes[0].max_value, 120);
         assert_eq!(config.innate_abilities.len(), 1);
-        assert_eq!(config.innate_abilities[0].id, "basic_attack");
-        assert_eq!(config.innate_abilities[0].effects.len(), 1);
+        assert_eq!(config.innate_abilities[0].0, "basic_attack");
     }
 }

--- a/src/game/config/map_loader.rs
+++ b/src/game/config/map_loader.rs
@@ -3,6 +3,7 @@ mod definition_sync;
 mod entity_sync;
 mod universe_sync;
 
+pub use ability_cache::build_ability_cache as load_abilities;
 pub use definition_sync::{load_factions_into_db, load_resources_into_db};
 pub use entity_sync::load_entities_into_db;
 pub use universe_sync::{load_map_into_db, should_auto_load};

--- a/src/game/game_state.rs
+++ b/src/game/game_state.rs
@@ -6,9 +6,10 @@ use sqlx::SqlitePool;
 use tokio::sync::RwLock;
 use tokio::sync::broadcast;
 
+use crate::game::component::Ability;
 use crate::game::config::{
     AttributeConfig, ClassConfig, EntityConfig, FactionConfig, MudConfig, ResourceConfig,
-    load_classes, load_entity_configs,
+    load_abilities, load_classes, load_entity_configs,
 };
 use crate::game::engagement::Engagements;
 use crate::game::entity::Entity;
@@ -32,6 +33,7 @@ pub struct GameState {
     pub faction_config: FactionConfig,
     pub resource_config: ResourceConfig,
     pub mud_config: MudConfig,
+    pub abilities: HashMap<String, Ability>,
     pub entity_configs: HashMap<String, EntityConfig>,
     pub classes: HashMap<String, ClassConfig>,
     pub active_entities: RwLock<HashMap<i64, Entity>>,
@@ -101,6 +103,12 @@ impl GameState {
             HashMap::new()
         };
 
+        let abilities = if let Some(dir) = config_dir {
+            load_abilities(dir).unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+
         let (message_tx, _) = broadcast::channel::<PlayerMessage>(512);
 
         Ok(Self {
@@ -110,6 +118,7 @@ impl GameState {
             faction_config,
             resource_config,
             mud_config,
+            abilities,
             entity_configs,
             classes,
             active_entities: RwLock::new(HashMap::new()),

--- a/src/network/server/handlers/player.rs
+++ b/src/network/server/handlers/player.rs
@@ -141,7 +141,19 @@ fn resolve_class_data(
             .classes
             .get(class_id)
             .ok_or(StatusCode::BAD_REQUEST)?;
-        Ok((class_attributes(class), class.innate_abilities.clone()))
+        let abilities = class
+            .innate_abilities
+            .iter()
+            .map(|r| {
+                state
+                    .game_state
+                    .abilities
+                    .get(&r.0)
+                    .cloned()
+                    .ok_or(StatusCode::BAD_REQUEST)
+            })
+            .collect::<Result<Vec<Ability>, StatusCode>>()?;
+        Ok((class_attributes(class), abilities))
     } else {
         Ok((default_player_attributes(), vec![]))
     }


### PR DESCRIPTION
Class configs previously embedded full `Ability` structs inline in TOML, duplicating definitions that already exist as standalone files under `muds/basic/abilities/`. This PR makes `ClassConfig.innate_abilities` use `Vec<AbilityReference>` (string IDs), consistent with how `EntityConfig` already works. Closes #174.

- `ClassConfig.innate_abilities` changed from `Vec<Ability>` to `Vec<AbilityReference>`, matching the existing `EntityConfig` pattern
- Class TOML files (`survivor.toml`, `cyborg.toml`) updated to reference abilities by ID instead of inline definitions
- `GameState` gains an `abilities: HashMap<String, Ability>` field loaded at startup from the config dir, used to resolve references in `resolve_class_data`
- Player creation handler updated to look up each `AbilityReference` in `game_state.abilities`, returning `BAD_REQUEST` if any ID is missing

<details>
<summary>Agent Context</summary>

**Goal:** Remove inline `Ability` struct duplication from class TOML configs by adopting the same `AbilityReference` (newtype `String`) pattern already used in `EntityConfig.innate_abilities` (`src/game/config/entity_config.rs:80`).

**Files changed:**
- `src/game/config/class_config.rs` — field type changed from `Vec<Ability>` to `Vec<AbilityReference>`; `class_config_round_trip` test updated to use `innate_abilities = ["basic_attack"]` format. Note: `innate_abilities` must appear *before* any `[[attributes]]` array-of-tables blocks in TOML, or the key is parsed as part of the last attributes entry.
- `muds/basic/classes/survivor.toml` — replaced two `[[innate_abilities]]` blocks with `innate_abilities = ["basic_attack", "sawed_off_shotgun", "defend"]` at the top of the file
- `muds/basic/classes/cyborg.toml` — replaced two `[[innate_abilities]]` blocks with `innate_abilities = ["heat_beam", "electric_shot", "defend"]` at the top of the file
- `src/game/config/map_loader.rs` — re-exported `build_ability_cache` as `pub load_abilities`
- `src/game/config.rs` — added `load_abilities` to the public config module exports
- `src/game/game_state.rs` — added `pub abilities: HashMap<String, Ability>` field; loaded via `load_abilities(config_dir)` in `GameState::load()`, same pattern as `load_classes`
- `src/network/server/handlers/player.rs` — `resolve_class_data` (line ~134) now resolves each `AbilityReference` via `state.game_state.abilities.get(&r.0)`, returns `StatusCode::BAD_REQUEST` if any ID is missing; `apply_class_abilities` signature and upsert logic unchanged

**Resolution pattern:** `build_ability_cache` in `src/game/config/map_loader/ability_cache.rs` walks `abilities/` dir, parses each TOML as an `Ability`, keys by relative path stem. `GameState.abilities` is this cache, making ability lookup O(1) at player creation time.

**TOML gotcha:** In TOML, a bare key placed after an `[[array-of-tables]]` header belongs to that array entry. `innate_abilities` must precede all `[[attributes]]` blocks to deserialize into `ClassConfig` (root level), not into the last `StartingAttribute`.

**Related:** `AbilityReference` defined at `src/game/config/ability_config/config.rs:46`. Entity resolution pattern in `src/game/config/map_loader/entity_sync.rs:97–122`.

</details>