### PR TITLE
Fixes #188 Add action_text to ability config with variable resolution

### DIFF
--- a/migrations/17_ability_action_text.sql
+++ b/migrations/17_ability_action_text.sql
@@ -1,0 +1,1 @@
+ALTER TABLE abilities ADD COLUMN action_text TEXT;

--- a/muds/basic/abilities/swing_ax.toml
+++ b/muds/basic/abilities/swing_ax.toml
@@ -1,5 +1,6 @@
 name = "Swing Ax"
 description = "A wild swing with a rusty ax."
+action_text = "{{entity}} swings ax at {{target}} for {{effect}}"
 engagement_types = ["battle"]
 costs = []
 role = "attack"

--- a/src/game.rs
+++ b/src/game.rs
@@ -8,6 +8,7 @@ pub mod interaction;
 pub mod mailbox;
 pub mod map;
 pub mod messaging;
+pub mod narration;
 pub mod player;
 
 pub use component::Ability;

--- a/src/game/config/ability_config/config.rs
+++ b/src/game/config/ability_config/config.rs
@@ -60,6 +60,8 @@ pub struct Ability {
     pub role: AbilityRole,
     #[serde(default)]
     pub targets: Vec<AbilityTargetType>,
+    #[serde(default)]
+    pub action_text: Option<String>,
 }
 
 #[cfg(test)]
@@ -134,6 +136,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -164,6 +167,7 @@ mod tests {
             ],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -191,6 +195,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -241,6 +246,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![AbilityTargetType::Opponent],
+            action_text: None,
         };
         let json = serde_json::to_string(&ability).unwrap();
         let restored: Ability = serde_json::from_str(&json).unwrap();
@@ -259,5 +265,38 @@ mod tests {
         }"#;
         let ability: Ability = serde_json::from_str(json).unwrap();
         assert!(ability.targets.is_empty());
+    }
+
+    #[test]
+    fn ability_with_action_text_serde_round_trip() {
+        let ability = Ability {
+            id: "swing_ax".to_string(),
+            name: "Swing Ax".to_string(),
+            description: None,
+            effects: vec![attack_effect()],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+            role: AbilityRole::Attack,
+            targets: vec![AbilityTargetType::Opponent],
+            action_text: Some("{{entity}} swings ax at {{target}} for {{effect}}".to_string()),
+        };
+        let json = serde_json::to_string(&ability).unwrap();
+        let restored: Ability = serde_json::from_str(&json).unwrap();
+        assert_eq!(ability, restored);
+    }
+
+    #[test]
+    fn ability_missing_action_text_deserializes_as_none() {
+        let json = r#"{
+            "id": "attack",
+            "name": "Attack",
+            "description": null,
+            "effects": [],
+            "engagement_types": [],
+            "costs": []
+        }"#;
+        let ability: Ability = serde_json::from_str(json).unwrap();
+        assert!(ability.action_text.is_none());
     }
 }

--- a/src/game/engagement/battle/abilities.rs
+++ b/src/game/engagement/battle/abilities.rs
@@ -63,6 +63,7 @@ mod tests {
             modifiers: vec![],
             role,
             targets: vec![],
+            action_text: None,
         }
     }
 

--- a/src/game/engagement/battle/ai.rs
+++ b/src/game/engagement/battle/ai.rs
@@ -128,6 +128,7 @@ mod tests {
             modifiers: vec![],
             role,
             targets: vec![target],
+            action_text: None,
         }
     }
 

--- a/src/game/engagement/battle/ai/simple_random.rs
+++ b/src/game/engagement/battle/ai/simple_random.rs
@@ -75,6 +75,7 @@ mod tests {
             modifiers: vec![],
             role,
             targets: vec![],
+            action_text: None,
         }
     }
 

--- a/src/game/engagement/battle/queued_ability.rs
+++ b/src/game/engagement/battle/queued_ability.rs
@@ -36,6 +36,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         }
     }
 

--- a/src/game/engagement/battle/resolution.rs
+++ b/src/game/engagement/battle/resolution.rs
@@ -156,6 +156,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         }
     }
 

--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -470,6 +470,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         let attrs = HashMap::new();
         eng.queue_ability(1, ability.clone(), 2, &attrs);
@@ -524,6 +525,7 @@ mod tests {
             modifiers: vec![],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         let attrs: HashMap<String, Attribute> = HashMap::new(); // no mp
         assert!(!eng.queue_ability(1, ability, 2, &attrs));

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -7,6 +7,7 @@ use crate::game::config::AttributeConfig;
 use crate::game::engagement::TurnOrder;
 use crate::game::entity::Entity;
 use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
+use crate::game::narration::{TextResolver, VariableMap};
 use crate::game::{GameState, messaging};
 
 use super::resolution;
@@ -279,15 +280,25 @@ async fn apply_battle_effects(
 }
 
 fn ability_cast_message(qa: &QueuedAbility, entity_names: &HashMap<i64, String>) -> BattleMessage {
+    let caster_name = entity_names
+        .get(&qa.caster_id)
+        .cloned()
+        .unwrap_or_else(|| "Unknown".to_string());
+    let target_name = entity_names
+        .get(&qa.target_id)
+        .cloned()
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    if let Some(action_text) = &qa.ability.action_text {
+        let vars = VariableMap::new()
+            .insert("entity", &caster_name)
+            .insert("target", &target_name);
+        return BattleMessage::Meta(TextResolver::resolve(action_text, &vars));
+    }
+
     BattleMessage::AbilityCast {
-        caster_name: entity_names
-            .get(&qa.caster_id)
-            .cloned()
-            .unwrap_or_else(|| "Unknown".to_string()),
-        target_name: entity_names
-            .get(&qa.target_id)
-            .cloned()
-            .unwrap_or_else(|| "Unknown".to_string()),
+        caster_name,
+        target_name,
         ability_name: qa.ability.name.clone(),
     }
 }
@@ -418,5 +429,77 @@ async fn build_battle_update(
         countdown_secs: params.countdown_secs,
         max_turn_secs: params.max_turn_secs,
         available_abilities: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::{Ability, AbilityRole};
+    use crate::game::engagement::EngagementType;
+
+    fn make_ability(action_text: Option<&str>) -> Ability {
+        Ability {
+            id: "test".to_string(),
+            name: "Test Strike".to_string(),
+            description: None,
+            effects: vec![],
+            engagement_types: vec![EngagementType::Battle],
+            costs: vec![],
+            modifiers: vec![],
+            role: AbilityRole::Attack,
+            targets: vec![],
+            action_text: action_text.map(|s| s.to_string()),
+        }
+    }
+
+    fn make_names() -> HashMap<i64, String> {
+        let mut m = HashMap::new();
+        m.insert(1, "Alice".to_string());
+        m.insert(2, "Bob".to_string());
+        m
+    }
+
+    #[test]
+    fn no_action_text_returns_ability_cast() {
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability: make_ability(None),
+            target_id: 2,
+        };
+        let msg = ability_cast_message(&qa, &make_names());
+        assert_eq!(
+            msg,
+            BattleMessage::AbilityCast {
+                caster_name: "Alice".to_string(),
+                target_name: "Bob".to_string(),
+                ability_name: "Test Strike".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn with_action_text_returns_meta_with_resolved_text() {
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability: make_ability(Some("{{entity}} strikes {{target}}!")),
+            target_id: 2,
+        };
+        let msg = ability_cast_message(&qa, &make_names());
+        assert_eq!(msg, BattleMessage::Meta("Alice strikes Bob!".to_string()));
+    }
+
+    #[test]
+    fn with_action_text_effect_stub_left_as_literal() {
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability: make_ability(Some("{{entity}} hits {{target}} for {{effect}}")),
+            target_id: 2,
+        };
+        let msg = ability_cast_message(&qa, &make_names());
+        assert_eq!(
+            msg,
+            BattleMessage::Meta("Alice hits Bob for {{effect}}".to_string())
+        );
     }
 }

--- a/src/game/narration.rs
+++ b/src/game/narration.rs
@@ -1,0 +1,5 @@
+pub mod resolver;
+pub mod variable_map;
+
+pub use resolver::TextResolver;
+pub use variable_map::VariableMap;

--- a/src/game/narration/resolver.rs
+++ b/src/game/narration/resolver.rs
@@ -1,0 +1,72 @@
+use super::variable_map::VariableMap;
+
+pub struct TextResolver;
+
+impl TextResolver {
+    pub fn resolve(text: &str, vars: &VariableMap) -> String {
+        let mut result = String::with_capacity(text.len());
+        let mut remaining = text;
+
+        while let Some(open) = remaining.find("{{") {
+            result.push_str(&remaining[..open]);
+            let after_open = &remaining[open + 2..];
+            if let Some(close) = after_open.find("}}") {
+                let key = &after_open[..close];
+                if let Some(value) = vars.get(key) {
+                    result.push_str(value);
+                } else {
+                    result.push_str("{{");
+                    result.push_str(key);
+                    result.push_str("}}");
+                }
+                remaining = &after_open[close + 2..];
+            } else {
+                result.push_str("{{");
+                remaining = after_open;
+            }
+        }
+        result.push_str(remaining);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vars() -> VariableMap {
+        VariableMap::new()
+            .insert("entity", "Alice")
+            .insert("target", "Bob")
+    }
+
+    #[test]
+    fn resolves_known_vars() {
+        let result = TextResolver::resolve("{{entity}} attacks {{target}}!", &vars());
+        assert_eq!(result, "Alice attacks Bob!");
+    }
+
+    #[test]
+    fn unknown_var_left_as_literal() {
+        let result = TextResolver::resolve("{{entity}} hits for {{effect}}", &vars());
+        assert_eq!(result, "Alice hits for {{effect}}");
+    }
+
+    #[test]
+    fn empty_text_returns_empty() {
+        let result = TextResolver::resolve("", &vars());
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn no_placeholders_returned_unchanged() {
+        let result = TextResolver::resolve("no vars here", &vars());
+        assert_eq!(result, "no vars here");
+    }
+
+    #[test]
+    fn unclosed_brace_left_as_is() {
+        let result = TextResolver::resolve("{{entity}} and {{unclosed", &vars());
+        assert_eq!(result, "Alice and {{unclosed");
+    }
+}

--- a/src/game/narration/variable_map.rs
+++ b/src/game/narration/variable_map.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct VariableMap(HashMap<String, String>);
+
+impl VariableMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.0.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_inserts_and_retrieves() {
+        let vars = VariableMap::new()
+            .insert("entity", "Alice")
+            .insert("target", "Bob");
+        assert_eq!(vars.get("entity"), Some("Alice"));
+        assert_eq!(vars.get("target"), Some("Bob"));
+    }
+
+    #[test]
+    fn missing_key_returns_none() {
+        let vars = VariableMap::new();
+        assert_eq!(vars.get("unknown"), None);
+    }
+}

--- a/src/persistence/ability_repo.rs
+++ b/src/persistence/ability_repo.rs
@@ -13,6 +13,7 @@ type AbilityRow = (
     String,
     String,
     String,
+    Option<String>,
 );
 
 pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), PersistenceError> {
@@ -25,8 +26,8 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
     let role_str = ability_role_to_str(&ability.role);
     sqlx::query(
         "INSERT INTO abilities \
-         (id, name, description, effects_json, costs_json, modifiers_json, engagement_types_json, role, targets_json) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         (id, name, description, effects_json, costs_json, modifiers_json, engagement_types_json, role, targets_json, action_text) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(id) DO UPDATE SET \
              name = excluded.name, \
              description = excluded.description, \
@@ -35,7 +36,8 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
              modifiers_json = excluded.modifiers_json, \
              engagement_types_json = excluded.engagement_types_json, \
              role = excluded.role, \
-             targets_json = excluded.targets_json",
+             targets_json = excluded.targets_json, \
+             action_text = excluded.action_text",
     )
     .bind(&ability.id)
     .bind(&ability.name)
@@ -46,6 +48,7 @@ pub async fn upsert(pool: &SqlitePool, ability: &Ability) -> Result<(), Persiste
     .bind(&engagement_types_json)
     .bind(role_str)
     .bind(&targets_json)
+    .bind(&ability.action_text)
     .execute(pool)
     .await?;
     Ok(())
@@ -57,7 +60,7 @@ pub async fn find_by_entity(
 ) -> Result<Vec<Ability>, PersistenceError> {
     let rows: Vec<AbilityRow> = sqlx::query_as(
         "SELECT a.id, a.name, a.description, a.effects_json, a.costs_json, \
-             a.modifiers_json, a.engagement_types_json, a.role, a.targets_json \
+             a.modifiers_json, a.engagement_types_json, a.role, a.targets_json, a.action_text \
              FROM abilities a \
              JOIN entity_abilities ea ON a.id = ea.ability_id \
              WHERE ea.entity_id = ?",
@@ -79,6 +82,7 @@ pub async fn find_by_entity(
                 et_json,
                 role_str,
                 targets_json,
+                action_text,
             )| {
                 let effects = serde_json::from_str(&effects_json).unwrap_or_else(|e| {
                     tracing::warn!("Failed to deserialize effects for ability {id}: {e}");
@@ -111,6 +115,7 @@ pub async fn find_by_entity(
                     engagement_types,
                     role: ability_role_from_str(&role_str),
                     targets,
+                    action_text,
                 }
             },
         )
@@ -201,6 +206,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             role: AbilityRole::Attack,
             targets: vec![AbilityTargetType::Opponent],
+            action_text: None,
         }
     }
 
@@ -215,6 +221,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             role: AbilityRole::Defend,
             targets: vec![AbilityTargetType::SelfTarget],
+            action_text: None,
         }
     }
 

--- a/src/persistence/entity_repo.rs
+++ b/src/persistence/entity_repo.rs
@@ -840,6 +840,7 @@ mod tests {
             engagement_types: vec![EngagementType::Battle],
             role: AbilityRole::Attack,
             targets: vec![],
+            action_text: None,
         };
         ability_repo::upsert(db.pool(), &ability).await.unwrap();
         ability_repo::set_entity_abilities(db.pool(), id, &["strike"])

--- a/src/tui/app/battle_state.rs
+++ b/src/tui/app/battle_state.rs
@@ -81,6 +81,7 @@ impl BattleState {
                 modifiers: vec![],
                 role: AbilityRole::Attack,
                 targets: vec![],
+                action_text: None,
             }]
         } else {
             abilities

--- a/src/tui/screens/battle/render.rs
+++ b/src/tui/screens/battle/render.rs
@@ -285,7 +285,7 @@ fn battle_message_to_line(msg: &BattleMessage) -> Line<'_> {
         BattleMessage::Meta(_) => Line::from(Span::styled(
             msg.to_string(),
             Style::default()
-                .fg(Color::DarkGray)
+                .fg(Color::White)
                 .add_modifier(Modifier::ITALIC),
         )),
     }

--- a/src/tui/screens/battle/render.rs
+++ b/src/tui/screens/battle/render.rs
@@ -284,9 +284,7 @@ fn battle_message_to_line(msg: &BattleMessage) -> Line<'_> {
         )),
         BattleMessage::Meta(_) => Line::from(Span::styled(
             msg.to_string(),
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::ITALIC),
+            Style::default().fg(Color::White),
         )),
     }
 }


### PR DESCRIPTION
Adds an optional `action_text` field to the `Ability` config so authors can write flavor-rich battle messages with `{{entity}}`, `{{target}}`, and `{{effect}}` placeholders. A new `game/narration` module handles `{{var_name}}` substitution. The `{{effect}}` placeholder is left as a stub to be wired in a follow-on issue.

- New `action_text: Option<String>` field on `Ability` (serde-defaulted so existing configs parse unchanged)
- New `game/narration` module with `VariableMap` (builder-style) and `TextResolver` for `{{var}}` substitution; unknown vars left as literals
- `ability_cast_message()` in battle tick emits `BattleMessage::Meta(resolved)` when `action_text` is present, falling back to the existing `AbilityCast` format when absent
- Migration `17_ability_action_text.sql` adds the column to SQLite; `ability_repo` persists and loads it so the value survives the DB round-trip

<details>
<summary>Agent Context</summary>

**Goal:** Allow ability config authors to write custom battle flavor text with variable placeholders instead of always seeing the generic "X uses Y on Z" message.

**Key files changed:**
- `src/game/config/ability_config/config.rs` — `Ability` struct; added `pub action_text: Option<String>` with `#[serde(default)]`
- `src/game/narration.rs` — new module root; re-exports `TextResolver`, `VariableMap`
- `src/game/narration/variable_map.rs` — `VariableMap` newtype over `HashMap<String,String>` with builder-style `insert()`
- `src/game/narration/resolver.rs` — `TextResolver::resolve(text, vars)` scans for `{{key}}` tokens; replaces known vars, leaves unknown ones (e.g. `{{effect}}`) as literal text
- `src/game.rs` — added `pub mod narration;`
- `src/game/engagement/battle/tick.rs:ability_cast_message()` — checks `qa.ability.action_text`; if `Some`, builds `VariableMap` with `entity`/`target` and returns `BattleMessage::Meta(resolved)`; if `None`, returns existing `BattleMessage::AbilityCast`
- `src/tui/screens/battle/render.rs` — `BattleMessage::Meta` now renders white italic (was dark gray)
- `migrations/17_ability_action_text.sql` — `ALTER TABLE abilities ADD COLUMN action_text TEXT`
- `src/persistence/ability_repo.rs` — `AbilityRow` tuple extended; `action_text` added to SELECT, INSERT, and UPDATE; set on constructed `Ability`
- `muds/basic/abilities/swing_ax.toml` — demo: `action_text = "{{entity}} swings ax at {{target}} for {{effect}}"`

**Decisions:**
- Module named `game/narration` (not `text`) to fit the domain layer convention
- `{{effect}}` intentionally left unresolved (returned as literal) — follow-on issue will wire it
- All existing `Ability` struct literals across the codebase updated with `action_text: None`; no `Default` impl added to avoid hiding required fields in future construction sites

**Tests added:**
- `TextResolver` unit tests (happy path, unknown var stub, empty text, no placeholders, unclosed brace)
- `VariableMap` builder/retrieval tests
- `ability_cast_message()` tests: with and without `action_text`, and `{{effect}}` stub behavior
- Serde round-trip tests for `Ability` with `action_text` set and absent

**Follow-on:** Issue to wire `{{effect}}` — will resolve to the effect name/value at cast time.

**Related:** Closes #188
</details>