### PR TITLE
Fixes #212 Use raw string literals in instructions topic renderers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Claude
 .claude/settings.local.json
+.claude/worktrees/

--- a/src/instructions/abilities.rs
+++ b/src/instructions/abilities.rs
@@ -13,141 +13,125 @@ pub fn render() -> String {
 }
 
 fn header() -> String {
-    [
-        "mudroom instructions abilities — ability config file reference",
-        "",
-        "Ability files live at abilities/*.toml under a mud's config directory",
-        "(e.g. muds/basic/abilities/basic_attack.toml). Each file defines one ability.",
-        "The ability's id is derived from its file path relative to the abilities",
-        "directory (extension stripped) — it is not set in the TOML itself.",
-    ]
-    .join("\n")
+    r#"mudroom instructions abilities — ability config file reference
+
+Ability files live at abilities/*.toml under a mud's config directory
+(e.g. muds/basic/abilities/basic_attack.toml). Each file defines one ability.
+The ability's id is derived from its file path relative to the abilities
+directory (extension stripped) — it is not set in the TOML itself."#
+        .to_string()
 }
 
 fn fields_section() -> String {
-    [
-        "Top-level fields:",
-        "  name              string            Display name.",
-        "  description       string, optional  Short description.",
-        "  action_text       string, optional  Narration template shown when the",
-        "                                       ability is used, e.g.",
-        "                                       \"{{entity}} swings ax at {{target}}\".",
-        "  engagement_types  array of strings   Engagement types this ability can be",
-        "                                       used in. See \"engagement_types\" below.",
-        "  costs             array of tables    Resources consumed to use the ability.",
-        "                                       See \"costs\" below. Use [] for none.",
-        "  role              string, optional   The ability's role. See \"role\" below.",
-        "                                       Defaults to \"attack\" if omitted.",
-        "  targets           array of strings   Who the ability can target. See",
-        "                                       \"targets\" below. Defaults to [] if",
-        "                                       omitted.",
-        "  modifiers         array of tables    Optional attribute-scaling modifiers.",
-        "                                       Each has attribute_id (string) and",
-        "                                       operator (\"add\", \"subtract\",",
-        "                                       \"multiply\", or \"divide\"). Defaults to",
-        "                                       [] if omitted.",
-        "  [[effects]]       array of tables     One or more effect blocks describing",
-        "                                       what the ability does. See \"effects\"",
-        "                                       below.",
-    ]
-    .join("\n")
+    r#"Top-level fields:
+  name              string            Display name.
+  description       string, optional  Short description.
+  action_text       string, optional  Narration template shown when the
+                                       ability is used, e.g.
+                                       "{{entity}} swings ax at {{target}}".
+  engagement_types  array of strings   Engagement types this ability can be
+                                       used in. See "engagement_types" below.
+  costs             array of tables    Resources consumed to use the ability.
+                                       See "costs" below. Use [] for none.
+  role              string, optional   The ability's role. See "role" below.
+                                       Defaults to "attack" if omitted.
+  targets           array of strings   Who the ability can target. See
+                                       "targets" below. Defaults to [] if
+                                       omitted.
+  modifiers         array of tables    Optional attribute-scaling modifiers.
+                                       Each has attribute_id (string) and
+                                       operator ("add", "subtract",
+                                       "multiply", or "divide"). Defaults to
+                                       [] if omitted.
+  [[effects]]       array of tables     One or more effect blocks describing
+                                       what the ability does. See "effects"
+                                       below."#
+        .to_string()
 }
 
 fn engagement_types_section() -> String {
-    [
-        "engagement_types values:",
-        "  \"battle\"         Usable during a battle engagement.",
-        "  \"conversation\"   Usable during a conversation engagement.",
-    ]
-    .join("\n")
+    r#"engagement_types values:
+  "battle"         Usable during a battle engagement.
+  "conversation"   Usable during a conversation engagement."#
+        .to_string()
 }
 
 fn costs_section() -> String {
-    [
-        "costs entries:",
-        "  { type = \"resource\", resource_id = \"<attribute id>\", amount = <integer> }",
-        "    Consumes `amount` of the entity's `resource_id` attribute (e.g. mp or",
-        "    stamina) when the ability is used. Use an empty array (costs = [])",
-        "    for abilities with no cost.",
-    ]
-    .join("\n")
+    r#"costs entries:
+  { type = "resource", resource_id = "<attribute id>", amount = <integer> }
+    Consumes `amount` of the entity's `resource_id` attribute (e.g. mp or
+    stamina) when the ability is used. Use an empty array (costs = [])
+    for abilities with no cost."#
+        .to_string()
 }
 
 fn role_section() -> String {
-    [
-        "role values:",
-        "  \"attack\"   Offensive ability (default).",
-        "  \"defend\"   Defensive ability.",
-        "  \"world\"    Non-combat / world-interaction ability.",
-    ]
-    .join("\n")
+    r#"role values:
+  "attack"   Offensive ability (default).
+  "defend"   Defensive ability.
+  "world"    Non-combat / world-interaction ability."#
+        .to_string()
 }
 
 fn targets_section() -> String {
-    [
-        "targets values:",
-        "  \"opponent\"   Targets the opposing side.",
-        "  \"allies\"     Targets allies.",
-        "  \"self\"       Targets the acting entity.",
-    ]
-    .join("\n")
+    r#"targets values:
+  "opponent"   Targets the opposing side.
+  "allies"     Targets allies.
+  "self"       Targets the acting entity."#
+        .to_string()
 }
 
 fn effects_section() -> String {
-    [
-        "[[effects]] fields:",
-        "  name           string            Identifier for the effect.",
-        "  trigger_info   inline table      When/how the effect fires. See",
-        "                                   \"trigger_info variants\" below.",
-        "  effect_type    inline table      What the effect does. See",
-        "                                   \"effect_type variants\" below.",
-        "  description    inline table,     Optional narration for the effect.",
-        "                 optional          { text = \"...\" } supports variables",
-        "                                   like {{value}} and {{abs_value}}.",
-        "  scope          string, optional  \"world\" (default), \"battle\", or",
-        "                                   \"conversation\" — where the effect",
-        "                                   applies.",
-        "",
-        "trigger_info variants:",
-        "  { type = \"once\" }",
-        "    Fires a single time when the ability is used.",
-        "  { type = \"over_time\", start = <ticks>, end = <ticks, optional>, rate = <ticks> }",
-        "    Fires repeatedly starting at `start`, every `rate` ticks, until `end`",
-        "    (or indefinitely if `end` is omitted).",
-        "",
-        "effect_type variants:",
-        "  { type = \"attribute_update\", attribute_id = \"<id>\", value = <integer> }",
-        "    Adds `value` to the target's `attribute_id` attribute (negative values",
-        "    deal damage, positive values heal/buff).",
-        "  { type = \"attribute_shield\", attribute_id = \"<id>\", absorb_amount = <integer> }",
-        "    Grants a shield absorbing up to `absorb_amount` of damage to",
-        "    `attribute_id` before it is reduced directly.",
-        "  { type = \"entity_spawn\", entity_id = \"<id>\", location = <table, optional> }",
-        "    Spawns an entity with the given `entity_id`, optionally at a specific",
-        "    location (world_id, dungeon_id, room_id). Omit `location` to spawn near",
-        "    the acting entity.",
-    ]
-    .join("\n")
+    r#"[[effects]] fields:
+  name           string            Identifier for the effect.
+  trigger_info   inline table      When/how the effect fires. See
+                                   "trigger_info variants" below.
+  effect_type    inline table      What the effect does. See
+                                   "effect_type variants" below.
+  description    inline table,     Optional narration for the effect.
+                 optional          { text = "..." } supports variables
+                                   like {{value}} and {{abs_value}}.
+  scope          string, optional  "world" (default), "battle", or
+                                   "conversation" — where the effect
+                                   applies.
+
+trigger_info variants:
+  { type = "once" }
+    Fires a single time when the ability is used.
+  { type = "over_time", start = <ticks>, end = <ticks, optional>, rate = <ticks> }
+    Fires repeatedly starting at `start`, every `rate` ticks, until `end`
+    (or indefinitely if `end` is omitted).
+
+effect_type variants:
+  { type = "attribute_update", attribute_id = "<id>", value = <integer> }
+    Adds `value` to the target's `attribute_id` attribute (negative values
+    deal damage, positive values heal/buff).
+  { type = "attribute_shield", attribute_id = "<id>", absorb_amount = <integer> }
+    Grants a shield absorbing up to `absorb_amount` of damage to
+    `attribute_id` before it is reduced directly.
+  { type = "entity_spawn", entity_id = "<id>", location = <table, optional> }
+    Spawns an entity with the given `entity_id`, optionally at a specific
+    location (world_id, dungeon_id, room_id). Omit `location` to spawn near
+    the acting entity."#
+        .to_string()
 }
 
 fn example_section() -> String {
-    [
-        "Complete annotated example (muds/basic/abilities/defend.toml):",
-        "",
-        "  name = \"Defend\"",
-        "  description = \"Brace for impact, absorbing incoming damage.\"",
-        "  engagement_types = [\"battle\"]           # usable in battle only",
-        "  costs = []                              # no resource cost",
-        "  role = \"defend\"                         # defensive ability",
-        "  targets = [\"self\"]                      # targets the caster",
-        "",
-        "  [[effects]]",
-        "  name = \"damage_reduction\"",
-        "  trigger_info = { type = \"once\" }        # fires once when used",
-        "  effect_type = { type = \"attribute_shield\", attribute_id = \"hp\", absorb_amount = 5 }",
-        "  description = { text = \"Defend for {{abs_value}}\" }",
-    ]
-    .join("\n")
+    r#"Complete annotated example (muds/basic/abilities/defend.toml):
+
+  name = "Defend"
+  description = "Brace for impact, absorbing incoming damage."
+  engagement_types = ["battle"]           # usable in battle only
+  costs = []                              # no resource cost
+  role = "defend"                         # defensive ability
+  targets = ["self"]                      # targets the caster
+
+  [[effects]]
+  name = "damage_reduction"
+  trigger_info = { type = "once" }        # fires once when used
+  effect_type = { type = "attribute_shield", attribute_id = "hp", absorb_amount = 5 }
+  description = { text = "Defend for {{abs_value}}" }"#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/attributes.rs
+++ b/src/instructions/attributes.rs
@@ -1,78 +1,76 @@
 pub fn render() -> String {
-    [
-        "mudroom instructions attributes — attributes.toml reference",
-        "",
-        "Location:",
-        "  <mud-dir>/attributes.toml — a single file containing every [[attributes]]",
-        "  entry for the mud. Unlike abilities/classes/entities, attributes are not",
-        "  split across a subfolder.",
-        "",
-        "Each [[attributes]] entry defines one stat or resource that entities can",
-        "have. The `id` is the key used to reference this attribute elsewhere, such",
-        "as an ability's effect_type or a class's [[attributes]] override.",
-        "",
-        "Fields:",
-        "  id                  string — unique identifier for this attribute, used to",
-        "                      reference it from abilities, classes, etc.",
-        "  title               string — display name shown to players.",
-        "  description         string — longer text shown to players (e.g. in help).",
-        "  min_value           i64 — the minimum allowed value for this attribute.",
-        "                      This is a global floor; classes may narrow it further.",
-        "  max_value           i64 — the maximum allowed value for this attribute.",
-        "                      This is a global ceiling; classes may narrow it further.",
-        "  attribute_type      enum — categorizes how the engine treats this",
-        "                      attribute mechanically. See values below.",
-        "  attribute_category  enum — groups the attribute for display/organization",
-        "                      purposes. See values below.",
-        "  reset_condition     enum, optional — when this attribute's value resets",
-        "                      to its default during engagements. Defaults to",
-        "                      each_engagement_turn if omitted. See values below.",
-        "",
-        "attribute_type values:",
-        "  hp     — a hit point pool; tracks damage an entity can sustain.",
-        "  mp     — a mana/energy pool; tracks resources spent on abilities.",
-        "  level  — an entity's overall experience level.",
-        "  xp     — accumulated experience points.",
-        "  stat   — a general-purpose stat (e.g. strength, dexterity) that does not",
-        "           fit the other categories.",
-        "",
-        "attribute_category values:",
-        "  life     — resources tied to survival, such as hp.",
-        "  speed    — attributes that affect turn order or action speed.",
-        "  general  — everything else (stats, level, xp, mp, etc).",
-        "",
-        "reset_condition values:",
-        "  each_engagement_turn  — the attribute resets at the start of every turn",
-        "                          within an engagement (battle). This is the",
-        "                          default when the field is omitted.",
-        "  end_of_engagement     — the attribute resets once, when the engagement",
-        "                          ends.",
-        "  never                 — the attribute is never automatically reset; its",
-        "                          value persists across turns and engagements.",
-        "",
-        "Example (from muds/basic/attributes.toml):",
-        "",
-        "  [[attributes]]",
-        "  id = \"hp\"",
-        "  title = \"Hit Points\"",
-        "  description = \"The amount of damage you can sustain before falling.\"",
-        "  min_value = 0",
-        "  max_value = 999",
-        "  attribute_type = \"hp\"",
-        "  attribute_category = \"life\"",
-        "  reset_condition = \"never\"",
-        "",
-        "  [[attributes]]",
-        "  id = \"strength\"",
-        "  title = \"Strength\"",
-        "  description = \"Raw physical power and carrying capacity.\"",
-        "  min_value = 1",
-        "  max_value = 20",
-        "  attribute_type = \"stat\"",
-        "  attribute_category = \"general\"",
-        "  # reset_condition omitted — defaults to each_engagement_turn",
-    ]
-    .join("\n")
+    r#"mudroom instructions attributes — attributes.toml reference
+
+Location:
+  <mud-dir>/attributes.toml — a single file containing every [[attributes]]
+  entry for the mud. Unlike abilities/classes/entities, attributes are not
+  split across a subfolder.
+
+Each [[attributes]] entry defines one stat or resource that entities can
+have. The `id` is the key used to reference this attribute elsewhere, such
+as an ability's effect_type or a class's [[attributes]] override.
+
+Fields:
+  id                  string — unique identifier for this attribute, used to
+                      reference it from abilities, classes, etc.
+  title               string — display name shown to players.
+  description         string — longer text shown to players (e.g. in help).
+  min_value           i64 — the minimum allowed value for this attribute.
+                      This is a global floor; classes may narrow it further.
+  max_value           i64 — the maximum allowed value for this attribute.
+                      This is a global ceiling; classes may narrow it further.
+  attribute_type      enum — categorizes how the engine treats this
+                      attribute mechanically. See values below.
+  attribute_category  enum — groups the attribute for display/organization
+                      purposes. See values below.
+  reset_condition     enum, optional — when this attribute's value resets
+                      to its default during engagements. Defaults to
+                      each_engagement_turn if omitted. See values below.
+
+attribute_type values:
+  hp     — a hit point pool; tracks damage an entity can sustain.
+  mp     — a mana/energy pool; tracks resources spent on abilities.
+  level  — an entity's overall experience level.
+  xp     — accumulated experience points.
+  stat   — a general-purpose stat (e.g. strength, dexterity) that does not
+           fit the other categories.
+
+attribute_category values:
+  life     — resources tied to survival, such as hp.
+  speed    — attributes that affect turn order or action speed.
+  general  — everything else (stats, level, xp, mp, etc).
+
+reset_condition values:
+  each_engagement_turn  — the attribute resets at the start of every turn
+                          within an engagement (battle). This is the
+                          default when the field is omitted.
+  end_of_engagement     — the attribute resets once, when the engagement
+                          ends.
+  never                 — the attribute is never automatically reset; its
+                          value persists across turns and engagements.
+
+Example (from muds/basic/attributes.toml):
+
+  [[attributes]]
+  id = "hp"
+  title = "Hit Points"
+  description = "The amount of damage you can sustain before falling."
+  min_value = 0
+  max_value = 999
+  attribute_type = "hp"
+  attribute_category = "life"
+  reset_condition = "never"
+
+  [[attributes]]
+  id = "strength"
+  title = "Strength"
+  description = "Raw physical power and carrying capacity."
+  min_value = 1
+  max_value = 20
+  attribute_type = "stat"
+  attribute_category = "general"
+  # reset_condition omitted — defaults to each_engagement_turn"#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/classes.rs
+++ b/src/instructions/classes.rs
@@ -1,54 +1,52 @@
 pub fn render() -> String {
-    let lines = [
-        "mudroom instructions classes — class config file (classes/*.toml) reference",
-        "",
-        "Location: <mud-dir>/classes/<class-id>.toml — one file per class. The filename",
-        "(without .toml) is the class ID, used with `mudroom players reset <player> <class>`.",
-        "You can override the ID explicitly with a top-level `id` field in the file.",
-        "",
-        "Example (muds/basic/classes/survivor.toml):",
-        "",
-        "  name = \"Survivor\"",
-        "  description = \"A scrappy melee brawler who clawed their way through the wasteland.\"",
-        "  innate_abilities = [\"basic_attack\", \"sawed_off_shotgun\", \"defend\"]",
-        "",
-        "  [[attributes]]",
-        "  definition_id = \"hp\"",
-        "  min_value = 0",
-        "  max_value = 120",
-        "  current_value = 120",
-        "",
-        "  [[attributes]]",
-        "  definition_id = \"mp\"",
-        "  min_value = 0",
-        "  max_value = 20",
-        "  current_value = 20",
-        "",
-        "Fields:",
-        "  name              — display name shown to players (string, required)",
-        "  description       — player-visible flavor text (string, optional)",
-        "  innate_abilities  — array of ability IDs granted by this class. Each ID must",
-        "                      match the filename (without .toml) of a file under",
-        "                      abilities/ — e.g. \"basic_attack\" resolves to",
-        "                      abilities/basic_attack.toml.",
-        "  [[attributes]]    — repeated table overriding one attribute for this class:",
-        "    definition_id   — must match the `id` of an entry in attributes.toml",
-        "    min_value       — lower bound for this class; can be tighter than the",
-        "                      global attribute's range",
-        "    max_value       — upper bound for this class; can be tighter than the",
-        "                      global attribute's range",
-        "    current_value   — value the attribute is set to when this class is applied",
-        "",
-        "Key behaviors:",
-        "  - Only attributes listed under [[attributes]] are overridden for this class;",
-        "    any attribute defined in attributes.toml but omitted here keeps its global",
-        "    default range and value.",
-        "  - innate_abilities are granted to the player's entity when the class is",
-        "    applied via `mudroom players reset <player> <class>`.",
-        "  - The class ID (filename without .toml, or the `id` field if set) is the",
-        "    <class> argument passed to `mudroom players reset`.",
-    ];
-    lines.join("\n")
+    r#"mudroom instructions classes — class config file (classes/*.toml) reference
+
+Location: <mud-dir>/classes/<class-id>.toml — one file per class. The filename
+(without .toml) is the class ID, used with `mudroom players reset <player> <class>`.
+You can override the ID explicitly with a top-level `id` field in the file.
+
+Example (muds/basic/classes/survivor.toml):
+
+  name = "Survivor"
+  description = "A scrappy melee brawler who clawed their way through the wasteland."
+  innate_abilities = ["basic_attack", "sawed_off_shotgun", "defend"]
+
+  [[attributes]]
+  definition_id = "hp"
+  min_value = 0
+  max_value = 120
+  current_value = 120
+
+  [[attributes]]
+  definition_id = "mp"
+  min_value = 0
+  max_value = 20
+  current_value = 20
+
+Fields:
+  name              — display name shown to players (string, required)
+  description       — player-visible flavor text (string, optional)
+  innate_abilities  — array of ability IDs granted by this class. Each ID must
+                      match the filename (without .toml) of a file under
+                      abilities/ — e.g. "basic_attack" resolves to
+                      abilities/basic_attack.toml.
+  [[attributes]]    — repeated table overriding one attribute for this class:
+    definition_id   — must match the `id` of an entry in attributes.toml
+    min_value       — lower bound for this class; can be tighter than the
+                      global attribute's range
+    max_value       — upper bound for this class; can be tighter than the
+                      global attribute's range
+    current_value   — value the attribute is set to when this class is applied
+
+Key behaviors:
+  - Only attributes listed under [[attributes]] are overridden for this class;
+    any attribute defined in attributes.toml but omitted here keeps its global
+    default range and value.
+  - innate_abilities are granted to the player's entity when the class is
+    applied via `mudroom players reset <player> <class>`.
+  - The class ID (filename without .toml, or the `id` field if set) is the
+    <class> argument passed to `mudroom players reset`."#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/entities.rs
+++ b/src/instructions/entities.rs
@@ -1,107 +1,102 @@
 pub fn render() -> String {
-    let lines = vec![
-        "mudroom instructions entities — entities/*.toml file reference".to_string(),
-        String::new(),
-        "Entity config files define the NPCs, creatures, and objects that populate the".to_string(),
-        "world: their type, persona, dialog, starting attributes, and combat behavior.".to_string(),
-        String::new(),
-        "Location: <mud-dir>/entities/<entity-id>.toml — one file per entity.".to_string(),
-        "The entity ID defaults to the file path relative to the mud dir, without the".to_string(),
-        "\".toml\" extension (e.g. \"entities/innkeeper.toml\" -> \"entities/innkeeper\"),"
-            .to_string(),
-        "unless overridden by the `id` field. Room files reference entities by this ID".to_string(),
-        "in their `entities` array, e.g. entities = [\"entities/innkeeper\"].".to_string(),
-        String::new(),
-        "Example (muds/basic/entities/innkeeper.toml):".to_string(),
-        String::new(),
-        "  entity_type = \"character\"".to_string(),
-        String::new(),
-        "  [persona]".to_string(),
-        "  type = \"standard\"".to_string(),
-        "  dialog_file = \"innkeeper_dialog.md\"".to_string(),
-        String::new(),
-        "  [[attributes]]".to_string(),
-        "  definition_id = \"hp\"".to_string(),
-        "  min_value = 0".to_string(),
-        "  max_value = 100".to_string(),
-        "  current_value = 100".to_string(),
-        String::new(),
-        "Top-level fields:".to_string(),
-        String::new(),
-        "  id             Optional. Overrides the derived entity ID.".to_string(),
-        "  name           Optional. Display name. Defaults to a name derived from the".to_string(),
-        "                 filename if omitted.".to_string(),
-        "  entity_type    Required. One of \"character\", \"enemy\", \"object\".".to_string(),
-        "  description    Optional. Flavor text describing the entity.".to_string(),
-        "  persona        Optional. See [persona] below.".to_string(),
-        "  attributes     Optional list of [[attributes]] tables. See below.".to_string(),
-        "  innate_abilities  Optional list of ability IDs the entity always has".to_string(),
-        "                 available in combat, without needing to learn them, e.g.".to_string(),
-        "                 innate_abilities = [\"swing_ax\", \"scream_nonsense\", \"defend\"]."
-            .to_string(),
-        "  factions       Optional list of faction IDs this entity belongs to.".to_string(),
-        "  faction_relations  Optional. See [faction_relations.factions] below.".to_string(),
-        "  battle_ai      Optional. See [battle_ai] below.".to_string(),
-        "  entity_effects Optional list of standing effects applied to the entity".to_string(),
-        "                 (advanced; same effect structure used by abilities).".to_string(),
-        String::new(),
-        "[persona] sub-table:".to_string(),
-        String::new(),
-        "  type           Required. \"standard\" or \"agent\".".to_string(),
-        String::new(),
-        "  type = \"standard\" — a scripted dialog tree:".to_string(),
-        "    dialog_file  Path to a Markdown dialog tree, relative to the entity file's"
-            .to_string(),
-        "                 directory, e.g. dialog_file = \"innkeeper_dialog.md\".".to_string(),
-        "    dialog_tree  Alternative to dialog_file: an inline [persona.dialog_tree]".to_string(),
-        "                 table with the same structure the Markdown file parses into.".to_string(),
-        String::new(),
-        "  type = \"agent\" — an LLM-driven persona:".to_string(),
-        "    agent_type   Optional. Selects the agent provider/behavior. Defaults to".to_string(),
-        "                 \"default\".".to_string(),
-        "    persona_file Path to a Markdown persona file, relative to the entity".to_string(),
-        "                 file's directory, e.g. persona_file = \"mysterious_man.md\".".to_string(),
-        "                 See `mudroom instructions mud-config` for the persona file".to_string(),
-        "                 format (front matter, preamble, conditional sections).".to_string(),
-        String::new(),
-        "[[attributes]] (repeatable table, same shape as class attribute overrides):".to_string(),
-        String::new(),
-        "  definition_id  ID of an attribute defined in attributes.toml, e.g. \"hp\".".to_string(),
-        "  min_value      Minimum value for the attribute.".to_string(),
-        "  max_value      Maximum value for the attribute.".to_string(),
-        "  current_value  Starting value for the attribute.".to_string(),
-        String::new(),
-        "[faction_relations.factions] sub-table:".to_string(),
-        String::new(),
-        "  Maps a faction ID to this entity's relation towards it: \"hostile\",".to_string(),
-        "  \"unfriendly\", \"friendly\", or \"non_interactive\" (default when unset).".to_string(),
-        String::new(),
-        "[battle_ai] sub-table:".to_string(),
-        String::new(),
-        "  ai_type        Optional. \"none\" (default) or \"simple_random\".".to_string(),
-        String::new(),
-        "Combat entity example (muds/basic/entities/zombie.toml):".to_string(),
-        String::new(),
-        "  entity_type = \"enemy\"".to_string(),
-        "  factions = [\"enemy\"]".to_string(),
-        String::new(),
-        "  name = \"Zombie\"".to_string(),
-        "  description = \"A shambling corpse, visibly decayed.\"".to_string(),
-        "  innate_abilities = [\"basic_attack\", \"defend\"]".to_string(),
-        String::new(),
-        "  [battle_ai]".to_string(),
-        "  ai_type = \"simple_random\"".to_string(),
-        String::new(),
-        "  [[attributes]]".to_string(),
-        "  definition_id = \"hp\"".to_string(),
-        "  min_value = 0".to_string(),
-        "  max_value = 50".to_string(),
-        "  current_value = 50".to_string(),
-        String::new(),
-        "  [faction_relations.factions]".to_string(),
-        "  player = \"hostile\"".to_string(),
-    ];
-    lines.join("\n")
+    r#"mudroom instructions entities — entities/*.toml file reference
+
+Entity config files define the NPCs, creatures, and objects that populate the
+world: their type, persona, dialog, starting attributes, and combat behavior.
+
+Location: <mud-dir>/entities/<entity-id>.toml — one file per entity.
+The entity ID defaults to the file path relative to the mud dir, without the
+".toml" extension (e.g. "entities/innkeeper.toml" -> "entities/innkeeper"),
+unless overridden by the `id` field. Room files reference entities by this ID
+in their `entities` array, e.g. entities = ["entities/innkeeper"].
+
+Example (muds/basic/entities/innkeeper.toml):
+
+  entity_type = "character"
+
+  [persona]
+  type = "standard"
+  dialog_file = "innkeeper_dialog.md"
+
+  [[attributes]]
+  definition_id = "hp"
+  min_value = 0
+  max_value = 100
+  current_value = 100
+
+Top-level fields:
+
+  id             Optional. Overrides the derived entity ID.
+  name           Optional. Display name. Defaults to a name derived from the
+                 filename if omitted.
+  entity_type    Required. One of "character", "enemy", "object".
+  description    Optional. Flavor text describing the entity.
+  persona        Optional. See [persona] below.
+  attributes     Optional list of [[attributes]] tables. See below.
+  innate_abilities  Optional list of ability IDs the entity always has
+                 available in combat, without needing to learn them, e.g.
+                 innate_abilities = ["swing_ax", "scream_nonsense", "defend"].
+  factions       Optional list of faction IDs this entity belongs to.
+  faction_relations  Optional. See [faction_relations.factions] below.
+  battle_ai      Optional. See [battle_ai] below.
+  entity_effects Optional list of standing effects applied to the entity
+                 (advanced; same effect structure used by abilities).
+
+[persona] sub-table:
+
+  type           Required. "standard" or "agent".
+
+  type = "standard" — a scripted dialog tree:
+    dialog_file  Path to a Markdown dialog tree, relative to the entity file's
+                 directory, e.g. dialog_file = "innkeeper_dialog.md".
+    dialog_tree  Alternative to dialog_file: an inline [persona.dialog_tree]
+                 table with the same structure the Markdown file parses into.
+
+  type = "agent" — an LLM-driven persona:
+    agent_type   Optional. Selects the agent provider/behavior. Defaults to
+                 "default".
+    persona_file Path to a Markdown persona file, relative to the entity
+                 file's directory, e.g. persona_file = "mysterious_man.md".
+                 See `mudroom instructions mud-config` for the persona file
+                 format (front matter, preamble, conditional sections).
+
+[[attributes]] (repeatable table, same shape as class attribute overrides):
+
+  definition_id  ID of an attribute defined in attributes.toml, e.g. "hp".
+  min_value      Minimum value for the attribute.
+  max_value      Maximum value for the attribute.
+  current_value  Starting value for the attribute.
+
+[faction_relations.factions] sub-table:
+
+  Maps a faction ID to this entity's relation towards it: "hostile",
+  "unfriendly", "friendly", or "non_interactive" (default when unset).
+
+[battle_ai] sub-table:
+
+  ai_type        Optional. "none" (default) or "simple_random".
+
+Combat entity example (muds/basic/entities/zombie.toml):
+
+  entity_type = "enemy"
+  factions = ["enemy"]
+
+  name = "Zombie"
+  description = "A shambling corpse, visibly decayed."
+  innate_abilities = ["basic_attack", "defend"]
+
+  [battle_ai]
+  ai_type = "simple_random"
+
+  [[attributes]]
+  definition_id = "hp"
+  min_value = 0
+  max_value = 50
+  current_value = 50
+
+  [faction_relations.factions]
+  player = "hostile""#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/maps.rs
+++ b/src/instructions/maps.rs
@@ -1,114 +1,100 @@
 pub fn render() -> String {
-    let mut lines = vec![
-        "mudroom instructions maps — map and room config reference".to_string(),
-        String::new(),
-        "Maps define the navigable world: rooms, descriptions, exits, and entity".to_string(),
-        "placements. They live under the mud root in a nested directory hierarchy:".to_string(),
-        String::new(),
-        "  maps/<world_id>/<dungeon_id>/<room_id>.toml".to_string(),
-        String::new(),
-        "Each <world_id> directory holds one or more <dungeon_id> directories, and each"
-            .to_string(),
-        "<dungeon_id> directory holds one .toml file per room. Directory names become the"
-            .to_string(),
-        "world_id and dungeon_id; the room .toml filename (without the .toml extension)"
-            .to_string(),
-        "becomes the room_id.".to_string(),
+    let sections = [
+        header(),
+        naming_overrides(),
+        room_fields(),
+        examples(),
+        spawn_point(),
     ];
-    lines.extend(naming_overrides());
-    lines.extend(room_fields());
-    lines.extend(examples());
-    lines.extend(spawn_point());
-    lines.join("\n")
+    sections.join("\n\n")
 }
 
-fn naming_overrides() -> Vec<String> {
-    vec![
-        String::new(),
-        "Overriding names:".to_string(),
-        "  - Add a world.toml inside a <world_id> directory with a `name` key to override"
-            .to_string(),
-        "    the world's id (otherwise it defaults to the directory name).".to_string(),
-        "  - Add a dungeon.toml inside a <dungeon_id> directory with a `name` key to".to_string(),
-        "    override the dungeon's id (otherwise it defaults to the directory name).".to_string(),
-        "  - Add a `name` key at the top of a room .toml file to override that room's id"
-            .to_string(),
-        "    (otherwise it defaults to the filename stem).".to_string(),
-    ]
+fn header() -> String {
+    r#"mudroom instructions maps — map and room config reference
+
+Maps define the navigable world: rooms, descriptions, exits, and entity
+placements. They live under the mud root in a nested directory hierarchy:
+
+  maps/<world_id>/<dungeon_id>/<room_id>.toml
+
+Each <world_id> directory holds one or more <dungeon_id> directories, and each
+<dungeon_id> directory holds one .toml file per room. Directory names become the
+world_id and dungeon_id; the room .toml filename (without the .toml extension)
+becomes the room_id."#
+        .to_string()
 }
 
-fn room_fields() -> Vec<String> {
-    vec![
-        String::new(),
-        "Room fields:".to_string(),
-        "  - entities   — optional array of entity reference strings, e.g.".to_string(),
-        "                 [\"entities/innkeeper\"]. Paths are relative to the mud root and"
-            .to_string(),
-        "                 must match a corresponding file under entities/ (without the".to_string(),
-        "                 .toml extension).".to_string(),
-        "  - [description]".to_string(),
-        "      standard  — the room's prose description, shown to players.".to_string(),
-        "      checked   — optional list of conditional descriptions, each gated by an".to_string(),
-        "                  attribute check (attribute_id + expected_value). Rarely needed"
-            .to_string(),
-        "                  for basic authoring; defaults to an empty list.".to_string(),
-        "  - [north] / [south] / [east] / [west]".to_string(),
-        "      room_id   — the id of the room this exit leads to, another room .toml".to_string(),
-        "                  filename (or its `name` override) in the same".to_string(),
-        "                  <world_id>/<dungeon_id>/ directory. Omit the sub-table entirely"
-            .to_string(),
-        "                  to block movement in that direction. Cross-dungeon exits are"
-            .to_string(),
-        "                  not yet documented — keep exits within the same dungeon.".to_string(),
-    ]
+fn naming_overrides() -> String {
+    r#"Overriding names:
+  - Add a world.toml inside a <world_id> directory with a `name` key to override
+    the world's id (otherwise it defaults to the directory name).
+  - Add a dungeon.toml inside a <dungeon_id> directory with a `name` key to
+    override the dungeon's id (otherwise it defaults to the directory name).
+  - Add a `name` key at the top of a room .toml file to override that room's id
+    (otherwise it defaults to the filename stem)."#
+        .to_string()
 }
 
-fn examples() -> Vec<String> {
-    vec![
-        String::new(),
-        "Example room (muds/basic/maps/default/default/tavern.toml):".to_string(),
-        String::new(),
-        "  entities = [\"entities/innkeeper\"]".to_string(),
-        String::new(),
-        "  [description]".to_string(),
-        "  standard = \"A warm tavern with a crackling fireplace. The town square is to"
-            .to_string(),
-        "  the south. A dim corner lies to the east.\"".to_string(),
-        String::new(),
-        "  [south]".to_string(),
-        "  room_id = \"default\"".to_string(),
-        String::new(),
-        "  [east]".to_string(),
-        "  room_id = \"back_corner\"".to_string(),
-        String::new(),
-        "Example room — crossroads (muds/basic/maps/default/default/default.toml):".to_string(),
-        String::new(),
-        "  [description]".to_string(),
-        "  standard = \"You stand at the crossroads of a small town. A tavern lies to the"
-            .to_string(),
-        "  north. A dark corridor leads to the east.\"".to_string(),
-        String::new(),
-        "  [north]".to_string(),
-        "  room_id = \"tavern\"".to_string(),
-        String::new(),
-        "  [east]".to_string(),
-        "  room_id = \"dark_corridor\"".to_string(),
-    ]
+fn room_fields() -> String {
+    r#"Room fields:
+  - entities   — optional array of entity reference strings, e.g.
+                 ["entities/innkeeper"]. Paths are relative to the mud root and
+                 must match a corresponding file under entities/ (without the
+                 .toml extension).
+  - [description]
+      standard  — the room's prose description, shown to players.
+      checked   — optional list of conditional descriptions, each gated by an
+                  attribute check (attribute_id + expected_value). Rarely needed
+                  for basic authoring; defaults to an empty list.
+  - [north] / [south] / [east] / [west]
+      room_id   — the id of the room this exit leads to, another room .toml
+                  filename (or its `name` override) in the same
+                  <world_id>/<dungeon_id>/ directory. Omit the sub-table entirely
+                  to block movement in that direction. Cross-dungeon exits are
+                  not yet documented — keep exits within the same dungeon."#
+        .to_string()
 }
 
-fn spawn_point() -> Vec<String> {
-    vec![
-        String::new(),
-        "Spawn point:".to_string(),
-        "  mud.toml's [spawn] table references a room by world_id, dungeon_id, and".to_string(),
-        "  room_id, which must correspond to an existing".to_string(),
-        "  maps/<world_id>/<dungeon_id>/<room_id>.toml file:".to_string(),
-        String::new(),
-        "  [spawn]".to_string(),
-        "  world_id = \"default\"".to_string(),
-        "  dungeon_id = \"default\"".to_string(),
-        "  room_id = \"default\"".to_string(),
-    ]
+fn examples() -> String {
+    r#"Example room (muds/basic/maps/default/default/tavern.toml):
+
+  entities = ["entities/innkeeper"]
+
+  [description]
+  standard = "A warm tavern with a crackling fireplace. The town square is to
+  the south. A dim corner lies to the east."
+
+  [south]
+  room_id = "default"
+
+  [east]
+  room_id = "back_corner"
+
+Example room — crossroads (muds/basic/maps/default/default/default.toml):
+
+  [description]
+  standard = "You stand at the crossroads of a small town. A tavern lies to the
+  north. A dark corridor leads to the east."
+
+  [north]
+  room_id = "tavern"
+
+  [east]
+  room_id = "dark_corridor""#
+        .to_string()
+}
+
+fn spawn_point() -> String {
+    r#"Spawn point:
+  mud.toml's [spawn] table references a room by world_id, dungeon_id, and
+  room_id, which must correspond to an existing
+  maps/<world_id>/<dungeon_id>/<room_id>.toml file:
+
+  [spawn]
+  world_id = "default"
+  dungeon_id = "default"
+  room_id = "default""#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/mud_config.rs
+++ b/src/instructions/mud_config.rs
@@ -14,105 +14,97 @@ fn header() -> String {
 }
 
 fn directory_layout() -> String {
-    [
-        "Directory layout:",
-        "",
-        "  <mud-dir>/",
-        "    mud.toml              # top-level config (game_loop, spawn, agent, ...)",
-        "    attributes.toml       # global attribute definitions",
-        "    abilities/            # one .toml per ability",
-        "    classes/               # one .toml per class",
-        "    entities/              # one .toml per entity",
-        "    maps/",
-        "      <world_id>/",
-        "        <dungeon_id>/",
-        "          <room_id>.toml  # one file per room",
-    ]
-    .join("\n")
+    r#"Directory layout:
+
+  <mud-dir>/
+    mud.toml              # top-level config (game_loop, spawn, agent, ...)
+    attributes.toml       # global attribute definitions
+    abilities/            # one .toml per ability
+    classes/               # one .toml per class
+    entities/              # one .toml per entity
+    maps/
+      <world_id>/
+        <dungeon_id>/
+          <room_id>.toml  # one file per room"#
+        .to_string()
 }
 
 fn mud_toml_fields() -> String {
-    [
-        "mud.toml fields:",
-        "",
-        "  max_clients_per_machine  usize   Optional. Max clients allowed per machine.",
-        "                                   Defaults to 2.",
-        "",
-        "  [game_loop]",
-        "    tick_rate_ms      u64   How often the game loop ticks, in milliseconds.",
-        "    max_engage_ms     u64   Max duration of an engagement, in milliseconds.",
-        "    world_update_ms   u64   How often world state is persisted, in milliseconds.",
-        "",
-        "  [spawn]",
-        "    world_id    string   World new players spawn into.",
-        "    dungeon_id  string   Dungeon within that world.",
-        "    room_id     string   Room within that dungeon.",
-        "",
-        "  [agent.provider]",
-        "    type  string   Provider kind. One of: \"ollama\", \"anthropic\", \"open_ai\",",
-        "                   \"cohere\", \"gemini\", \"x_ai\".",
-        "",
-        "    Optional. Defaults to an ollama provider pointing at",
-        "    http://localhost:11434 with model \"llama3.2\" when [agent.provider] is",
-        "    omitted entirely.",
-        "",
-        "    Fields depend on the provider type:",
-        "      ollama:     base_url (string), model (string)",
-        "      anthropic:  api_key (string, optional), model (string)",
-        "      open_ai:    api_key (string, optional), base_url (string, optional),",
-        "                  model (string)",
-        "      cohere:     api_key (string, optional), model (string)",
-        "      gemini:     api_key (string, optional), model (string)",
-        "      x_ai:       api_key (string, optional), model (string)",
-        "",
-        "Example (muds/basic/mud.toml):",
-        "",
-        "  max_clients_per_machine = 2",
-        "",
-        "  [game_loop]",
-        "  tick_rate_ms = 500",
-        "  max_engage_ms = 60_000",
-        "  world_update_ms = 600000",
-        "",
-        "  [spawn]",
-        "  world_id = \"default\"",
-        "  dungeon_id = \"default\"",
-        "  room_id = \"default\"",
-        "",
-        "  [agent.provider]",
-        "  type = \"ollama\"",
-        "  base_url = \"$MUDROOM_OLLAMA_BASE_URL\"",
-        "  model = \"$MUDROOM_OLLAMA_MODEL\"",
-    ]
-    .join("\n")
+    r#"mud.toml fields:
+
+  max_clients_per_machine  usize   Optional. Max clients allowed per machine.
+                                   Defaults to 2.
+
+  [game_loop]
+    tick_rate_ms      u64   How often the game loop ticks, in milliseconds.
+    max_engage_ms     u64   Max duration of an engagement, in milliseconds.
+    world_update_ms   u64   How often world state is persisted, in milliseconds.
+
+  [spawn]
+    world_id    string   World new players spawn into.
+    dungeon_id  string   Dungeon within that world.
+    room_id     string   Room within that dungeon.
+
+  [agent.provider]
+    type  string   Provider kind. One of: "ollama", "anthropic", "open_ai",
+                   "cohere", "gemini", "x_ai".
+
+    Optional. Defaults to an ollama provider pointing at
+    http://localhost:11434 with model "llama3.2" when [agent.provider] is
+    omitted entirely.
+
+    Fields depend on the provider type:
+      ollama:     base_url (string), model (string)
+      anthropic:  api_key (string, optional), model (string)
+      open_ai:    api_key (string, optional), base_url (string, optional),
+                  model (string)
+      cohere:     api_key (string, optional), model (string)
+      gemini:     api_key (string, optional), model (string)
+      x_ai:       api_key (string, optional), model (string)
+
+Example (muds/basic/mud.toml):
+
+  max_clients_per_machine = 2
+
+  [game_loop]
+  tick_rate_ms = 500
+  max_engage_ms = 60_000
+  world_update_ms = 600000
+
+  [spawn]
+  world_id = "default"
+  dungeon_id = "default"
+  room_id = "default"
+
+  [agent.provider]
+  type = "ollama"
+  base_url = "$MUDROOM_OLLAMA_BASE_URL"
+  model = "$MUDROOM_OLLAMA_MODEL""#
+        .to_string()
 }
 
 fn env_var_substitution() -> String {
-    [
-        "Environment variable substitution:",
-        "",
-        "  String fields (and game_loop's integer fields, when written as a quoted",
-        "  string) support environment variable substitution. A value starting with",
-        "  \"$\" is treated as an environment variable name and resolved at load time;",
-        "  any other value is used literally. Loading fails if the referenced",
-        "  variable is not set.",
-        "",
-        "  Example: base_url = \"$MUDROOM_OLLAMA_BASE_URL\" resolves to the value of",
-        "  the MUDROOM_OLLAMA_BASE_URL environment variable.",
-    ]
-    .join("\n")
+    r#"Environment variable substitution:
+
+  String fields (and game_loop's integer fields, when written as a quoted
+  string) support environment variable substitution. A value starting with
+  "$" is treated as an environment variable name and resolved at load time;
+  any other value is used literally. Loading fails if the referenced
+  variable is not set.
+
+  Example: base_url = "$MUDROOM_OLLAMA_BASE_URL" resolves to the value of
+  the MUDROOM_OLLAMA_BASE_URL environment variable."#
+        .to_string()
 }
 
 fn related_topics() -> String {
-    [
-        "See also:",
-        "  mudroom instructions abilities   — abilities/*.toml reference",
-        "  mudroom instructions attributes  — attributes.toml reference",
-        "  mudroom instructions classes     — classes/*.toml reference",
-        "  mudroom instructions entities    — entities/*.toml reference",
-        "  mudroom instructions maps        — maps/<world>/<dungeon>/<room>.toml reference",
-    ]
-    .join("\n")
+    r#"See also:
+  mudroom instructions abilities   — abilities/*.toml reference
+  mudroom instructions attributes  — attributes.toml reference
+  mudroom instructions classes     — classes/*.toml reference
+  mudroom instructions entities    — entities/*.toml reference
+  mudroom instructions maps        — maps/<world>/<dungeon>/<room>.toml reference"#
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/instructions/top_level.rs
+++ b/src/instructions/top_level.rs
@@ -19,26 +19,26 @@ const TOPICS: &[(&str, &str)] = &[
     ),
 ];
 
+const HEADER: &str = r#"mudroom instructions — authoring guidance for mud config files
+
+Usage: mudroom instructions [topic]  (alias: mudroom info [topic])"#;
+
 pub fn render() -> String {
-    let mut lines = vec![
-        "mudroom instructions — authoring guidance for mud config files".to_string(),
-        String::new(),
-        "Usage: mudroom instructions [topic]  (alias: mudroom info [topic])".to_string(),
-    ];
+    let mut result = HEADER.to_string();
     if TOPICS.is_empty() {
-        lines.push(String::new());
-        lines.push("No topics are registered yet.".to_string());
+        result.push_str("\n\nNo topics are registered yet.");
     } else {
         let width = TOPICS.iter().map(|(name, _)| name.len()).max().unwrap_or(0);
-        lines.push(String::new());
-        lines.push("Topics:".to_string());
-        for (name, description) in TOPICS {
-            lines.push(format!(
-                "  mudroom instructions {name:<width$}  — {description}"
-            ));
-        }
+        result.push_str("\n\nTopics:\n");
+        let topic_lines: Vec<String> = TOPICS
+            .iter()
+            .map(|(name, description)| {
+                format!("  mudroom instructions {name:<width$}  — {description}")
+            })
+            .collect();
+        result.push_str(&topic_lines.join("\n"));
     }
-    lines.join("\n")
+    result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replaces the line-array-plus-join pattern in the `mudroom instructions <topic>` renderers with raw string literals, making the instructional prose readable as text instead of dozens of quoted, comma-separated array entries. Closes #212.

- Converted `abilities.rs`, `attributes.rs`, `classes.rs`, `entities.rs`, `maps.rs`, and `mud_config.rs` to build their static text from `r#"..."#` literals instead of `Vec<String>`/`&[&str]` + `.join("\n")`
- `maps.rs` was restructured to match the section-helper + `sections.join("\n\n")` convention already used by `abilities.rs`/`mud_config.rs`, for consistency across all six topics
- `top_level.rs`'s static header/usage lines became a `const HEADER: &str = r#"..."#` while its topic-list loop (generated from the `TOPICS` const, with column-width alignment) stays dynamic, as it must
- Rendered CLI output is byte-identical to before — verified via the existing `text.contains(...)` test assertions (all pass unchanged) plus manual `cargo run -- instructions <topic>` spot-checks

<details>
<summary>Agent Context</summary>

**Goal:** Improve source readability of `src/instructions/*.rs` without changing rendered output, per issue #212 (which itself follows on #197-#203, the original `instructions`/`info` CLI command and its six topics).

**Files changed:**
- `src/instructions/abilities.rs` — 8 section helper fns (`header`, `fields_section`, `engagement_types_section`, `costs_section`, `role_section`, `targets_section`, `effects_section`, `example_section`), each now returns one raw string literal; `render()`'s `sections.join("\n\n")` unchanged.
- `src/instructions/attributes.rs`, `classes.rs`, `entities.rs` — single flat `Vec<String>`/array collapsed into one raw string literal each. `entities.rs` was the worst offender (~90 `.to_string()` calls), now a single literal.
- `src/instructions/maps.rs` — previously built via `let mut lines = vec![...]; lines.extend(section())` where each section fn began with a `String::new()` separator element and everything joined with a single `"\n"`. Restructured to the `abilities.rs`/`mud_config.rs` convention: `header()`, `naming_overrides()`, `room_fields()`, `examples()`, `spawn_point()` each return a raw string literal (no leading blank-line element), and `render()` combines them via `[..].join("\n\n")` — mathematically equivalent output (one blank line between sections) to the old approach, verified by diffing CLI output before/after.
- `src/instructions/mud_config.rs` — same section-helper conversion as `abilities.rs`.
- `src/instructions/top_level.rs` — extracted the two static header/usage lines into `const HEADER: &str = r#"..."#`; the `TOPICS` loop (width-aligned `format!` per topic) stays dynamic since it's genuinely data-driven, per the issue's explicit scope note.

**Key technical decision:** used flush-left raw string literals (content starts immediately after `r#"`, ends immediately before closing `"#`, no leading/trailing newline) rather than adding the `indoc` crate for compile-time dedenting. This avoids a new pinned dependency (CLAUDE.md requires exact versions for any new `Cargo.toml` entry) for no functional benefit — the issue's own writeup flagged this as "a style call, not a formatter fight." Interior lines of each literal are flush to column 0 regardless of surrounding Rust indentation, which is standard practice for multi-line Rust string literals.

**Verification performed:**
- `cargo fmt` — no diff (formatter doesn't touch raw string interiors)
- `cargo test` — full suite (465 tests) passes; all `#[cfg(test)] mod tests` blocks in the six files assert `text.contains(...)` against literal content, unchanged
- `cargo clippy --all-targets` — no new warnings; confirmed the two pre-existing warnings (`attribute_config.rs` cognitive complexity, unused import in `battle/collection.rs`) exist identically on `main` via `git stash`
- Manual `cargo run -- instructions <topic>` for `entities`, `maps`, and the top-level topic list, confirming formatting/spacing/column-alignment is unchanged

**Out of scope (per issue):** `top_level.rs`'s `TOPICS` loop generation logic itself — can't be a static literal since it's derived at runtime from the const slice with computed column width.

**Unrelated fix bundled in the second commit:** the first commit's `git add -A` accidentally staged unrelated `.claude/worktrees/*` agent-worktree gitlinks (leftover from unrelated Claude Code sessions in this repo, not part of this change). The second commit removes them and adds `.claude/worktrees/` to `.gitignore` to prevent recurrence.

</details>