### PR TITLE
Fixes #162 Route SSE disconnect cleanup through interaction mailbox

### DIFF
--- a/src/game/component/interaction.rs
+++ b/src/game/component/interaction.rs
@@ -20,6 +20,7 @@ pub enum Interaction {
     JoinBattle { engagement_id: i64 },
     LeaveBattle { engagement_id: i64 },
     CheckRoomThreats { room_id: String },
+    PlayerDisconnected,
 }
 
 #[cfg(test)]

--- a/src/game/interaction.rs
+++ b/src/game/interaction.rs
@@ -1,5 +1,6 @@
 pub mod conversation;
 pub mod help;
+pub mod lifecycle;
 pub mod look;
 pub mod movement;
 pub mod room_threats;
@@ -63,6 +64,9 @@ async fn dispatch_interaction(
         }
         Interaction::CheckRoomThreats { room_id } => {
             room_threats::check_room_hostility(game_state, player, &room_id).await;
+        }
+        Interaction::PlayerDisconnected => {
+            lifecycle::player_disconnected(game_state, player).await;
         }
     }
 }

--- a/src/game/interaction/lifecycle.rs
+++ b/src/game/interaction/lifecycle.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use crate::game::GameState;
+use crate::game::engagement::battle;
+use crate::game::player::Player;
+
+pub async fn player_disconnected(game_state: &Arc<GameState>, player: &Player) {
+    if let Some((engagement_id, surviving)) =
+        battle::participants::remove_entity(&game_state.engagements.battles, player.entity_id).await
+        && surviving <= 1
+    {
+        game_state.engagements.battles.conclude(engagement_id).await;
+        game_state.engagements.battles.remove(engagement_id).await;
+    }
+
+    game_state
+        .active_entities
+        .write()
+        .await
+        .remove(&player.entity_id);
+    game_state
+        .active_players
+        .write()
+        .await
+        .remove(&player.client_id);
+    game_state.mailboxes.remove(player.entity_id).await;
+}

--- a/src/network/server/state.rs
+++ b/src/network/server/state.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use crate::game::GameState;
-use crate::game::engagement::battle;
+use crate::game::component::Interaction;
 use crate::network::event::NetworkEvent;
 use crate::network::session::ServerSession;
 use crate::persistence::Database;
@@ -44,31 +44,19 @@ impl Drop for SseCleanupGuard {
         let game_state = self.game_state.clone();
         tokio::spawn(async move {
             connections.write().await.remove(&client_id);
-            info!(client_id = %client_id, "SSE disconnected — session ended");
-            cleanup_player_battle(&game_state, &client_id).await;
-            game_state.active_players.write().await.remove(&client_id);
+            info!(client_id = %client_id, "SSE disconnected — queuing cleanup");
+            let entity_id = {
+                let players = game_state.active_players.read().await;
+                players.get(&client_id).map(|p| p.entity_id)
+            };
+            if let Some(entity_id) = entity_id {
+                game_state
+                    .mailboxes
+                    .push(entity_id, Interaction::PlayerDisconnected)
+                    .await;
+            }
         });
     }
-}
-
-async fn cleanup_player_battle(game_state: &GameState, client_id: &str) {
-    let entity_id = {
-        let players = game_state.active_players.read().await;
-        let Some(player) = players.get(client_id) else {
-            return;
-        };
-        player.entity_id
-    };
-
-    if let Some((engagement_id, surviving)) =
-        battle::participants::remove_entity(&game_state.engagements.battles, entity_id).await
-        && surviving <= 1
-    {
-        game_state.engagements.battles.conclude(engagement_id).await;
-        game_state.engagements.battles.remove(engagement_id).await;
-    }
-
-    game_state.active_entities.write().await.remove(&entity_id);
 }
 
 // Stream wrapper that keeps the guard alive until the stream is dropped.


### PR DESCRIPTION
`SseCleanupGuard::drop` was directly mutating `active_players`, `active_entities`, and engagement state from a network-layer drop handler, racing with concurrent game loop ticks. This PR routes client-disconnect cleanup through the existing interaction/mailbox system so all game state mutation happens inside the game loop, serialized at tick boundaries. Closes #162.

- New `PlayerDisconnected` interaction variant pushed to the entity mailbox on SSE drop instead of mutating state inline
- New `src/game/interaction/lifecycle.rs` module handles the disconnect: removes the entity from battles, `active_entities`, `active_players`, and the mailbox
- `SseCleanupGuard::drop` now only removes from the network-layer `connections` map and enqueues the interaction (read-only lookup of `active_players` for `entity_id`)

<details>
<summary>Agent Context</summary>

**Goal:** Eliminate direct game-state mutation from the network-layer drop handler; route it through the interaction system to be processed at game loop tick boundaries.

**Problem:** `SseCleanupGuard::drop` in `src/network/server/state.rs` spawned an async task that wrote to `active_players`, `active_entities`, and `engagements` concurrently with game loop ticks reading the same `RwLock`-protected maps. This is the same class of violation fixed on the player-select path.

**Files changed:**
- `src/game/component/interaction.rs` — added `PlayerDisconnected` variant (no fields; player context available at dispatch time)
- `src/game/interaction.rs` — declared `pub mod lifecycle`, added dispatch arm for `PlayerDisconnected`
- `src/game/interaction/lifecycle.rs` — new file; `player_disconnected(game_state, player)` removes entity from battles, `active_entities`, `active_players`, mailbox
- `src/network/server/state.rs` — `SseCleanupGuard::drop` reads `active_players` (read-only) to resolve `entity_id`, pushes `Interaction::PlayerDisconnected` to mailbox; `cleanup_player_battle` deleted; swapped `use crate::game::engagement::battle` for `use crate::game::component::Interaction`

**Data flow:**
SSE drop → push `PlayerDisconnected` to entity mailbox → game loop tick → `interaction::process()` drains mailbox → `dispatch_interaction` → `lifecycle::player_disconnected` (removes state)

**Key constraint:** The player record intentionally stays in `active_players` until the interaction is processed, so `process()` can find the player and drain their mailbox on the next tick. The lifecycle handler removes it as the final step.

**Deferred:** No explicit test for the disconnect path — this would require a full integration test with an active SSE connection. Manual verification is the intended path for now.

Related issue: #162
</details>