### PR TITLE
Fixes #185 Limit battle ability selection to one per phase with replacement

### DIFF
--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -15,7 +15,7 @@ pub struct BattleEngagement {
     pub factions: Vec<String>,
     pub participants: HashMap<String, Vec<i64>>,
     pub turn_phase: BattlePhase,
-    action_queue: HashMap<i64, Vec<QueuedAbility>>,
+    action_queue: HashMap<i64, QueuedAbility>,
     ticks_in_phase: u64,
     turn_count: u64,
     pending_costs: HashMap<i64, Vec<(String, i64)>>,
@@ -107,20 +107,18 @@ impl BattleEngagement {
                 (resource_id.clone(), *amount)
             })
             .collect();
+        self.pending_costs.remove(&caster_id);
         if !tracked.is_empty() {
-            self.pending_costs
-                .entry(caster_id)
-                .or_default()
-                .extend(tracked);
+            self.pending_costs.insert(caster_id, tracked);
         }
-        self.action_queue
-            .entry(caster_id)
-            .or_default()
-            .push(QueuedAbility {
+        self.action_queue.insert(
+            caster_id,
+            QueuedAbility {
                 caster_id,
                 ability,
                 target_id,
-            });
+            },
+        );
         true
     }
 
@@ -206,7 +204,7 @@ impl BattleEngagement {
                     out.messages.push(BattleMessage::PhaseChange {
                         phase: next.clone(),
                     });
-                    out.pending_actions = self.action_queue.values().flatten().cloned().collect();
+                    out.pending_actions = self.action_queue.values().cloned().collect();
                     self.turn_phase = next;
                     self.ticks_in_phase = 0;
                 }
@@ -230,7 +228,7 @@ impl BattleEngagement {
                 out.resolution_queue = self
                     .action_queue
                     .drain()
-                    .flat_map(|(_, abilities)| abilities)
+                    .map(|(_, ability)| ability)
                     .collect();
                 self.pending_costs.clear();
                 if !self.factions.is_empty() {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,7 +2,7 @@ mod battle_state;
 mod conversation_state;
 mod network_event_handler;
 
-pub use battle_state::{BattleFocus, BattleState};
+pub use battle_state::{BattleFocus, BattleState, QueuedAbilityInfo};
 pub use conversation_state::ConversationState;
 
 use crate::network::event::{ClassInfo, PlayerInfo};

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -9,6 +9,12 @@ pub enum BattleFocus {
 }
 
 #[derive(Debug, Clone)]
+pub struct QueuedAbilityInfo {
+    pub ability_id: String,
+    pub target_id: i64,
+}
+
+#[derive(Debug, Clone)]
 pub struct TargetDialog {
     pub pending_ability_id: String,
     pub selected_index: usize,
@@ -25,7 +31,7 @@ pub struct BattleState {
     pub entity_scroll: usize,
     pub focus: BattleFocus,
     pub dialog: Option<TargetDialog>,
-    pub has_queued_defend: bool,
+    pub queued_ability: Option<QueuedAbilityInfo>,
 }
 
 impl BattleState {
@@ -39,7 +45,7 @@ impl BattleState {
             entity_scroll: 0,
             focus: BattleFocus::Abilities,
             dialog: None,
-            has_queued_defend: false,
+            queued_ability: None,
         }
     }
 

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -1,4 +1,4 @@
-use crate::game::engagement::battle::{BattleMessage, BattlePhase};
+use crate::game::engagement::battle::BattleMessage;
 use crate::game::messaging::ConversationKind;
 use crate::network::NetworkEvent;
 use crate::network::event::BattleSnapshot;
@@ -129,9 +129,7 @@ impl App {
         }
         if battle.snapshot.phase != snapshot.phase {
             battle.selected_ability_index = 0;
-            if matches!(&snapshot.phase, BattlePhase::Planning { .. }) {
-                battle.has_queued_defend = false;
-            }
+            battle.queued_ability = None;
         }
         battle.snapshot.participants = snapshot.participants;
         battle.snapshot.phase = snapshot.phase;

--- a/src/tui/screens/battle/keys.rs
+++ b/src/tui/screens/battle/keys.rs
@@ -1,9 +1,8 @@
 use crossterm::event::{KeyCode, KeyModifiers};
 
-use crate::game::engagement::battle::BattlePhase;
 use crate::game::{Interaction, TurnAction};
 use crate::network::client::send_interaction;
-use crate::tui::app::{App, BattleFocus, GameMode};
+use crate::tui::app::{App, BattleFocus, GameMode, QueuedAbilityInfo};
 
 pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
     if app.battle.as_ref().is_some_and(|b| b.dialog.is_some()) {
@@ -108,15 +107,18 @@ async fn handle_dialog_confirm(app: &mut App) {
     let client_id = client_id.to_owned();
     if let Some(target_id) = target_id {
         let action = Interaction::EngagementAction(TurnAction::QueueAbility {
-            ability_id,
+            ability_id: ability_id.clone(),
             target_id,
         });
         let _ = send_interaction(&url, &client_id, &action).await;
+        if let Some(battle) = &mut app.battle {
+            battle.queued_ability = Some(QueuedAbilityInfo {
+                ability_id,
+                target_id,
+            });
+        }
     }
     if let Some(battle) = &mut app.battle {
-        if matches!(&battle.snapshot.phase, BattlePhase::Response { .. }) {
-            battle.has_queued_defend = true;
-        }
         battle.close_target_dialog();
     }
 }

--- a/src/tui/screens/battle/render.rs
+++ b/src/tui/screens/battle/render.rs
@@ -127,6 +127,10 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
     };
 
     let filtered = battle.filtered_abilities();
+    let queued_id = battle
+        .queued_ability
+        .as_ref()
+        .map(|q| q.ability_id.as_str());
     let items: Vec<ListItem> = filtered
         .iter()
         .enumerate()
@@ -143,10 +147,15 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
-            let label = if cost_str.is_empty() {
+            let base_label = if cost_str.is_empty() {
                 ability.name.clone()
             } else {
                 format!("{} ({})", ability.name, cost_str)
+            };
+            let label = if queued_id == Some(ability.id.as_str()) {
+                format!("\u{25cf} {base_label}")
+            } else {
+                base_label
             };
             if i == battle.selected_ability_index && is_focused {
                 ListItem::new(label).style(
@@ -161,10 +170,10 @@ fn render_abilities_panel(frame: &mut Frame, battle: &BattleState, area: Rect) {
         .collect();
 
     let title = match battle.ability_role_label() {
-        Some("Defend") if battle.has_queued_defend => Line::from(vec![
-            Span::raw("Abilities [Defend] "),
+        Some(label) if battle.queued_ability.is_some() => Line::from(vec![
+            Span::raw(format!("Abilities [{label}] ")),
             Span::styled(
-                "\u{25cf} Defending",
+                "\u{25cf} Queued",
                 Style::default()
                     .fg(Color::Cyan)
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
Enforces a single queued ability per entity per battle phase, replacing any prior selection rather than accumulating. This closes #185 and eliminates the multi-cast bug where a player could fire several abilities in one resolution step.

- Server-side `action_queue` changed from `HashMap<i64, Vec<QueuedAbility>>` to `HashMap<i64, QueuedAbility>`, so re-queuing replaces the previous entry and its tracked costs
- TUI's partial `has_queued_defend` flag replaced with a unified `queued_ability: Option<QueuedAbilityInfo>` that covers both Planning and Response phases, cleared on any phase transition
- Battle screen now shows a `● Queued` indicator in the abilities panel title and prefixes the queued ability row with `●` for both attack and defend phases

<details>
<summary>Agent Context</summary>

**Goal:** One ability per entity per phase. Re-selecting replaces the queued choice; the server never resolves more than one ability per entity from a single phase.

**Files changed:**
- `src/game/engagement/battle/state.rs` — `BattleEngagement.action_queue` type changed; `queue_ability()` now calls `pending_costs.remove(&caster_id)` before `insert` (replaces costs, not accumulates), then `action_queue.insert(...)` instead of `push`; `advance_phase()` Planning branch uses `.values().cloned()` and Resolution branch uses `.map(|(_, a)| a)` to match the flat `QueuedAbility` value type
- `src/tui/app/battle_state.rs` — New `QueuedAbilityInfo { ability_id: String, target_id: i64 }` struct; `BattleState.has_queued_defend: bool` removed, replaced with `queued_ability: Option<QueuedAbilityInfo>`
- `src/tui/app.rs` — Re-exports `QueuedAbilityInfo` alongside `BattleState`/`BattleFocus`
- `src/tui/app/network_event_handler.rs` — `handle_battle_update()` drops the `if matches!(Planning)` guard; now clears `queued_ability = None` on any phase change; removed unused `BattlePhase` import
- `src/tui/screens/battle/keys.rs` — `handle_dialog_confirm()` clones `ability_id` before moving into `TurnAction::QueueAbility`, stores `QueuedAbilityInfo` on confirm for both Planning and Response; removed `BattlePhase` import and old Response-only `has_queued_defend` block
- `src/tui/screens/battle/render.rs` — `render_abilities_panel()` computes `queued_id` from `battle.queued_ability`; list items prefixed with `●` when matched; title uses `Some(label) if battle.queued_ability.is_some()` pattern instead of `Some("Defend") if has_queued_defend`

**Key decisions:**
- `pending_costs` is now replaced (not extended) on re-queue — old costs are removed via `remove()` before the new entry is inserted, so `refund_all_costs()` always sees only the current ability's costs
- `all_submitted` check (`contains_key`) is unaffected by the type change — still works correctly with single-entry map
- Visual indicator uses the same `●` glyph in both the list item and the panel title for consistency; title label is dynamic (`Attack`/`Defend`) rather than hardcoded
- `queued_ability` is cleared on *any* phase transition (not just Planning entry) so the UI never shows a stale queued indicator

**Related:** This is a prerequisite for clean behavior when #182 (skip phase) is implemented.

</details>