### PR TITLE
Fixes #177 Add mudroom players list and players rm CLI commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,29 @@ pub enum Commands {
         #[arg(long)]
         reload_maps: bool,
     },
+    /// Player administration commands
+    Players {
+        #[command(subcommand)]
+        command: PlayersCommands,
+    },
+}
+
+#[derive(Subcommand, Debug, PartialEq)]
+pub enum PlayersCommands {
+    /// List all players in the server database
+    List {
+        /// Server name — identifies which database to use (matches server --name)
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Remove a player by name from the server database
+    Rm {
+        /// Player name to remove
+        player: String,
+        /// Server name — identifies which database to use (matches server --name)
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod paths;
 pub mod persistence;
 pub mod tui;
 
-use cli::{Cli, Commands};
+use cli::{Cli, Commands, PlayersCommands};
 
 #[derive(Default)]
 pub struct ServerConfig {}
@@ -20,8 +20,43 @@ pub async fn run_cli(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             reload_maps,
         }) => run_server(name, config, reload_maps, ServerConfig::default()).await,
         Some(Commands::Client { url, debug }) => run_client(url, debug).await,
+        Some(Commands::Players { command }) => run_players(command).await,
         None => run_client(None, false).await,
     }
+}
+
+async fn run_players(command: PlayersCommands) -> Result<(), Box<dyn std::error::Error>> {
+    use persistence::{entity_repo, player_repo};
+    paths::create_session_base_dirs().await?;
+    match command {
+        PlayersCommands::List { name } => {
+            let db = open_players_db(name).await?;
+            let players = player_repo::find_all(db.pool()).await?;
+            for p in players {
+                println!("{}\t{}\t{}", p.id, p.client_id, p.name);
+            }
+        }
+        PlayersCommands::Rm { player, name } => {
+            let db = open_players_db(name).await?;
+            let p = player_repo::find_by_name(db.pool(), &player)
+                .await?
+                .ok_or_else(|| format!("player '{player}' not found"))?;
+            entity_repo::delete(db.pool(), p.entity_id).await?;
+            println!("Player '{player}' removed.");
+        }
+    }
+    Ok(())
+}
+
+async fn open_players_db(
+    name: Option<String>,
+) -> Result<persistence::Database, Box<dyn std::error::Error>> {
+    let server_key = match name {
+        Some(n) => n,
+        None => paths::find_last_server_key()?
+            .ok_or("no server found — start the server at least once first")?,
+    };
+    Ok(persistence::Database::connect(&server_key).await?)
 }
 
 pub async fn run_server(

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -47,6 +47,32 @@ pub async fn create_session_base_dirs() -> StateResult<()> {
     Ok(())
 }
 
+pub fn find_last_server_key() -> StateResult<Option<String>> {
+    let dir = session_dir()?.join("server");
+    if !dir.exists() {
+        return Ok(None);
+    }
+    let mut latest: Option<(std::time::SystemTime, String)> = None;
+    for entry in std::fs::read_dir(&dir)?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let stem = match path.file_stem().and_then(|s| s.to_str()).map(String::from) {
+            Some(s) => s,
+            None => continue,
+        };
+        if let Ok(modified) = path.metadata().and_then(|m| m.modified()) {
+            match &latest {
+                None => latest = Some((modified, stem)),
+                Some((t, _)) if modified > *t => latest = Some((modified, stem)),
+                _ => {}
+            }
+        }
+    }
+    Ok(latest.map(|(_, key)| key))
+}
+
 pub fn find_config_dir() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
 

--- a/src/persistence/player_repo.rs
+++ b/src/persistence/player_repo.rs
@@ -69,6 +69,39 @@ pub async fn find_by_entity_id(
     }))
 }
 
+pub async fn find_all(pool: &SqlitePool) -> Result<Vec<Player>, PersistenceError> {
+    let rows: Vec<(i64, String, String, i64)> =
+        sqlx::query_as("SELECT id, client_id, name, entity_id FROM players")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(id, client_id, name, entity_id)| Player {
+            id,
+            client_id,
+            name,
+            entity_id,
+        })
+        .collect())
+}
+
+pub async fn find_by_name(
+    pool: &SqlitePool,
+    name: &str,
+) -> Result<Option<Player>, PersistenceError> {
+    let row: Option<(i64, String, String, i64)> =
+        sqlx::query_as("SELECT id, client_id, name, entity_id FROM players WHERE name = ?")
+            .bind(name)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(id, client_id, name, entity_id)| Player {
+        id,
+        client_id,
+        name,
+        entity_id,
+    }))
+}
+
 pub async fn delete(pool: &SqlitePool, id: i64) -> Result<(), PersistenceError> {
     sqlx::query("DELETE FROM players WHERE id = ?")
         .bind(id)
@@ -164,6 +197,46 @@ mod tests {
     async fn find_by_entity_id_returns_none_for_missing() {
         let db = Database::connect_in_memory().await.unwrap();
         let found = find_by_entity_id(db.pool(), 999).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_all_returns_all_players() {
+        let db = Database::connect_in_memory().await.unwrap();
+        let entity_id = setup(&db).await;
+        insert(db.pool(), "client1", "Alice", entity_id)
+            .await
+            .unwrap();
+
+        let players = find_all(db.pool()).await.unwrap();
+        assert_eq!(players.len(), 1);
+        assert_eq!(players[0].name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn find_all_returns_empty_when_no_players() {
+        let db = Database::connect_in_memory().await.unwrap();
+        let players = find_all(db.pool()).await.unwrap();
+        assert!(players.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_name_returns_player() {
+        let db = Database::connect_in_memory().await.unwrap();
+        let entity_id = setup(&db).await;
+        insert(db.pool(), "client1", "Alice", entity_id)
+            .await
+            .unwrap();
+
+        let found = find_by_name(db.pool(), "Alice").await.unwrap().unwrap();
+        assert_eq!(found.name, "Alice");
+        assert_eq!(found.client_id, "client1");
+    }
+
+    #[tokio::test]
+    async fn find_by_name_returns_none_for_missing() {
+        let db = Database::connect_in_memory().await.unwrap();
+        let found = find_by_name(db.pool(), "Nobody").await.unwrap();
         assert!(found.is_none());
     }
 


### PR DESCRIPTION
Adds two server-administration CLI subcommands that operate directly on the local SQLite database — no running server required. The most recently started server is used automatically, with an optional `--name` flag to target a specific server instance.

- New `mudroom players list [--name <server>]` command prints all players as tab-separated `id  client_id  name`
- New `mudroom players rm <player> [--name <server>]` command removes a player and their entity by name (cascade deletes attributes and interactions)
- `find_last_server_key()` added to `paths.rs` to detect the most recently modified server session JSON file under `~/.mudroom/session/server/`
- `find_all` and `find_by_name` added to `player_repo` with full test coverage

<details>
<summary>Agent Context</summary>

**Goal:** Closes #177. Two admin CLI subcommands for inspecting and cleaning up player records without needing a live server.

**Key design decision:** Commands connect directly to the SQLite DB rather than going over HTTP. This matches the "on the server" constraint — operators run these from the same machine the server lives on.

**Auto-detection logic:** `paths::find_last_server_key()` (`src/paths.rs`) scans `~/.mudroom/session/server/*.json` for the most recently `modified` file and returns its stem as the server key. Falls back to an error if no session files exist. If `--name` is provided on the subcommand, it bypasses auto-detection entirely.

**CLI changes** (`src/cli.rs`):
- Added `Commands::Players { command: PlayersCommands }` variant
- Added `PlayersCommands` enum with `List { name: Option<String> }` and `Rm { player: String, name: Option<String> }`
- `--name` is placed on each subcommand (not the parent) so `mudroom players list --name foo` works naturally

**Dispatch** (`src/lib.rs`):
- `run_players(command)` matches on `PlayersCommands`, calls `open_players_db(name)` helper
- `open_players_db` resolves the server key and calls `persistence::Database::connect`
- `Rm` calls `entity_repo::delete(pool, entity_id)` — FK cascade on the schema handles player row + attributes + interactions

**Repo additions** (`src/persistence/player_repo.rs`):
- `find_all`: `SELECT id, client_id, name, entity_id FROM players`
- `find_by_name`: `SELECT ... WHERE name = ?` — returns `Option<Player>`
- 4 new tests covering both functions

**No HTTP layer changes:** The earlier draft added admin endpoints and client functions; those were removed. The final implementation is entirely local.

**Cascade behavior:** `players.entity_id` has `ON DELETE CASCADE` from `entities`. Deleting the entity is sufficient; `player_repo::delete` is not called separately.

</details>