### PR TITLE
Fixes #161 Route room threat check through interaction mailbox on player activation

### DIFF
--- a/src/game/component/interaction.rs
+++ b/src/game/component/interaction.rs
@@ -19,6 +19,7 @@ pub enum Interaction {
     EndConversation,
     JoinBattle { engagement_id: i64 },
     LeaveBattle { engagement_id: i64 },
+    CheckRoomThreats { room_id: String },
 }
 
 #[cfg(test)]

--- a/src/game/game_loop/activations.rs
+++ b/src/game/game_loop/activations.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use crate::game::GameState;
+use crate::game::Interaction;
 use crate::game::game_state::PendingActivation;
-use crate::game::interaction::room_threats;
 use crate::persistence::Database;
 
 pub async fn process(game_state: &Arc<GameState>, db: &Database) {
@@ -35,5 +35,11 @@ async fn apply_activation(
         tracing::error!(error = %e, "Failed to sync active entities on player activation");
     }
 
-    room_threats::check_room_hostility(game_state, &activation.player, &room_id).await;
+    game_state
+        .mailboxes
+        .push(
+            activation.player.entity_id,
+            Interaction::CheckRoomThreats { room_id },
+        )
+        .await;
 }

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -61,6 +61,9 @@ async fn dispatch_interaction(
         Interaction::LeaveBattle { .. } => {
             dispatch_leave_battle(game_state, player).await;
         }
+        Interaction::CheckRoomThreats { room_id } => {
+            room_threats::check_room_hostility(game_state, player, &room_id).await;
+        }
     }
 }
 


### PR DESCRIPTION
Removes a direct call to `check_room_hostility` from the game loop's activation phase and routes it through the mailbox/interaction system instead, closing #161. This ensures battles are always started from within the interaction dispatch flow, consistent with how movement handles the same check.

- New `CheckRoomThreats { room_id }` variant added to the `Interaction` enum
- `apply_activation` now pushes `CheckRoomThreats` into the player's mailbox rather than calling `check_room_hostility` directly
- `dispatch_interaction` handles the new variant by delegating to `room_threats::check_room_hostility`, matching the pattern used in movement processing

<details>
<summary>Agent Context</summary>

**Goal:** Remove `check_room_hostility` from the activations phase and route it through the interaction system.

**Problem:** `src/game/game_loop/activations.rs:38` was calling `room_threats::check_room_hostility` directly from `apply_activation`. This function can call `game_state.engagements.add_battle()`, creating a battle engagement from the activations phase rather than the interactions phase — bypassing the interaction dispatch system.

**Correct pattern reference:** `src/game/interaction/movement.rs:93` calls the same function correctly from within the interaction handler.

**Fix:**
- `src/game/component/interaction.rs`: Added `CheckRoomThreats { room_id: String }` variant (serde snake_case: `check_room_threats`)
- `src/game/game_loop/activations.rs`: Replaced direct `room_threats::check_room_hostility` call with `game_state.mailboxes.push(entity_id, Interaction::CheckRoomThreats { room_id })`. Removed `room_threats` import, added `Interaction` import.
- `src/game/interaction.rs`: Added match arm for `Interaction::CheckRoomThreats { room_id }` → `room_threats::check_room_hostility(game_state, player, &room_id)`.

**Timing preserved:** `activations::process` runs before `interactions::process` within the same game loop tick, so the `CheckRoomThreats` interaction is processed in the same tick it is queued — no behavioral delay.

**Related:** Issue #161 notes this is filed alongside a companion `register_player_in_game_state` issue; both stem from the same `activate_player` call chain.

</details>