### PR TITLE
Fixes #189 Add effect text to ability config with variable resolution and indented rendering

### DIFF
--- a/muds/basic/abilities/defend.toml
+++ b/muds/basic/abilities/defend.toml
@@ -9,3 +9,4 @@ targets = ["self"]
 name = "damage_reduction"
 trigger_info = { type = "once" }
 effect_type = { type = "attribute_shield", attribute_id = "hp", absorb_amount = 5 }
+description = { text = "Defend for {{abs_value}}" }

--- a/muds/basic/abilities/swing_ax.toml
+++ b/muds/basic/abilities/swing_ax.toml
@@ -1,6 +1,6 @@
 name = "Swing Ax"
 description = "A wild swing with a rusty ax."
-action_text = "{{entity}} swings ax at {{target}} for {{effect}}"
+action_text = "{{entity}} swings ax at {{target}}"
 engagement_types = ["battle"]
 costs = []
 role = "attack"
@@ -10,3 +10,4 @@ targets = ["opponent"]
 name = "ax_damage"
 trigger_info = { type = "once" }
 effect_type = { type = "attribute_update", attribute_id = "hp", value = -15 }
+description = { text = "Axe chops for {{abs_value}}" }

--- a/src/game/component/effect.rs
+++ b/src/game/component/effect.rs
@@ -1,4 +1,7 @@
-use crate::game::component::location::Location;
+pub mod effect_type;
+
+pub use effect_type::EffectType;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -21,37 +24,12 @@ pub enum TriggerInfo {
     Once,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case", tag = "type")]
-pub enum EffectType {
-    AttributeUpdate {
-        attribute_id: String,
-        value: i64,
-    },
-    AttributeShield {
-        attribute_id: String,
-        absorb_amount: i64,
-    },
-    EntitySpawn {
-        entity_id: String,
-        location: Option<Location>,
-    },
-}
-
-impl EffectType {
-    pub fn resolution_order(&self) -> u8 {
-        match self {
-            EffectType::AttributeShield { .. } => 0,
-            EffectType::AttributeUpdate { .. } => 1,
-            EffectType::EntitySpawn { .. } => 2,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct EffectDescription {
     pub start_description: Option<String>,
     pub end_description: Option<String>,
+    #[serde(default)]
+    pub text: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -84,7 +62,7 @@ mod tests {
             },
             description: EffectDescription {
                 start_description: Some("You feel better.".to_string()),
-                end_description: None,
+                ..Default::default()
             },
             scope: EffectScope::default(),
         };
@@ -147,6 +125,39 @@ mod tests {
         let restored: Effect = serde_json::from_str(&json).unwrap();
         assert_eq!(effect, restored);
         assert_eq!(restored.scope, EffectScope::Battle);
+    }
+
+    #[test]
+    fn effect_description_text_serde_round_trip() {
+        let effect = Effect {
+            name: "custom".to_string(),
+            effect_type: EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -5,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription {
+                text: Some("cleaves for 5".to_string()),
+                ..Default::default()
+            },
+            scope: EffectScope::default(),
+        };
+        let json = serde_json::to_string(&effect).unwrap();
+        let restored: Effect = serde_json::from_str(&json).unwrap();
+        assert_eq!(effect, restored);
+        assert_eq!(restored.description.text, Some("cleaves for 5".to_string()));
+    }
+
+    #[test]
+    fn effect_description_text_defaults_to_none_when_absent() {
+        let json = r#"{
+            "name": "hit",
+            "effect_type": {"type": "attribute_update", "attribute_id": "hp", "value": -5},
+            "trigger_info": {"type": "once"},
+            "description": {}
+        }"#;
+        let effect: Effect = serde_json::from_str(json).unwrap();
+        assert_eq!(effect.description.text, None);
     }
 
     #[test]

--- a/src/game/component/effect/effect_type.rs
+++ b/src/game/component/effect/effect_type.rs
@@ -1,0 +1,79 @@
+use crate::game::component::location::Location;
+use crate::game::narration::VariableMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum EffectType {
+    AttributeUpdate {
+        attribute_id: String,
+        value: i64,
+    },
+    AttributeShield {
+        attribute_id: String,
+        absorb_amount: i64,
+    },
+    EntitySpawn {
+        entity_id: String,
+        location: Option<Location>,
+    },
+}
+
+impl EffectType {
+    pub fn resolution_order(&self) -> u8 {
+        match self {
+            EffectType::AttributeShield { .. } => 0,
+            EffectType::AttributeUpdate { .. } => 1,
+            EffectType::EntitySpawn { .. } => 2,
+        }
+    }
+
+    pub fn variable_map(&self) -> VariableMap {
+        match self {
+            EffectType::AttributeUpdate { value, .. } => VariableMap::new()
+                .insert("value", value.to_string())
+                .insert("abs_value", value.abs().to_string()),
+            EffectType::AttributeShield { absorb_amount, .. } => VariableMap::new()
+                .insert("value", absorb_amount.to_string())
+                .insert("abs_value", absorb_amount.abs().to_string()),
+            EffectType::EntitySpawn { .. } => VariableMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn variable_map_attribute_update_provides_value_and_abs_value() {
+        let vars = EffectType::AttributeUpdate {
+            attribute_id: "hp".to_string(),
+            value: -15,
+        }
+        .variable_map();
+        assert_eq!(vars.get("value"), Some("-15"));
+        assert_eq!(vars.get("abs_value"), Some("15"));
+    }
+
+    #[test]
+    fn variable_map_attribute_shield_provides_value_and_abs_value() {
+        let vars = EffectType::AttributeShield {
+            attribute_id: "hp".to_string(),
+            absorb_amount: 10,
+        }
+        .variable_map();
+        assert_eq!(vars.get("value"), Some("10"));
+        assert_eq!(vars.get("abs_value"), Some("10"));
+    }
+
+    #[test]
+    fn variable_map_entity_spawn_is_empty() {
+        let vars = EffectType::EntitySpawn {
+            entity_id: "goblin".to_string(),
+            location: None,
+        }
+        .variable_map();
+        assert_eq!(vars.get("value"), None);
+    }
+}

--- a/src/game/engagement/battle/message.rs
+++ b/src/game/engagement/battle/message.rs
@@ -24,6 +24,7 @@ pub enum BattleMessage {
         target_id: i64,
     },
     Meta(String),
+    EffectText(String),
 }
 
 impl fmt::Display for BattleMessage {
@@ -46,6 +47,7 @@ impl fmt::Display for BattleMessage {
                 "{caster_name} is preparing {ability_name} → {target_name}"
             ),
             BattleMessage::Meta(msg) => write!(f, "{msg}"),
+            BattleMessage::EffectText(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -7,7 +7,7 @@ use crate::game::config::AttributeConfig;
 use crate::game::engagement::TurnOrder;
 use crate::game::entity::Entity;
 use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
-use crate::game::narration::{TextResolver, VariableMap};
+use crate::game::narration::{TextResolver, VariableMap, effect_text};
 use crate::game::{GameState, messaging};
 
 use super::resolution;
@@ -257,7 +257,7 @@ async fn apply_battle_effects(
 
     for &caster_id in speed_sorted_casters {
         for qa in by_caster.remove(&caster_id).unwrap_or_default() {
-            cast_messages.push(ability_cast_message(&qa, entity_names));
+            cast_messages.extend(ability_cast_messages(&qa, entity_names));
             target_effects
                 .entry(qa.target_id)
                 .or_insert_with(Vec::new)
@@ -266,7 +266,7 @@ async fn apply_battle_effects(
     }
     for abilities in by_caster.into_values() {
         for qa in abilities {
-            cast_messages.push(ability_cast_message(&qa, entity_names));
+            cast_messages.extend(ability_cast_messages(&qa, entity_names));
             target_effects
                 .entry(qa.target_id)
                 .or_insert_with(Vec::new)
@@ -279,7 +279,10 @@ async fn apply_battle_effects(
     }
 }
 
-fn ability_cast_message(qa: &QueuedAbility, entity_names: &HashMap<i64, String>) -> BattleMessage {
+fn ability_cast_messages(
+    qa: &QueuedAbility,
+    entity_names: &HashMap<i64, String>,
+) -> Vec<BattleMessage> {
     let caster_name = entity_names
         .get(&qa.caster_id)
         .cloned()
@@ -289,18 +292,29 @@ fn ability_cast_message(qa: &QueuedAbility, entity_names: &HashMap<i64, String>)
         .cloned()
         .unwrap_or_else(|| "Unknown".to_string());
 
-    if let Some(action_text) = &qa.ability.action_text {
+    let effect_lines: Vec<BattleMessage> = qa
+        .ability
+        .effects
+        .iter()
+        .map(effect_text)
+        .filter(|s| !s.is_empty())
+        .map(BattleMessage::EffectText)
+        .collect();
+
+    let cast_message = if let Some(action_text) = &qa.ability.action_text {
         let vars = VariableMap::new()
             .insert("entity", &caster_name)
             .insert("target", &target_name);
-        return BattleMessage::Meta(TextResolver::resolve(action_text, &vars));
-    }
+        BattleMessage::Meta(TextResolver::resolve(action_text, &vars))
+    } else {
+        BattleMessage::AbilityCast {
+            caster_name,
+            target_name,
+            ability_name: qa.ability.name.clone(),
+        }
+    };
 
-    BattleMessage::AbilityCast {
-        caster_name,
-        target_name,
-        ability_name: qa.ability.name.clone(),
-    }
+    std::iter::once(cast_message).chain(effect_lines).collect()
 }
 
 fn pending_attack_message(
@@ -435,6 +449,9 @@ async fn build_battle_update(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::component::effect::{
+        Effect, EffectDescription, EffectScope, EffectType, TriggerInfo,
+    };
     use crate::game::component::{Ability, AbilityRole};
     use crate::game::engagement::EngagementType;
 
@@ -460,46 +477,112 @@ mod tests {
         m
     }
 
+    fn hp_effect(value: i64, text: Option<&str>) -> Effect {
+        Effect {
+            name: "damage".to_string(),
+            effect_type: EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription {
+                text: text.map(|s| s.to_string()),
+                ..Default::default()
+            },
+            scope: EffectScope::default(),
+        }
+    }
+
     #[test]
-    fn no_action_text_returns_ability_cast() {
+    fn no_action_text_no_effects_returns_ability_cast() {
         let qa = QueuedAbility {
             caster_id: 1,
             ability: make_ability(None),
             target_id: 2,
         };
-        let msg = ability_cast_message(&qa, &make_names());
+        let msgs = ability_cast_messages(&qa, &make_names());
         assert_eq!(
-            msg,
-            BattleMessage::AbilityCast {
+            msgs,
+            vec![BattleMessage::AbilityCast {
                 caster_name: "Alice".to_string(),
                 target_name: "Bob".to_string(),
                 ability_name: "Test Strike".to_string(),
-            }
+            }]
         );
     }
 
     #[test]
-    fn with_action_text_returns_meta_with_resolved_text() {
+    fn no_action_text_with_effect_appends_indented_effect_line() {
+        let mut ability = make_ability(None);
+        ability.effects = vec![hp_effect(-5, Some("Defend for {{abs_value}}"))];
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability,
+            target_id: 2,
+        };
+        let msgs = ability_cast_messages(&qa, &make_names());
+        assert_eq!(
+            msgs,
+            vec![
+                BattleMessage::AbilityCast {
+                    caster_name: "Alice".to_string(),
+                    target_name: "Bob".to_string(),
+                    ability_name: "Test Strike".to_string(),
+                },
+                BattleMessage::EffectText("Defend for 5".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn with_action_text_no_effects_returns_single_meta() {
         let qa = QueuedAbility {
             caster_id: 1,
             ability: make_ability(Some("{{entity}} strikes {{target}}!")),
             target_id: 2,
         };
-        let msg = ability_cast_message(&qa, &make_names());
-        assert_eq!(msg, BattleMessage::Meta("Alice strikes Bob!".to_string()));
+        let msgs = ability_cast_messages(&qa, &make_names());
+        assert_eq!(
+            msgs,
+            vec![BattleMessage::Meta("Alice strikes Bob!".to_string())]
+        );
     }
 
     #[test]
-    fn with_action_text_effect_stub_left_as_literal() {
+    fn with_action_text_and_hp_effect_emits_separate_indented_line() {
+        let mut ability = make_ability(Some("{{entity}} hits {{target}}"));
+        ability.effects = vec![hp_effect(-10, None)];
         let qa = QueuedAbility {
             caster_id: 1,
-            ability: make_ability(Some("{{entity}} hits {{target}} for {{effect}}")),
+            ability,
             target_id: 2,
         };
-        let msg = ability_cast_message(&qa, &make_names());
+        let msgs = ability_cast_messages(&qa, &make_names());
         assert_eq!(
-            msg,
-            BattleMessage::Meta("Alice hits Bob for {{effect}}".to_string())
+            msgs,
+            vec![
+                BattleMessage::Meta("Alice hits Bob".to_string()),
+                BattleMessage::EffectText("deals 10 damage".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn with_action_text_and_custom_effect_text_uses_resolved_text() {
+        let mut ability = make_ability(Some("{{entity}} swings ax at {{target}}"));
+        ability.effects = vec![hp_effect(-15, Some("Axe chops for {{abs_value}}"))];
+        let qa = QueuedAbility {
+            caster_id: 1,
+            ability,
+            target_id: 2,
+        };
+        let msgs = ability_cast_messages(&qa, &make_names());
+        assert_eq!(
+            msgs,
+            vec![
+                BattleMessage::Meta("Alice swings ax at Bob".to_string()),
+                BattleMessage::EffectText("Axe chops for 15".to_string()),
+            ]
         );
     }
 }

--- a/src/game/narration.rs
+++ b/src/game/narration.rs
@@ -1,5 +1,7 @@
+pub mod effect_text;
 pub mod resolver;
 pub mod variable_map;
 
+pub use effect_text::effect_text;
 pub use resolver::TextResolver;
 pub use variable_map::VariableMap;

--- a/src/game/narration/effect_text.rs
+++ b/src/game/narration/effect_text.rs
@@ -1,0 +1,134 @@
+use crate::game::component::effect::{Effect, EffectType};
+use crate::game::narration::TextResolver;
+
+pub fn effect_text(effect: &Effect) -> String {
+    let raw = match &effect.description.text {
+        Some(text) => text.as_str(),
+        None => default_text(&effect.effect_type),
+    };
+    if raw.is_empty() {
+        return String::new();
+    }
+    TextResolver::resolve(raw, &effect.effect_type.variable_map())
+}
+
+fn default_text(effect_type: &EffectType) -> &'static str {
+    if let EffectType::AttributeUpdate {
+        attribute_id,
+        value,
+    } = effect_type
+        && attribute_id == "hp"
+    {
+        return if *value > 0 {
+            "heals for {{value}}"
+        } else if *value < 0 {
+            "deals {{abs_value}} damage"
+        } else {
+            ""
+        };
+    }
+    ""
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::effect::{EffectDescription, EffectScope, TriggerInfo};
+
+    fn make_effect(effect_type: EffectType, text: Option<&str>) -> Effect {
+        Effect {
+            name: "test".to_string(),
+            effect_type,
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription {
+                text: text.map(|s| s.to_string()),
+                ..Default::default()
+            },
+            scope: EffectScope::default(),
+        }
+    }
+
+    #[test]
+    fn hp_damage_returns_deals_damage() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -10,
+            },
+            None,
+        );
+        assert_eq!(effect_text(&e), "deals 10 damage");
+    }
+
+    #[test]
+    fn hp_healing_returns_heals_for() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: 5,
+            },
+            None,
+        );
+        assert_eq!(effect_text(&e), "heals for 5");
+    }
+
+    #[test]
+    fn hp_zero_returns_empty() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: 0,
+            },
+            None,
+        );
+        assert_eq!(effect_text(&e), "");
+    }
+
+    #[test]
+    fn non_hp_attribute_returns_empty() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "mp".to_string(),
+                value: -5,
+            },
+            None,
+        );
+        assert_eq!(effect_text(&e), "");
+    }
+
+    #[test]
+    fn author_text_literal_returned_unchanged() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -10,
+            },
+            Some("cleaves for 15"),
+        );
+        assert_eq!(effect_text(&e), "cleaves for 15");
+    }
+
+    #[test]
+    fn author_text_with_abs_value_variable_resolved() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -10,
+            },
+            Some("Axe chops for {{abs_value}}"),
+        );
+        assert_eq!(effect_text(&e), "Axe chops for 10");
+    }
+
+    #[test]
+    fn author_text_with_value_variable_resolved() {
+        let e = make_effect(
+            EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: 8,
+            },
+            Some("restores {{value}} hp"),
+        );
+        assert_eq!(effect_text(&e), "restores 8 hp");
+    }
+}

--- a/src/persistence/entity_effect_repo.rs
+++ b/src/persistence/entity_effect_repo.rs
@@ -106,7 +106,7 @@ mod tests {
             trigger_info: TriggerInfo::Once,
             description: EffectDescription {
                 start_description: Some("You feel healed.".to_string()),
-                end_description: None,
+                ..Default::default()
             },
             scope: Default::default(),
         }

--- a/src/tui/screens/battle/render.rs
+++ b/src/tui/screens/battle/render.rs
@@ -224,7 +224,7 @@ fn render_message_log(frame: &mut Frame, app: &App, battle: &BattleState, area: 
 
     let log = Paragraph::new(Text::from(all_lines))
         .block(Block::default().title("Battle Log").borders(Borders::ALL))
-        .wrap(Wrap { trim: true })
+        .wrap(Wrap { trim: false })
         .scroll((scroll_from_top, 0));
     frame.render_widget(log, area);
 }
@@ -286,6 +286,10 @@ fn battle_message_to_line(msg: &BattleMessage) -> Line<'_> {
             msg.to_string(),
             Style::default().fg(Color::White),
         )),
+        BattleMessage::EffectText(text) => Line::from(vec![
+            Span::raw("  "),
+            Span::styled(text.as_str(), Style::default().fg(Color::Gray)),
+        ]),
     }
 }
 


### PR DESCRIPTION
Closes #189. Extends the battle narration pipeline with per-effect text, completing the end-to-end message system started in #188. Effect text now appears beneath each ability cast line in the battle log, with author-supplied templates or smart HP defaults resolved through the existing `TextResolver`.

- Optional `text` field on `EffectDescription` lets ability authors write effect narration using `{{value}}` and `{{abs_value}}` template variables (e.g. `"Axe chops for {{abs_value}}"`)
- `EffectType::variable_map()` injects numeric variables for `AttributeUpdate` and `AttributeShield` effects; `effect_text()` in `src/game/narration/effect_text.rs` applies smart HP defaults (`"heals for {{value}}"` / `"deals {{abs_value}} damage"`) when no author text is set
- `ability_cast_messages()` (formerly `ability_cast_message()`) returns `Vec<BattleMessage>`, emitting the cast line followed by one `BattleMessage::EffectText` per non-empty effect — works for abilities with and without `action_text`
- `BattleMessage::EffectText` is a dedicated variant rendered in the TUI as a two-span line with a `"  "` indent and gray styling; `Wrap { trim: false }` ensures the indent is preserved

<details>
<summary>Agent Context</summary>

**Goal:** Source the `{{effect}}` variable introduced in #188 and render per-effect narration lines in the battle log.

**Key files changed:**
- `src/game/component/effect.rs` — `EffectDescription` gets `pub text: Option<String>` with `#[serde(default)]`; `EffectType` extracted to submodule
- `src/game/component/effect/effect_type.rs` (new) — `EffectType` with `resolution_order()` and `variable_map()` methods; `variable_map()` returns `VariableMap` with `"value"` and `"abs_value"` for `AttributeUpdate`/`AttributeShield`, empty for `EntitySpawn`
- `src/game/narration/effect_text.rs` (new) — `effect_text(effect: &Effect) -> String`; resolution precedence: author `description.text` → smart default template → `""`; all paths run through `TextResolver::resolve` with `effect_type.variable_map()`
- `src/game/narration.rs` — adds `pub mod effect_text` and `pub use effect_text::effect_text`
- `src/game/engagement/battle/tick.rs` — `ability_cast_messages()` now returns `Vec<BattleMessage>`; collects `EffectText` lines from all effects regardless of whether `action_text` is set; call sites use `.extend()` instead of `.push()`
- `src/game/engagement/battle/message.rs` — new `EffectText(String)` variant; `Display` renders plain text (indentation is a rendering concern)
- `src/tui/screens/battle/render.rs` — `EffectText` arm in `battle_message_to_line` builds a two-`Span` `Line` (`"  "` + gray text); `Wrap { trim: false }` prevents ratatui from stripping the leading-space indent
- `muds/basic/abilities/swing_ax.toml` — `action_text` trimmed to remove the old `for {{effect}}` placeholder; effect gets `description = { text = "Axe chops for {{abs_value}}" }`
- `muds/basic/abilities/defend.toml` — effect gets `description = { text = "Defend for {{abs_value}}" }`

**Architectural decisions:**
- `{{effect}}` is no longer inlined into `action_text` templates; each effect produces its own separate `BattleMessage::EffectText` line. This allows multiple effects to each have distinct narration without cluttering the action line.
- `BattleMessage::EffectText` is a distinct variant (not a flag on `Meta`) so the renderer can apply consistent indentation/styling semantically rather than by string inspection.
- `trim: false` on the `Paragraph` is safe because no other `BattleMessage` variant produces leading whitespace — only `EffectText` needs preserved indentation, and that indentation comes from the `Span::raw("  ")` prepended by the renderer.
- Smart defaults only apply to `hp` attribute updates; other attributes fall back to `""` (no effect text emitted). This is intentional — left open for future expansion.

**Related:** #188 (action text framework), #189 (this PR)
</details>