### PR TITLE
Fixes #197 Add instructions/info CLI command with top-level output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod completions;
+pub mod instructions;
 pub mod players;
 pub mod router;
 pub mod server;
@@ -49,7 +50,16 @@ pub enum Commands {
         /// Target shell
         shell: Shell,
     },
+    /// Print authoring instructions for mud config files
+    #[command(alias = "info")]
+    Instructions {
+        #[command(subcommand)]
+        topic: Option<InstructionsTopic>,
+    },
 }
+
+#[derive(Subcommand, Debug, PartialEq)]
+pub enum InstructionsTopic {}
 
 #[derive(Subcommand, Debug, PartialEq)]
 pub enum PlayersCommands {
@@ -199,6 +209,18 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn instructions_subcommand_parses() {
+        let cli = parse(&["mudroom", "instructions"]);
+        assert_eq!(cli.command, Some(Commands::Instructions { topic: None }));
+    }
+
+    #[test]
+    fn info_alias_parses() {
+        let cli = parse(&["mudroom", "info"]);
+        assert_eq!(cli.command, Some(Commands::Instructions { topic: None }));
     }
 
     #[test]

--- a/src/cli/instructions.rs
+++ b/src/cli/instructions.rs
@@ -1,0 +1,7 @@
+use crate::instructions::{self, InstructionType};
+
+use super::InstructionsTopic;
+
+pub fn run(_topic: Option<InstructionsTopic>) {
+    instructions::print_instructions(InstructionType::TopLevel);
+}

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -1,4 +1,4 @@
-use super::{Cli, Commands, client, completions, players, server};
+use super::{Cli, Commands, client, completions, instructions, players, server};
 
 pub struct CliRouter;
 
@@ -14,6 +14,10 @@ impl CliRouter {
             Some(Commands::Players { command }) => players::run(command).await,
             Some(Commands::Completions { shell }) => {
                 completions::run(shell);
+                Ok(())
+            }
+            Some(Commands::Instructions { topic }) => {
+                instructions::run(topic);
                 Ok(())
             }
             None => client::run(None, false).await,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,0 +1,12 @@
+pub mod top_level;
+
+pub enum InstructionType {
+    TopLevel,
+}
+
+pub fn print_instructions(topic: InstructionType) {
+    let text = match topic {
+        InstructionType::TopLevel => top_level::render(),
+    };
+    println!("{text}");
+}

--- a/src/instructions/top_level.rs
+++ b/src/instructions/top_level.rs
@@ -1,0 +1,40 @@
+const TOPICS: &[(&str, &str)] = &[];
+
+pub fn render() -> String {
+    let mut lines = vec![
+        "mudroom instructions — authoring guidance for mud config files".to_string(),
+        String::new(),
+        "Usage: mudroom instructions [topic]  (alias: mudroom info [topic])".to_string(),
+    ];
+    if TOPICS.is_empty() {
+        lines.push(String::new());
+        lines.push("No topics are registered yet.".to_string());
+    } else {
+        let width = TOPICS.iter().map(|(name, _)| name.len()).max().unwrap_or(0);
+        lines.push(String::new());
+        lines.push("Topics:".to_string());
+        for (name, description) in TOPICS {
+            lines.push(format!(
+                "  mudroom instructions {name:<width$}  — {description}"
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_includes_usage_header() {
+        let text = render();
+        assert!(text.contains("mudroom instructions [topic]"));
+    }
+
+    #[test]
+    fn render_notes_no_topics_when_empty() {
+        let text = render();
+        assert!(text.contains("No topics are registered yet."));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod cli;
 pub mod game;
+pub mod instructions;
 pub mod logging;
 pub mod network;
 pub mod paths;


### PR DESCRIPTION
Adds a discoverable `mudroom instructions` (alias `info`) command so agents and config authors can look up guidance on writing mud config files directly from the CLI. Running it with no topic prints an index of available topics.

- New top-level `instructions`/`info` subcommands, wired through the existing CLI router
- New `instructions` module (`src/instructions.rs` + `src/instructions/`) with an `InstructionType` enum and `print_instructions()` entry point
- Extensible top-level index renderer that currently reports no topics are registered yet, ready for follow-on issues to add rows
- Clap parse tests covering both the `instructions` command and its `info` alias

<details>
<summary>Agent Context</summary>

**Goal:** Scaffolding for issue #197 — the first in a series. Follow-on issues will each add one `InstructionType` variant plus one `src/instructions/<topic>.rs` file.

**Key files:**
- `src/cli.rs` — added `Commands::Instructions { topic: Option<InstructionsTopic> }` with `#[command(alias = "info")]`, and an empty `InstructionsTopic` `Subcommand` enum (confirmed `derive(Subcommand)` compiles fine on a zero-variant enum with clap 4.5.60). Added parse tests `instructions_subcommand_parses` and `info_alias_parses`.
- `src/cli/instructions.rs` — thin handler: `run(topic: Option<InstructionsTopic>)` calls `instructions::print_instructions(InstructionType::TopLevel)`. No topic-to-variant match yet since `InstructionsTopic` has no variants.
- `src/cli/router.rs` — added `Commands::Instructions` dispatch arm.
- `src/instructions.rs` — module root; `InstructionType` enum (`TopLevel` only) + `print_instructions()` dispatcher, following the same root-file/submodule-folder convention as `src/game/config.rs` and `src/game/component/interaction.rs`.
- `src/instructions/top_level.rs` — `render() -> String` builds the index text from a `TOPICS: &[(&str, &str)]` slice (currently empty); falls back to "No topics are registered yet." Format is column-aligned and designed to gain rows without restructuring as topics are added.
- `src/lib.rs` — declared `pub mod instructions;`.

**Design decision:** Chose a single `Instructions` clap variant with a `#[command(alias = "info")]` attribute rather than two duplicate `Instructions`/`Info` variants (the issue allowed either) — avoids duplicating the enum arm, router arm, and parse tests for what is one feature with two invocation names.

**Verified:** `cargo fmt && cargo test && cargo clippy` all clean (two pre-existing clippy warnings in unrelated files confirmed present on `main` via `git stash` before/after comparison). Manually ran `cargo run -- instructions`, `cargo run -- info`, and `cargo run -- --help` to confirm both commands print identical output and the alias is registered.

**Related:** Closes #197. Follow-on issues will populate `InstructionType`/`InstructionsTopic` with real topics (abilities, attributes, classes, maps, etc.) and add the corresponding match arms in `src/instructions.rs` and `src/cli/instructions.rs`.

</details>