### PR TITLE
Fixes #190 Add ResetCondition to AttributeDefinition config

### DIFF
--- a/src/game/component.rs
+++ b/src/game/component.rs
@@ -16,6 +16,7 @@ pub use attribute::Attribute;
 pub use attribute_definition::AttributeCategory;
 pub use attribute_definition::AttributeDefinition;
 pub use attribute_definition::AttributeType;
+pub use attribute_definition::ResetCondition;
 pub use check::Check;
 pub use description::CheckedDescription;
 pub use description::Description;

--- a/src/game/component/attribute_definition.rs
+++ b/src/game/component/attribute_definition.rs
@@ -1,5 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ResetCondition {
+    #[default]
+    EachEngagementTurn,
+    EndOfEngagement,
+    Never,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum AttributeCategory {
     #[serde(rename = "life")]
@@ -33,6 +42,8 @@ pub struct AttributeDefinition {
     pub max_value: i64,
     pub attribute_type: AttributeType,
     pub attribute_category: AttributeCategory,
+    #[serde(default)]
+    pub reset_condition: ResetCondition,
 }
 
 #[cfg(test)]
@@ -49,6 +60,7 @@ mod tests {
             max_value: 100,
             attribute_type: AttributeType::HP,
             attribute_category: AttributeCategory::Life,
+            reset_condition: ResetCondition::EndOfEngagement,
         };
         let json = serde_json::to_string(&def).unwrap();
         let restored: AttributeDefinition = serde_json::from_str(&json).unwrap();
@@ -56,6 +68,50 @@ mod tests {
         assert_eq!(restored.title, def.title);
         assert_eq!(restored.min_value, def.min_value);
         assert_eq!(restored.max_value, def.max_value);
+        assert_eq!(restored.reset_condition, def.reset_condition);
+    }
+
+    #[test]
+    fn reset_condition_serializes_snake_case() {
+        let cases = [
+            (
+                ResetCondition::EachEngagementTurn,
+                r#""each_engagement_turn""#,
+            ),
+            (ResetCondition::EndOfEngagement, r#""end_of_engagement""#),
+            (ResetCondition::Never, r#""never""#),
+        ];
+        for (condition, expected) in cases {
+            assert_eq!(serde_json::to_string(&condition).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn reset_condition_serde_round_trip() {
+        for condition in [
+            ResetCondition::EachEngagementTurn,
+            ResetCondition::EndOfEngagement,
+            ResetCondition::Never,
+        ] {
+            let json = serde_json::to_string(&condition).unwrap();
+            let restored: ResetCondition = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored, condition);
+        }
+    }
+
+    #[test]
+    fn attribute_definition_missing_reset_condition_defaults() {
+        let json = r#"{
+            "id": "strength",
+            "title": "Strength",
+            "description": "Raw power.",
+            "min_value": 1,
+            "max_value": 20,
+            "attribute_type": "stat",
+            "attribute_category": "general"
+        }"#;
+        let def: AttributeDefinition = serde_json::from_str(json).unwrap();
+        assert_eq!(def.reset_condition, ResetCondition::EachEngagementTurn);
     }
 
     #[test]
@@ -81,6 +137,7 @@ mod tests {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: ResetCondition::EachEngagementTurn,
         };
         let json = serde_json::to_string(&def).unwrap();
         let restored: AttributeDefinition = serde_json::from_str(&json).unwrap();

--- a/src/game/config/attribute_config.rs
+++ b/src/game/config/attribute_config.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::game::component::AttributeDefinition;
-use crate::game::component::attribute_definition::{AttributeCategory, AttributeType};
+use crate::game::component::attribute_definition::{
+    AttributeCategory, AttributeType, ResetCondition,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AttributeConfig {
@@ -34,6 +36,7 @@ fn default_life_attributes() -> Vec<AttributeDefinition> {
             max_value: 999,
             attribute_type: AttributeType::HP,
             attribute_category: AttributeCategory::Life,
+            reset_condition: ResetCondition::Never,
         },
         AttributeDefinition {
             id: "mp".to_string(),
@@ -43,6 +46,7 @@ fn default_life_attributes() -> Vec<AttributeDefinition> {
             max_value: 999,
             attribute_type: AttributeType::MP,
             attribute_category: AttributeCategory::General,
+            reset_condition: ResetCondition::Never,
         },
         AttributeDefinition {
             id: "level".to_string(),
@@ -52,6 +56,7 @@ fn default_life_attributes() -> Vec<AttributeDefinition> {
             max_value: 100,
             attribute_type: AttributeType::Level,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "xp".to_string(),
@@ -61,6 +66,7 @@ fn default_life_attributes() -> Vec<AttributeDefinition> {
             max_value: i64::MAX,
             attribute_type: AttributeType::XP,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
     ]
 }
@@ -75,6 +81,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "dexterity".to_string(),
@@ -84,6 +91,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "constitution".to_string(),
@@ -93,6 +101,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "intelligence".to_string(),
@@ -102,6 +111,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "wisdom".to_string(),
@@ -111,6 +121,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
         AttributeDefinition {
             id: "charisma".to_string(),
@@ -120,6 +131,7 @@ fn default_stat_attributes() -> Vec<AttributeDefinition> {
             max_value: 20,
             attribute_type: AttributeType::Stat,
             attribute_category: AttributeCategory::General,
+            reset_condition: Default::default(),
         },
     ]
 }
@@ -145,6 +157,30 @@ mod tests {
         assert!(ids.contains(&"wisdom"));
         assert!(ids.contains(&"charisma"));
         assert_eq!(config.attributes.len(), 10);
+
+        let find = |id: &str| {
+            config
+                .attributes
+                .iter()
+                .find(|a| a.id == id)
+                .unwrap()
+                .reset_condition
+                .clone()
+        };
+        assert_eq!(find("hp"), ResetCondition::Never);
+        assert_eq!(find("mp"), ResetCondition::Never);
+        for id in [
+            "level",
+            "xp",
+            "strength",
+            "dexterity",
+            "constitution",
+            "intelligence",
+            "wisdom",
+            "charisma",
+        ] {
+            assert_eq!(find(id), ResetCondition::EachEngagementTurn);
+        }
     }
 
     #[test]

--- a/src/game/engagement/turn_order.rs
+++ b/src/game/engagement/turn_order.rs
@@ -129,6 +129,7 @@ mod tests {
                 max_value: 100,
                 attribute_type: AttributeType::Stat,
                 attribute_category: AttributeCategory::Speed,
+                reset_condition: Default::default(),
             }],
         };
 
@@ -177,6 +178,7 @@ mod tests {
                 max_value: 100,
                 attribute_type: AttributeType::Stat,
                 attribute_category: AttributeCategory::Speed,
+                reset_condition: Default::default(),
             }],
         };
 


### PR DESCRIPTION
Adds a `ResetCondition` enum to `AttributeDefinition` so config authors can express how each attribute's working copy behaves across battle turns. Closes #190.

- New `ResetCondition` enum with `EachEngagementTurn` (default), `EndOfEngagement`, and `Never` variants, serialized as snake_case
- `reset_condition` field added to `AttributeDefinition` with `#[serde(default)]` so existing TOML/JSON files without the field continue to deserialize correctly
- `hp` and `mp` default to `Never`; all other attributes default to `EachEngagementTurn`
- Serde round-trip tests covering all three variants and the missing-field default case

<details>
<summary>Agent Context</summary>

**Goal:** Extend `AttributeDefinition` with a `reset_condition` field that the pending-stats battle system (follow-on issue) will read to decide how to initialize/flush each attribute's working copy each turn.

**Key files changed:**
- `src/game/component/attribute_definition.rs` — `ResetCondition` enum defined here; `reset_condition` field added to `AttributeDefinition`
- `src/game/component.rs` — `ResetCondition` added to the `pub use attribute_definition::` re-export block
- `src/game/config/attribute_config.rs` — `default_life_attributes()` sets `Never` on `hp` and `mp`; remaining attributes use `Default::default()` (`EachEngagementTurn`); `default_config_has_expected_attributes` test extended to assert per-attribute values
- `src/game/engagement/turn_order.rs` — Test `AttributeDefinition` struct literals updated to include `reset_condition: Default::default()`

**Decisions:**
- Named `ResetCondition` (not `BattleResetBehavior`) to keep it general — the concept isn't battle-specific and may apply to other engagement types in the future.
- `Never` used for `hp`/`mp` rather than `EndOfEngagement` — these stats represent persistent state that should never be automatically reset by the engine regardless of engagement lifecycle.
- `#[serde(default)]` on the field ensures backwards compatibility with attribute TOML files that predate this change.

**Related:** Follow-on issue will implement the pending-stats system that reads `reset_condition` to decide how to initialize each attribute's working copy at the start of each faction turn.
</details>