### PR TITLE
Fixes #181 Fix defend abilities not appearing in battle response phase

### DIFF
--- a/muds/basic/entities/zombie.toml
+++ b/muds/basic/entities/zombie.toml
@@ -3,6 +3,7 @@ factions = ["enemy"]
 
 name = "Zombie"
 description = "A shambling corpse, visbily decayed. Eyes completely white, no pupil to speak of."
+innate_abilities = ["basic_attack", "defend"]
 
 [battle_ai]
 ai_type = "simple_random"

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -14,9 +14,7 @@ pub mod timer;
 
 use std::collections::HashMap;
 
-pub use abilities::{
-    default_attack_ability, default_defend_ability, entity_innate_battle_abilities,
-};
+pub use abilities::entity_innate_battle_abilities;
 pub use ai::{BattleAiContext, run_battle_ai};
 pub use collection::Battles;
 pub use message::BattleMessage;

--- a/src/game/engagement/battle/abilities.rs
+++ b/src/game/engagement/battle/abilities.rs
@@ -1,7 +1,4 @@
-use crate::game::component::effect::{
-    Effect, EffectDescription, EffectScope, EffectType, TriggerInfo,
-};
-use crate::game::component::{Ability, AbilityRole, AbilityTargetType};
+use crate::game::component::{Ability, AbilityRole};
 use crate::game::engagement::EngagementType;
 use crate::game::entity::Entity;
 
@@ -40,56 +37,9 @@ pub fn battle_defend_abilities(entity: &Entity) -> Vec<Ability> {
         .collect()
 }
 
-pub fn default_defend_ability() -> Ability {
-    Ability {
-        id: "defend".to_string(),
-        name: "Defend".to_string(),
-        description: Some("Brace for impact, reducing incoming damage by 5.".to_string()),
-        effects: vec![Effect {
-            name: "damage_reduction".to_string(),
-            effect_type: EffectType::AttributeShield {
-                attribute_id: "hp".to_string(),
-                absorb_amount: 5,
-            },
-            trigger_info: TriggerInfo::Once,
-            description: EffectDescription::default(),
-            scope: EffectScope::default(),
-        }],
-        engagement_types: vec![EngagementType::Battle],
-        costs: vec![],
-        modifiers: vec![],
-        role: AbilityRole::Defend,
-        targets: vec![AbilityTargetType::SelfTarget],
-    }
-}
-
-pub fn default_attack_ability() -> Ability {
-    Ability {
-        id: "attack".to_string(),
-        name: "Attack".to_string(),
-        description: Some("A basic physical attack.".to_string()),
-        effects: vec![Effect {
-            name: "physical_damage".to_string(),
-            effect_type: EffectType::AttributeUpdate {
-                attribute_id: "hp".to_string(),
-                value: -10,
-            },
-            trigger_info: TriggerInfo::Once,
-            description: EffectDescription::default(),
-            scope: EffectScope::default(),
-        }],
-        engagement_types: vec![EngagementType::Battle],
-        costs: vec![],
-        modifiers: vec![],
-        role: AbilityRole::Attack,
-        targets: vec![AbilityTargetType::Opponent],
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::game::component::Location;
-    use crate::game::component::effect::{EffectType, TriggerInfo};
     use crate::game::entity::EntityType;
 
     use super::*;
@@ -114,22 +64,6 @@ mod tests {
             role,
             targets: vec![],
         }
-    }
-
-    #[test]
-    fn default_defend_ability_has_correct_structure() {
-        let ability = default_defend_ability();
-        assert_eq!(ability.id, "defend");
-        assert_eq!(ability.name, "Defend");
-        assert_eq!(ability.effects.len(), 1);
-        assert!(matches!(
-            ability.effects[0].effect_type,
-            EffectType::AttributeShield {
-                ref attribute_id,
-                absorb_amount: 5,
-            } if attribute_id == "hp"
-        ));
-        assert!(matches!(ability.effects[0].trigger_info, TriggerInfo::Once));
     }
 
     #[test]

--- a/src/game/engagement/battle/ai.rs
+++ b/src/game/engagement/battle/ai.rs
@@ -83,8 +83,12 @@ pub fn pick_random<T>(items: &[T]) -> Option<&T> {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::game::component::Location;
+    use crate::game::component::effect::{
+        Effect, EffectDescription, EffectScope, EffectType, TriggerInfo,
+    };
+    use crate::game::component::{Ability, AbilityRole, AbilityTargetType, Location};
     use crate::game::config::BattleAiConfig;
+    use crate::game::engagement::EngagementType;
     use crate::game::entity::{Entity, EntityType};
 
     use super::*;
@@ -97,9 +101,36 @@ mod tests {
         }
     }
 
+    fn make_ability(id: &str, role: AbilityRole, target: AbilityTargetType) -> Ability {
+        Ability {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            effects: vec![Effect {
+                name: "dmg".to_string(),
+                effect_type: EffectType::AttributeUpdate {
+                    attribute_id: "hp".to_string(),
+                    value: -5,
+                },
+                trigger_info: TriggerInfo::Once,
+                description: EffectDescription::default(),
+                scope: EffectScope::default(),
+            }],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+            role,
+            targets: vec![target],
+        }
+    }
+
     fn make_entity(id: i64, ai_type: BattleAiType) -> Entity {
         let mut e = Entity::new(id, EntityType::Enemy, test_location());
         e.battle_ai = BattleAiConfig { ai_type };
+        e.innate_abilities = vec![
+            make_ability("attack", AbilityRole::Attack, AbilityTargetType::Opponent),
+            make_ability("defend", AbilityRole::Defend, AbilityTargetType::SelfTarget),
+        ];
         e
     }
 

--- a/src/game/engagement/battle/ai/simple_random.rs
+++ b/src/game/engagement/battle/ai/simple_random.rs
@@ -1,7 +1,6 @@
 use crate::game::engagement::battle::abilities::{
     battle_attack_abilities, battle_defend_abilities,
 };
-use crate::game::engagement::battle::{default_attack_ability, default_defend_ability};
 use crate::game::entity::Entity;
 
 use super::AiAction;
@@ -10,17 +9,13 @@ use super::pick_random;
 pub fn plan_attack(entity: &Entity, targets: &[i64]) -> Option<AiAction> {
     let &target_id = pick_random(targets)?;
     let attacks = battle_attack_abilities(entity);
-    let ability = pick_random(&attacks)
-        .cloned()
-        .unwrap_or_else(default_attack_ability);
+    let ability = pick_random(&attacks).cloned()?;
     Some((entity.id, ability, target_id, entity.attributes.clone()))
 }
 
 pub fn plan_defend(entity: &Entity) -> Option<AiAction> {
     let defends = battle_defend_abilities(entity);
-    let ability = pick_random(&defends)
-        .cloned()
-        .unwrap_or_else(default_defend_ability);
+    let ability = pick_random(&defends).cloned()?;
     Some((entity.id, ability, entity.id, entity.attributes.clone()))
 }
 
@@ -83,12 +78,10 @@ mod tests {
     }
 
     #[test]
-    fn plan_attack_falls_back_to_default_when_no_attack_abilities() {
+    fn plan_attack_returns_none_when_no_attack_abilities() {
         let entity = make_enemy(1);
         let targets = vec![2_i64];
-        let (_, ability, target, _) = plan_attack(&entity, &targets).unwrap();
-        assert_eq!(ability.id, "attack");
-        assert_eq!(target, 2);
+        assert!(plan_attack(&entity, &targets).is_none());
     }
 
     #[test]
@@ -108,16 +101,8 @@ mod tests {
     }
 
     #[test]
-    fn plan_defend_falls_back_to_default_when_no_defend_abilities() {
+    fn plan_defend_returns_none_when_no_defend_abilities() {
         let entity = make_enemy(1);
-        let (_, ability, target, _) = plan_defend(&entity).unwrap();
-        assert_eq!(ability.id, "defend");
-        assert_eq!(target, 1);
-    }
-
-    #[test]
-    fn plan_defend_always_returns_some() {
-        let entity = make_enemy(42);
-        assert!(plan_defend(&entity).is_some());
+        assert!(plan_defend(&entity).is_none());
     }
 }

--- a/src/game/engagement/battle/collection.rs
+++ b/src/game/engagement/battle/collection.rs
@@ -97,8 +97,8 @@ impl Battles {
                         Some(BattleAiContext {
                             engagement_id: e.id,
                             phase: battle.turn_phase.clone(),
-                            planning_ids: battle.planning_ids(),
-                            responding_ids: battle.responding_ids(),
+                            planning_ids: battle.unacted_planning_ids(),
+                            responding_ids: battle.unacted_responding_ids(),
                         })
                     }
                     _ => None,

--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -63,6 +63,20 @@ impl BattleEngagement {
             .collect()
     }
 
+    pub fn unacted_planning_ids(&self) -> Vec<i64> {
+        self.planning_ids()
+            .into_iter()
+            .filter(|id| !self.action_queue.contains_key(id))
+            .collect()
+    }
+
+    pub fn unacted_responding_ids(&self) -> Vec<i64> {
+        self.responding_ids()
+            .into_iter()
+            .filter(|id| !self.action_queue.contains_key(id))
+            .collect()
+    }
+
     /// Queue an ability for the caster targeting the given entity. Validates and tracks resource
     /// costs for potential refund. Returns false if the caster lacks sufficient resources.
     pub fn queue_ability(

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -10,7 +10,9 @@ use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
 use crate::game::{GameState, messaging};
 
 use super::resolution;
-use super::{BattleMessage, BattlePhase, BattleTick, QueuedAbility};
+use super::{
+    BattleMessage, BattlePhase, BattleTick, QueuedAbility, entity_innate_battle_abilities,
+};
 use super::{loot, timer};
 
 struct BattleTickOutcome {
@@ -109,7 +111,7 @@ async fn handle_tick(
         .cloned()
         .collect();
 
-    let player_ids = find_participant_player_ids(game_state, &all_ids).await;
+    let player_pairs = find_participant_player_ids(game_state, &all_ids).await;
 
     let countdown_ticks = max_engage_ticks.saturating_sub(result.ticks_in_phase);
     let tick_rate_ms = game_state.mud_config.game_loop.tick_rate_ms;
@@ -126,15 +128,24 @@ async fn handle_tick(
     };
     let update = build_battle_update(game_state, params).await;
 
-    for &pid in &player_ids {
-        messaging::battle_update(&game_state.message_tx, pid, update.clone());
+    {
+        let entities = game_state.active_entities.read().await;
+        for &(pid, entity_id) in &player_pairs {
+            let available_abilities = entities
+                .get(&entity_id)
+                .map(entity_innate_battle_abilities)
+                .unwrap_or_default();
+            let mut player_update = update.clone();
+            player_update.available_abilities = available_abilities;
+            messaging::battle_update(&game_state.message_tx, pid, player_update);
+        }
     }
 
     BattleTickOutcome {
         engagement_id,
         all_participant_ids: all_ids,
         dead_entity_ids: dead_ids,
-        player_ids,
+        player_ids: player_pairs.into_iter().map(|(pid, _)| pid).collect(),
     }
 }
 
@@ -342,12 +353,15 @@ async fn clear_active_effects(game_state: &Arc<GameState>, entity_ids: &[i64]) {
     }
 }
 
-async fn find_participant_player_ids(game_state: &Arc<GameState>, entity_ids: &[i64]) -> Vec<i64> {
+async fn find_participant_player_ids(
+    game_state: &Arc<GameState>,
+    entity_ids: &[i64],
+) -> Vec<(i64, i64)> {
     let players = game_state.active_players.read().await;
     players
         .values()
         .filter(|p| entity_ids.contains(&p.entity_id))
-        .map(|p| p.id)
+        .map(|p| (p.id, p.entity_id))
         .collect()
 }
 
@@ -403,5 +417,6 @@ async fn build_battle_update(
         messages: params.messages,
         countdown_secs: params.countdown_secs,
         max_turn_secs: params.max_turn_secs,
+        available_abilities: vec![],
     }
 }

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -120,9 +120,7 @@ async fn dispatch_queue_ability(
             .innate_abilities
             .iter()
             .find(|a| a.id == ability_id)
-            .cloned()
-            .or_else(|| (ability_id == "attack").then(battle::default_attack_ability))
-            .or_else(|| (ability_id == "defend").then(battle::default_defend_ability));
+            .cloned();
         (ability, entity.attributes.clone())
     };
     let Some(ability) = ability_opt else {

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -5,9 +5,7 @@ use tracing;
 
 use crate::game::component::attribute_definition::AttributeType;
 use crate::game::component::faction_relations::FactionRelation;
-use crate::game::engagement::battle::{
-    BattlePhase, default_attack_ability, default_defend_ability, entity_innate_battle_abilities,
-};
+use crate::game::engagement::battle::{BattlePhase, entity_innate_battle_abilities};
 use crate::game::entity::Entity;
 use crate::game::messaging::{BattleParticipantInfo, BattleStartedMessage};
 use crate::game::player::Player;
@@ -133,14 +131,10 @@ pub(super) async fn build_battle_started_message(
 
     let participant_infos = build_participant_infos(participants, &entities, &players, &hp_attr_id);
 
-    let mut available_abilities = entities
+    let available_abilities = entities
         .get(&player.entity_id)
         .map(entity_innate_battle_abilities)
         .unwrap_or_default();
-    if available_abilities.is_empty() {
-        available_abilities.push(default_attack_ability());
-        available_abilities.push(default_defend_ability());
-    }
 
     let mut turn_order: Vec<i64> = participants.values().flatten().copied().collect();
     turn_order.sort_unstable();

--- a/src/game/messaging.rs
+++ b/src/game/messaging.rs
@@ -42,6 +42,7 @@ pub struct BattleUpdateMessage {
     pub messages: Vec<BattleMessage>,
     pub countdown_secs: u64,
     pub max_turn_secs: u64,
+    pub available_abilities: Vec<Ability>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/network/server/message_relay.rs
+++ b/src/network/server/message_relay.rs
@@ -113,7 +113,7 @@ fn battle_update_snapshot(data: BattleUpdateMessage) -> BattleSnapshot {
         turn_order: vec![],
         countdown_secs: data.countdown_secs,
         max_turn_secs: data.max_turn_secs,
-        available_abilities: vec![],
+        available_abilities: data.available_abilities,
     }
 }
 

--- a/src/persistence/ability_repo.rs
+++ b/src/persistence/ability_repo.rs
@@ -24,9 +24,18 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
     let targets_json = serde_json::to_string(&ability.targets).unwrap_or_default();
     let role_str = ability_role_to_str(&ability.role);
     sqlx::query(
-        "INSERT OR REPLACE INTO abilities \
+        "INSERT INTO abilities \
          (id, name, description, effects_json, costs_json, modifiers_json, engagement_types_json, role, targets_json) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(id) DO UPDATE SET \
+             name = excluded.name, \
+             description = excluded.description, \
+             effects_json = excluded.effects_json, \
+             costs_json = excluded.costs_json, \
+             modifiers_json = excluded.modifiers_json, \
+             engagement_types_json = excluded.engagement_types_json, \
+             role = excluded.role, \
+             targets_json = excluded.targets_json",
     )
     .bind(&ability.id)
     .bind(&ability.name)

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -137,6 +137,7 @@ impl App {
         battle.snapshot.phase = snapshot.phase;
         battle.snapshot.countdown_secs = snapshot.countdown_secs;
         battle.snapshot.max_turn_secs = snapshot.max_turn_secs;
+        battle.snapshot.available_abilities = snapshot.available_abilities;
         battle.message_log.extend(messages);
     }
 }


### PR DESCRIPTION
## Summary

- `BattleUpdateMessage` now carries `available_abilities` and is populated per-player each tick, so the TUI ability list refreshes on every phase transition (previously frozen at `BattleStarted`)
- Removed `default_attack_ability`/`default_defend_ability` fallbacks — entities must have abilities configured in TOML; removed the flawed fallback in `room_threats.rs` that silently dropped `defend` once any class ability existed
- Fixed AI queuing the same action 1000× per timer expiry by filtering already-queued entities from AI contexts via `unacted_planning_ids`/`unacted_responding_ids`
- Fixed `ability_repo::upsert` using `INSERT OR REPLACE` which CASCADE-deleted `entity_abilities` rows for any shared ability (e.g. `defend` used by both zombie and madman); switched to `ON CONFLICT DO UPDATE SET` to update in-place — this also fixes the same data loss in `players reset` and player-select flows
- Added `innate_abilities` config to zombie

## Test plan

- [ ] Start server + client, create/select a player with a class
- [ ] Enter dark corridor — battle starts with zombie and madman
- [ ] Planning phase shows attack abilities
- [ ] Response phase shows defend ability
- [ ] Enemies act once per phase (no 1000× pileup on timer expiry)
- [ ] After `--reload-maps`, both zombie and madman have their correct abilities in `entity_abilities` (verify with `sqlite3`)
- [ ] `mudroom players reset <name> <class>` does not nuke other entities' abilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)