### PR TITLE
Fixes #191 Add pending attribute layer to battle engagement

### DIFF
--- a/src/game/engagement.rs
+++ b/src/game/engagement.rs
@@ -310,7 +310,14 @@ mod tests {
         engagements
             .add_battle("room1".to_string(), factions, participants)
             .await;
-        let results = engagements.battles.tick_all(30).await;
+        let results = engagements
+            .battles
+            .tick_all(
+                30,
+                &HashMap::new(),
+                &crate::game::config::AttributeConfig::default_config(),
+            )
+            .await;
         assert_eq!(results.len(), 1);
         assert_eq!(
             results[0].phase,

--- a/src/game/engagement/battle/collection.rs
+++ b/src/game/engagement/battle/collection.rs
@@ -2,10 +2,13 @@ use std::collections::HashMap;
 
 use tokio::sync::RwLock;
 
-use crate::game::component::{Ability, Attribute};
+use crate::game::component::effect::Effect;
+use crate::game::component::{Ability, Attribute, ResetCondition};
+use crate::game::config::AttributeConfig;
 use crate::game::engagement::{Engagement, EngagementType};
+use crate::game::entity::Entity;
 
-use super::{BattleAiContext, BattlePhase, BattleTick, factory};
+use super::{BattleAiContext, BattleMessage, BattlePhase, BattleTick, factory, resolution};
 
 pub struct Battles {
     pub(in crate::game::engagement) map: RwLock<HashMap<i64, Engagement>>,
@@ -42,15 +45,98 @@ impl Battles {
             .map(|e| e.id)
     }
 
-    pub async fn tick_all(&self, max_engage_ticks: u64) -> Vec<BattleTick> {
+    pub async fn tick_all(
+        &self,
+        max_engage_ticks: u64,
+        entities: &HashMap<i64, Entity>,
+        attribute_config: &AttributeConfig,
+    ) -> Vec<BattleTick> {
         let mut map = self.map.write().await;
         let mut results = Vec::new();
         for engagement in map.values_mut() {
             if let Some(battle) = &mut engagement.battle {
-                results.push(battle.tick(engagement.id, max_engage_ticks));
+                results.push(battle.tick(
+                    engagement.id,
+                    max_engage_ticks,
+                    entities,
+                    attribute_config,
+                ));
             }
         }
         results
+    }
+
+    /// Resolves effects for a target within a specific battle engagement, routing attribute
+    /// updates through that engagement's pending attribute working copy rather than the
+    /// entity's actual state.
+    pub async fn resolve_battle_effects(
+        &self,
+        engagement_id: i64,
+        target_id: i64,
+        effects: Vec<Effect>,
+        entities: &mut HashMap<i64, Entity>,
+    ) -> Vec<BattleMessage> {
+        let mut map = self.map.write().await;
+        let Some(engagement) = map.get_mut(&engagement_id) else {
+            return vec![];
+        };
+        let Some(battle) = &mut engagement.battle else {
+            return vec![];
+        };
+        resolution::resolve_effects(
+            target_id,
+            effects,
+            entities,
+            &mut battle.pending_entity_attributes,
+        )
+    }
+
+    /// Copies every `Never`-reset-condition attribute from the engagement's pending working
+    /// copy back into the actual entities. Called once, at the end of the Resolution phase,
+    /// after this round's queued effects have already been applied to pending.
+    pub async fn flush_never_attributes(
+        &self,
+        engagement_id: i64,
+        attribute_config: &AttributeConfig,
+        entities: &mut HashMap<i64, Entity>,
+    ) {
+        let map = self.map.read().await;
+        let Some(engagement) = map.get(&engagement_id) else {
+            return;
+        };
+        let Some(battle) = &engagement.battle else {
+            return;
+        };
+        let never_ids: Vec<&str> = attribute_config
+            .attributes
+            .iter()
+            .filter(|def| def.reset_condition == ResetCondition::Never)
+            .map(|def| def.id.as_str())
+            .collect();
+        for (entity_id, pending_attrs) in &battle.pending_entity_attributes {
+            let Some(entity) = entities.get_mut(entity_id) else {
+                continue;
+            };
+            for &attr_id in &never_ids {
+                if let Some(attr) = pending_attrs.get(attr_id) {
+                    entity.attributes.insert(attr_id.to_string(), attr.clone());
+                }
+            }
+        }
+    }
+
+    /// Returns a clone of the engagement's pending attribute working copy (empty if the
+    /// engagement or its battle isn't found), used to prefer in-turn pending values over actual
+    /// entity state when making battle decisions (e.g. turn order).
+    pub async fn pending_attributes(
+        &self,
+        engagement_id: i64,
+    ) -> HashMap<i64, HashMap<String, Attribute>> {
+        let map = self.map.read().await;
+        map.get(&engagement_id)
+            .and_then(|engagement| engagement.battle.as_ref())
+            .map(|battle| battle.pending_entity_attributes.clone())
+            .unwrap_or_default()
     }
 
     pub async fn update_participants(&self, engagement_id: i64, dead_entity_ids: &[i64]) -> usize {
@@ -139,7 +225,6 @@ impl Default for Battles {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::game::engagement::battle::factory;
 
     fn test_participants() -> (Vec<String>, HashMap<String, Vec<i64>>) {
         let mut participants = HashMap::new();
@@ -181,7 +266,9 @@ mod tests {
     #[tokio::test]
     async fn tick_all_advances_battle_phase() {
         let battles = make_battles().await;
-        let results = battles.tick_all(30).await;
+        let results = battles
+            .tick_all(30, &HashMap::new(), &AttributeConfig::default_config())
+            .await;
         assert_eq!(results.len(), 1);
         assert_eq!(
             results[0].phase,
@@ -222,5 +309,121 @@ mod tests {
         let eng = map.get(&1).unwrap();
         assert_eq!(eng.room_id, Some("room1".to_string()));
         assert_eq!(eng.engagement_type, EngagementType::Battle);
+    }
+
+    fn never_hp_config() -> AttributeConfig {
+        use crate::game::component::{AttributeCategory, AttributeDefinition};
+
+        AttributeConfig {
+            attributes: vec![AttributeDefinition {
+                id: "hp".to_string(),
+                title: "Hit Points".to_string(),
+                description: String::new(),
+                min_value: 0,
+                max_value: 100,
+                attribute_type: crate::game::component::AttributeType::HP,
+                attribute_category: AttributeCategory::Life,
+                reset_condition: ResetCondition::Never,
+            }],
+        }
+    }
+
+    fn entity_with_hp(id: i64, hp: i64) -> Entity {
+        use crate::game::component::Location;
+        use crate::game::entity::EntityType;
+
+        let loc = Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        };
+        let mut entity = Entity::new(id, EntityType::Player, loc);
+        entity.attributes.insert(
+            "hp".to_string(),
+            Attribute::new("hp".to_string(), 0, 100, hp),
+        );
+        entity
+    }
+
+    #[tokio::test]
+    async fn flush_never_attributes_copies_pending_hp_to_actual() {
+        let battles = make_battles().await;
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_hp(1, 100));
+
+        {
+            let mut map = battles.map.write().await;
+            let battle = map.get_mut(&1).unwrap().battle.as_mut().unwrap();
+            battle.pending_entity_attributes.insert(
+                1,
+                HashMap::from([(
+                    "hp".to_string(),
+                    Attribute::new("hp".to_string(), 0, 100, 42),
+                )]),
+            );
+        }
+
+        battles
+            .flush_never_attributes(1, &never_hp_config(), &mut entities)
+            .await;
+
+        assert_eq!(entities[&1].attributes["hp"].current_value, 42);
+    }
+
+    #[tokio::test]
+    async fn flush_never_attributes_leaves_pending_intact() {
+        let battles = make_battles().await;
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_hp(1, 100));
+
+        {
+            let mut map = battles.map.write().await;
+            let battle = map.get_mut(&1).unwrap().battle.as_mut().unwrap();
+            battle.pending_entity_attributes.insert(
+                1,
+                HashMap::from([(
+                    "hp".to_string(),
+                    Attribute::new("hp".to_string(), 0, 100, 42),
+                )]),
+            );
+        }
+
+        battles
+            .flush_never_attributes(1, &never_hp_config(), &mut entities)
+            .await;
+
+        let map = battles.map.read().await;
+        let battle = map[&1].battle.as_ref().unwrap();
+        assert_eq!(battle.pending_entity_attributes[&1]["hp"].current_value, 42);
+    }
+
+    #[tokio::test]
+    async fn resolve_battle_effects_writes_pending_not_actual() {
+        use crate::game::component::effect::{
+            Effect, EffectDescription, EffectScope, EffectType, TriggerInfo,
+        };
+
+        let battles = make_battles().await;
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_hp(1, 100));
+        let effects = vec![Effect {
+            name: "damage".to_string(),
+            effect_type: EffectType::AttributeUpdate {
+                attribute_id: "hp".to_string(),
+                value: -10,
+            },
+            trigger_info: TriggerInfo::Once,
+            description: EffectDescription::default(),
+            scope: EffectScope::default(),
+        }];
+
+        battles
+            .resolve_battle_effects(1, 1, effects, &mut entities)
+            .await;
+
+        assert_eq!(entities[&1].attributes["hp"].current_value, 100);
+        let map = battles.map.read().await;
+        let battle = map[&1].battle.as_ref().unwrap();
+        assert_eq!(battle.pending_entity_attributes[&1]["hp"].current_value, 90);
     }
 }

--- a/src/game/engagement/battle/resolution.rs
+++ b/src/game/engagement/battle/resolution.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::game::component::Attribute;
 use crate::game::component::effect::{Effect, EffectType, TriggerInfo};
 use crate::game::entity::Entity;
 
@@ -14,22 +15,31 @@ pub fn resolve_effects(
     target_id: i64,
     mut effects: Vec<Effect>,
     entities: &mut HashMap<i64, Entity>,
+    pending: &mut HashMap<i64, HashMap<String, Attribute>>,
 ) -> Vec<BattleMessage> {
     let Some(entity) = entities.get_mut(&target_id) else {
         return vec![];
     };
     effects.sort_by_key(|e| e.effect_type.resolution_order());
     let mut context = ResolutionContext::default();
+    let target_pending = pending.entry(target_id).or_default();
     for effect in &effects {
-        resolve_effect(effect, entity, &mut context);
+        resolve_effect(effect, entity, target_pending, &mut context);
     }
     vec![]
 }
 
-fn resolve_effect(effect: &Effect, entity: &mut Entity, context: &mut ResolutionContext) {
+fn resolve_effect(
+    effect: &Effect,
+    entity: &mut Entity,
+    pending: &mut HashMap<String, Attribute>,
+    context: &mut ResolutionContext,
+) {
     match &effect.effect_type {
         EffectType::AttributeShield { .. } => apply_attribute_shield(effect, entity, context),
-        EffectType::AttributeUpdate { .. } => apply_attribute_update(effect, entity, context),
+        EffectType::AttributeUpdate { .. } => {
+            apply_attribute_update(effect, entity, pending, context)
+        }
         EffectType::EntitySpawn { .. } => apply_entity_spawn(effect, entity, context),
     }
 }
@@ -41,7 +51,12 @@ fn apply_attribute_shield(effect: &Effect, entity: &mut Entity, context: &mut Re
     }
 }
 
-fn apply_attribute_update(effect: &Effect, entity: &mut Entity, context: &mut ResolutionContext) {
+fn apply_attribute_update(
+    effect: &Effect,
+    entity: &Entity,
+    pending: &mut HashMap<String, Attribute>,
+    context: &mut ResolutionContext,
+) {
     let EffectType::AttributeUpdate {
         attribute_id,
         value,
@@ -53,7 +68,12 @@ fn apply_attribute_update(effect: &Effect, entity: &mut Entity, context: &mut Re
         return;
     }
     let adjusted = absorb_with_shields(&mut context.once_shields, attribute_id, *value);
-    if let Some(attr) = entity.attributes.get_mut(attribute_id) {
+    if !pending.contains_key(attribute_id)
+        && let Some(actual) = entity.attributes.get(attribute_id)
+    {
+        pending.insert(attribute_id.clone(), actual.clone());
+    }
+    if let Some(attr) = pending.get_mut(attribute_id) {
         attr.current_value = (attr.current_value + adjusted)
             .max(attr.min_value)
             .min(attr.max_value);
@@ -168,24 +188,31 @@ mod tests {
         entities
     }
 
+    fn no_pending() -> HashMap<i64, HashMap<String, Attribute>> {
+        HashMap::new()
+    }
+
     #[test]
     fn shield_absorbs_partial_damage_and_is_consumed() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         // Shield and damage come through the same resolution pass
         resolve_effects(
             1,
             vec![shield_effect(5, TriggerInfo::Once), damage_effect(-10)],
             &mut entities,
+            &mut pending,
         );
 
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 95);
-        assert!(entity.active_effects.is_empty());
+        assert_eq!(pending[&1]["hp"].current_value, 95);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 100);
+        assert!(entities[&1].active_effects.is_empty());
     }
 
     #[test]
     fn over_time_shield_is_stubbed_and_not_applied() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         let over_time_shield = shield_effect(
             5,
             TriggerInfo::OverTime {
@@ -195,88 +222,93 @@ mod tests {
             },
         );
 
-        resolve_effects(1, vec![over_time_shield, damage_effect(-10)], &mut entities);
+        resolve_effects(
+            1,
+            vec![over_time_shield, damage_effect(-10)],
+            &mut entities,
+            &mut pending,
+        );
 
-        let entity = entities.get(&1).unwrap();
         // OverTime shield pushed to active_effects but not applied — full damage lands
-        assert_eq!(entity.attributes["hp"].current_value, 90);
-        assert_eq!(entity.active_effects.len(), 1);
+        assert_eq!(pending[&1]["hp"].current_value, 90);
+        assert_eq!(entities[&1].active_effects.len(), 1);
     }
 
     #[test]
     fn shield_does_not_affect_positive_attribute_updates() {
         let mut entities = single_entity(50);
+        let mut pending = no_pending();
         let effects = vec![shield_effect(5, TriggerInfo::Once), damage_effect(10)];
 
-        resolve_effects(1, effects, &mut entities);
+        resolve_effects(1, effects, &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 60);
+        assert_eq!(pending[&1]["hp"].current_value, 60);
         // Shield is still present since heals don't trigger it
         // (shield was in same-pass effects, not active_effects — it's simply not consumed)
-        assert!(entity.active_effects.is_empty());
+        assert!(entities[&1].active_effects.is_empty());
     }
 
     #[test]
     fn defend_and_attack_in_same_pass_shield_intercepts() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
 
         // Simulate: defend (shield 5) + attack (-10) queued for same target in same resolution pass
         let effects = vec![shield_effect(5, TriggerInfo::Once), damage_effect(-10)];
 
-        resolve_effects(1, effects, &mut entities);
+        resolve_effects(1, effects, &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
         // Shield absorbed 5, 5 damage gets through
-        assert_eq!(entity.attributes["hp"].current_value, 95);
-        assert!(entity.active_effects.is_empty());
+        assert_eq!(pending[&1]["hp"].current_value, 95);
+        assert!(entities[&1].active_effects.is_empty());
     }
 
     #[test]
     fn shield_fully_absorbs_attack() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         let effects = vec![shield_effect(20, TriggerInfo::Once), damage_effect(-10)];
 
-        resolve_effects(1, effects, &mut entities);
+        resolve_effects(1, effects, &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 100);
-        assert!(entity.active_effects.is_empty());
+        assert_eq!(pending[&1]["hp"].current_value, 100);
+        assert!(entities[&1].active_effects.is_empty());
     }
 
     #[test]
     fn shield_depletes_across_multiple_hits_until_exhausted() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         let effects = vec![
             shield_effect(8, TriggerInfo::Once),
             damage_effect(-5),
             damage_effect(-5),
         ];
 
-        resolve_effects(1, effects, &mut entities);
+        resolve_effects(1, effects, &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
         // Shield absorbs 5 from first hit (3 remaining), then 3 from second (exhausted),
         // leaving 2 damage through
-        assert_eq!(entity.attributes["hp"].current_value, 98);
-        assert!(entity.active_effects.is_empty());
+        assert_eq!(pending[&1]["hp"].current_value, 98);
+        assert!(entities[&1].active_effects.is_empty());
     }
 
     #[test]
     fn absorb_clamps_to_zero_not_positive() {
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         let effects = vec![shield_effect(20, TriggerInfo::Once), damage_effect(-10)];
 
-        resolve_effects(1, effects, &mut entities);
+        resolve_effects(1, effects, &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.attributes["hp"].current_value, 100);
+        assert_eq!(pending[&1]["hp"].current_value, 100);
     }
 
     #[test]
     fn unknown_target_is_noop() {
         let mut entities: HashMap<i64, Entity> = HashMap::new();
-        let messages = resolve_effects(99, vec![damage_effect(-10)], &mut entities);
+        let mut pending = no_pending();
+        let messages = resolve_effects(99, vec![damage_effect(-10)], &mut entities, &mut pending);
         assert!(messages.is_empty());
     }
 
@@ -284,6 +316,7 @@ mod tests {
     fn applying_shield_effect_directly_adds_to_active_effects_via_over_time() {
         // Verifies OverTime shields are stored for future use
         let mut entities = single_entity(100);
+        let mut pending = no_pending();
         let over_time_shield = shield_effect(
             5,
             TriggerInfo::OverTime {
@@ -293,17 +326,52 @@ mod tests {
             },
         );
 
-        resolve_effects(1, vec![over_time_shield], &mut entities);
+        resolve_effects(1, vec![over_time_shield], &mut entities, &mut pending);
 
-        let entity = entities.get(&1).unwrap();
-        assert_eq!(entity.active_effects.len(), 1);
-        assert_eq!(entity.attributes["hp"].current_value, 100);
+        assert_eq!(entities[&1].active_effects.len(), 1);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 100);
     }
 
     #[test]
     fn attack_ability_effects_resolve_correctly() {
         let mut entities = single_entity(100);
-        resolve_effects(1, attack_ability(-10).effects, &mut entities);
-        assert_eq!(entities[&1].attributes["hp"].current_value, 90);
+        let mut pending = no_pending();
+        resolve_effects(1, attack_ability(-10).effects, &mut entities, &mut pending);
+        assert_eq!(pending[&1]["hp"].current_value, 90);
+    }
+
+    #[test]
+    fn attribute_update_does_not_mutate_actual_entity() {
+        let mut entities = single_entity(100);
+        let mut pending = no_pending();
+        resolve_effects(1, vec![damage_effect(-10)], &mut entities, &mut pending);
+
+        assert_eq!(pending[&1]["hp"].current_value, 90);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 100);
+    }
+
+    #[test]
+    fn attribute_update_seeds_pending_from_actual_when_absent() {
+        let mut entities = single_entity(75);
+        let mut pending = no_pending();
+        resolve_effects(1, vec![damage_effect(-5)], &mut entities, &mut pending);
+
+        assert_eq!(pending[&1]["hp"].current_value, 70);
+    }
+
+    #[test]
+    fn attribute_update_uses_existing_pending_value_not_actual() {
+        let mut entities = single_entity(100);
+        let mut pending = no_pending();
+        pending
+            .entry(1)
+            .or_default()
+            .insert("hp".to_string(), hp_attribute(50));
+
+        resolve_effects(1, vec![damage_effect(-10)], &mut entities, &mut pending);
+
+        // Started from the existing pending value (50), not actual (100)
+        assert_eq!(pending[&1]["hp"].current_value, 40);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 100);
     }
 }

--- a/src/game/engagement/battle/state.rs
+++ b/src/game/engagement/battle/state.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::game::component::{Ability, Attribute, Cost};
+use crate::game::component::{Ability, Attribute, Cost, ResetCondition};
+use crate::game::config::AttributeConfig;
 use crate::game::entity::Entity;
 
 use super::{BattleMessage, BattlePhase, BattleTick, QueuedAbility};
@@ -21,6 +22,7 @@ pub struct BattleEngagement {
     turn_count: u64,
     pending_costs: HashMap<i64, Vec<(String, i64)>>,
     planning_faction_index: usize,
+    pub pending_entity_attributes: HashMap<i64, HashMap<String, Attribute>>,
 }
 
 impl BattleEngagement {
@@ -35,6 +37,7 @@ impl BattleEngagement {
             turn_count: 0,
             pending_costs: HashMap::new(),
             planning_faction_index: 0,
+            pending_entity_attributes: HashMap::new(),
         }
     }
 
@@ -97,7 +100,12 @@ impl BattleEngagement {
                 resource_id,
                 amount,
             } = cost;
-            match entity_attrs.get(resource_id) {
+            let current = self
+                .pending_entity_attributes
+                .get(&caster_id)
+                .and_then(|attrs| attrs.get(resource_id))
+                .or_else(|| entity_attrs.get(resource_id));
+            match current {
                 Some(attr) if attr.current_value >= *amount => {}
                 _ => return false,
             }
@@ -154,6 +162,7 @@ impl BattleEngagement {
         self.action_queue.remove(&entity_id);
         self.skipped_ids.remove(&entity_id);
         self.pending_costs.remove(&entity_id);
+        self.pending_entity_attributes.remove(&entity_id);
     }
 
     pub fn surviving_faction_count(&self) -> usize {
@@ -163,9 +172,15 @@ impl BattleEngagement {
             .count()
     }
 
-    pub fn tick(&mut self, engagement_id: i64, max_engage_ticks: u64) -> BattleTick {
+    pub fn tick(
+        &mut self,
+        engagement_id: i64,
+        max_engage_ticks: u64,
+        entities: &HashMap<i64, Entity>,
+        attribute_config: &AttributeConfig,
+    ) -> BattleTick {
         let all_participant_ids = self.all_entity_ids();
-        let output = self.advance_phase(max_engage_ticks, &all_participant_ids);
+        let output = self.advance_phase(max_engage_ticks, entities, attribute_config);
         BattleTick {
             engagement_id,
             all_participant_ids,
@@ -182,7 +197,12 @@ impl BattleEngagement {
 
     /// Drives the phase state machine one step, returning messages and queued work produced by
     /// the transition. Advances `self.turn_phase` and resets `self.ticks_in_phase` as needed.
-    fn advance_phase(&mut self, max_engage_ticks: u64, _all_ids: &[i64]) -> PhaseOutput {
+    fn advance_phase(
+        &mut self,
+        max_engage_ticks: u64,
+        entities: &HashMap<i64, Entity>,
+        attribute_config: &AttributeConfig,
+    ) -> PhaseOutput {
         let mut out = PhaseOutput {
             messages: Vec::new(),
             resolution_queue: Vec::new(),
@@ -191,6 +211,7 @@ impl BattleEngagement {
         match self.turn_phase.clone() {
             BattlePhase::InnateEffects => {
                 self.turn_count += 1;
+                self.refresh_pending_attributes(entities, attribute_config);
                 let next = BattlePhase::Planning {
                     faction: self.planning_faction().to_string(),
                 };
@@ -253,6 +274,38 @@ impl BattleEngagement {
         }
         out
     }
+
+    /// Refreshes the pending attribute working copy for every participant at the start of a
+    /// faction turn: `EachEngagementTurn` attributes always reset to the actual value;
+    /// `EndOfEngagement` and `Never` attributes are only seeded from actual the first time (so
+    /// in-progress changes from earlier turns aren't clobbered).
+    fn refresh_pending_attributes(
+        &mut self,
+        entities: &HashMap<i64, Entity>,
+        attribute_config: &AttributeConfig,
+    ) {
+        for entity_id in self.all_entity_ids() {
+            let Some(entity) = entities.get(&entity_id) else {
+                continue;
+            };
+            let pending = self.pending_entity_attributes.entry(entity_id).or_default();
+            for def in &attribute_config.attributes {
+                let Some(actual) = entity.attributes.get(&def.id) else {
+                    continue;
+                };
+                match def.reset_condition {
+                    ResetCondition::EachEngagementTurn => {
+                        pending.insert(def.id.clone(), actual.clone());
+                    }
+                    ResetCondition::EndOfEngagement | ResetCondition::Never => {
+                        pending
+                            .entry(def.id.clone())
+                            .or_insert_with(|| actual.clone());
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -261,9 +314,13 @@ mod tests {
     use crate::game::component::effect::{
         Effect, EffectDescription, EffectScope, EffectType, TriggerInfo,
     };
-    use crate::game::component::{Ability, Attribute, Cost};
+    use crate::game::component::location::Location;
+    use crate::game::component::{
+        Ability, Attribute, AttributeCategory, AttributeDefinition, AttributeType, Cost,
+    };
     use crate::game::engagement::EngagementType;
     use crate::game::engagement::battle::{BattleMessage, BattlePhase};
+    use crate::game::entity::EntityType;
     use std::collections::HashMap;
 
     use super::*;
@@ -329,7 +386,7 @@ mod tests {
     #[test]
     fn tick_innate_effects_transitions_to_planning() {
         let mut eng = make_engagement();
-        let tick = eng.tick(1, 30);
+        let tick = eng.tick(1, 30, &HashMap::new(), &AttributeConfig::default_config());
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Planning {
@@ -349,21 +406,21 @@ mod tests {
     fn turn_count_increments_each_innate_effects_phase() {
         let mut eng = make_engagement();
         assert_eq!(eng.turn_count, 0);
-        eng.tick(1, 1); // InnateEffects → Planning (turn_count becomes 1)
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning (turn_count becomes 1)
         assert_eq!(eng.turn_count, 1);
-        eng.tick(1, 1); // Planning → Response
-        eng.tick(1, 1); // Response → Resolution
-        eng.tick(1, 1); // Resolution → InnateEffects (still 1, InnateEffects hasn't fired yet)
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // Planning → Response
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // Response → Resolution
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // Resolution → InnateEffects (still 1, InnateEffects hasn't fired yet)
         assert_eq!(eng.turn_count, 1);
-        eng.tick(1, 1); // InnateEffects fires again → Planning (turn_count becomes 2)
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects fires again → Planning (turn_count becomes 2)
         assert_eq!(eng.turn_count, 2);
     }
 
     #[test]
     fn tick_planning_waits_for_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 30); // InnateEffects → Planning
-        let tick = eng.tick(1, 30);
+        eng.tick(1, 30, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning
+        let tick = eng.tick(1, 30, &HashMap::new(), &AttributeConfig::default_config());
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Planning {
@@ -376,8 +433,8 @@ mod tests {
     #[test]
     fn tick_planning_advances_on_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // InnateEffects → Planning{player}
-        let tick = eng.tick(1, 1); // timeout → Response{player}
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning{player}
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // timeout → Response{player}
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Response {
@@ -395,9 +452,9 @@ mod tests {
     #[test]
     fn tick_response_advances_on_timeout() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // InnateEffects → Planning
-        eng.tick(1, 1); // timeout → Response
-        let tick = eng.tick(1, 1); // timeout → Resolution
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // timeout → Response
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // timeout → Resolution
         assert_eq!(eng.turn_phase, BattlePhase::Resolution);
         assert!(tick.messages.iter().any(|m| matches!(
             m,
@@ -410,10 +467,10 @@ mod tests {
     #[test]
     fn tick_resolution_drains_queue_and_resets() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // → Planning
-        eng.tick(1, 1); // → Response
-        eng.tick(1, 1); // → Resolution
-        let tick = eng.tick(1, 1); // Resolution → InnateEffects
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Planning
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Response
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Resolution
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // Resolution → InnateEffects
         assert_eq!(eng.turn_phase, BattlePhase::InnateEffects);
         assert!(tick.messages.iter().any(|m| matches!(
             m,
@@ -427,12 +484,12 @@ mod tests {
     fn tick_resolution_advances_planning_faction_index() {
         let mut eng = make_engagement();
         assert_eq!(eng.planning_faction_index, 0);
-        eng.tick(1, 1); // → Planning{player}
-        eng.tick(1, 1); // → Response{player}
-        eng.tick(1, 1); // → Resolution
-        eng.tick(1, 1); // Resolution → InnateEffects (index advances to 1)
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Planning{player}
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Response{player}
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // → Resolution
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // Resolution → InnateEffects (index advances to 1)
         assert_eq!(eng.planning_faction_index, 1);
-        let tick = eng.tick(1, 1); // InnateEffects → Planning{enemy}
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning{enemy}
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Planning {
@@ -451,7 +508,7 @@ mod tests {
     fn tick_concluded_is_noop() {
         let mut eng = make_engagement();
         eng.turn_phase = BattlePhase::Concluded;
-        let tick = eng.tick(1, 30);
+        let tick = eng.tick(1, 30, &HashMap::new(), &AttributeConfig::default_config());
         assert_eq!(eng.turn_phase, BattlePhase::Concluded);
         assert!(tick.messages.is_empty());
     }
@@ -459,7 +516,7 @@ mod tests {
     #[test]
     fn tick_planning_to_response_includes_pending_actions() {
         let mut eng = make_engagement();
-        eng.tick(1, 30); // InnateEffects → Planning{player}
+        eng.tick(1, 30, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning{player}
         let ability = Ability {
             id: "slash".to_string(),
             name: "Slash".to_string(),
@@ -474,7 +531,7 @@ mod tests {
         };
         let attrs = HashMap::new();
         eng.queue_ability(1, ability.clone(), 2, &attrs);
-        let tick = eng.tick(1, 1); // timeout → Response{player}
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // timeout → Response{player}
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Response {
@@ -489,8 +546,8 @@ mod tests {
     #[test]
     fn tick_planning_to_response_empty_pending_actions_when_no_queued() {
         let mut eng = make_engagement();
-        eng.tick(1, 1); // InnateEffects → Planning
-        let tick = eng.tick(1, 1); // timeout → Response
+        eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // InnateEffects → Planning
+        let tick = eng.tick(1, 1, &HashMap::new(), &AttributeConfig::default_config()); // timeout → Response
         assert_eq!(
             eng.turn_phase,
             BattlePhase::Response {
@@ -529,5 +586,107 @@ mod tests {
         };
         let attrs: HashMap<String, Attribute> = HashMap::new(); // no mp
         assert!(!eng.queue_ability(1, ability, 2, &attrs));
+    }
+
+    fn test_attribute_config() -> AttributeConfig {
+        AttributeConfig {
+            attributes: vec![
+                AttributeDefinition {
+                    id: "hp".to_string(),
+                    title: "Hit Points".to_string(),
+                    description: String::new(),
+                    min_value: 0,
+                    max_value: 100,
+                    attribute_type: AttributeType::HP,
+                    attribute_category: AttributeCategory::Life,
+                    reset_condition: ResetCondition::Never,
+                },
+                AttributeDefinition {
+                    id: "speed".to_string(),
+                    title: "Speed".to_string(),
+                    description: String::new(),
+                    min_value: 0,
+                    max_value: 100,
+                    attribute_type: AttributeType::Stat,
+                    attribute_category: AttributeCategory::Speed,
+                    reset_condition: ResetCondition::EachEngagementTurn,
+                },
+            ],
+        }
+    }
+
+    fn entity_with_attrs(id: i64, hp: i64, speed: i64) -> Entity {
+        let loc = Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        };
+        let mut entity = Entity::new(id, EntityType::Player, loc);
+        entity.attributes.insert(
+            "hp".to_string(),
+            Attribute::new("hp".to_string(), 0, 100, hp),
+        );
+        entity.attributes.insert(
+            "speed".to_string(),
+            Attribute::new("speed".to_string(), 0, 100, speed),
+        );
+        entity
+    }
+
+    #[test]
+    fn innate_effects_resets_each_engagement_turn_attr_to_actual() {
+        let mut eng = make_engagement();
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_attrs(1, 100, 10));
+        let config = test_attribute_config();
+
+        // Pretend a prior in-turn effect changed pending speed away from actual.
+        eng.pending_entity_attributes.insert(
+            1,
+            HashMap::from([(
+                "speed".to_string(),
+                Attribute::new("speed".to_string(), 0, 100, 99),
+            )]),
+        );
+
+        eng.tick(1, 30, &entities, &config); // InnateEffects → Planning
+
+        assert_eq!(eng.pending_entity_attributes[&1]["speed"].current_value, 10);
+    }
+
+    #[test]
+    fn innate_effects_does_not_reset_never_attr() {
+        let mut eng = make_engagement();
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_attrs(1, 100, 10));
+        let config = test_attribute_config();
+
+        // hp already has a pending value that diverges from actual (e.g. mid-battle damage
+        // not yet flushed) — the InnateEffects refresh must not clobber it.
+        eng.pending_entity_attributes.insert(
+            1,
+            HashMap::from([(
+                "hp".to_string(),
+                Attribute::new("hp".to_string(), 0, 100, 50),
+            )]),
+        );
+
+        eng.tick(1, 30, &entities, &config); // InnateEffects → Planning
+
+        assert_eq!(eng.pending_entity_attributes[&1]["hp"].current_value, 50);
+    }
+
+    #[test]
+    fn innate_effects_initializes_never_attr_from_actual_on_first_turn() {
+        let mut eng = make_engagement();
+        let mut entities = HashMap::new();
+        entities.insert(1, entity_with_attrs(1, 80, 10));
+        let config = test_attribute_config();
+
+        assert!(eng.pending_entity_attributes.is_empty());
+
+        eng.tick(1, 30, &entities, &config); // first InnateEffects → Planning
+
+        assert_eq!(eng.pending_entity_attributes[&1]["hp"].current_value, 80);
     }
 }

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::game::component::Attribute;
 use crate::game::component::AttributeType;
 use crate::game::component::effect::{EffectScope, TriggerInfo};
 use crate::game::config::AttributeConfig;
@@ -10,7 +11,6 @@ use crate::game::messaging::{BattleParticipantInfo, BattleUpdateMessage};
 use crate::game::narration::{TextResolver, VariableMap, effect_text};
 use crate::game::{GameState, messaging};
 
-use super::resolution;
 use super::{
     BattleMessage, BattlePhase, BattleTick, QueuedAbility, entity_innate_battle_abilities,
 };
@@ -28,11 +28,14 @@ struct BattleTickOutcome {
 /// This is the single entry point for battle processing; no battle-specific logic escapes
 /// into the engagement orchestration layer.
 pub async fn process_ticks(game_state: &Arc<GameState>, max_engage_ticks: u64) {
-    let battle_results = game_state
-        .engagements
-        .battles
-        .tick_all(max_engage_ticks)
-        .await;
+    let battle_results = {
+        let entities = game_state.active_entities.read().await;
+        game_state
+            .engagements
+            .battles
+            .tick_all(max_engage_ticks, &entities, &game_state.attribute_config)
+            .await
+    };
     for result in battle_results {
         let outcome = handle_tick(game_state, result, max_engage_ticks).await;
         let surviving = game_state
@@ -68,20 +71,18 @@ async fn handle_tick(
 
     let (entity_names, speed_sorted_casters) = collect_entity_data(game_state, &result).await;
 
-    let mut cast_messages = Vec::new();
-    apply_innate_effects(
+    let effects_input = TickEffectsInput {
+        engagement_id,
+        all_participant_ids: all_ids.clone(),
+        turn_count: result.turn_count,
+        resolution_queue: result.resolution_queue,
+        phase: result.phase.clone(),
+    };
+    let cast_messages = resolve_tick_effects(
         game_state,
-        &result.all_participant_ids,
-        result.turn_count,
-        &mut cast_messages,
-    )
-    .await;
-    apply_battle_effects(
-        game_state,
-        result.resolution_queue,
+        effects_input,
         &speed_sorted_casters,
         &entity_names,
-        &mut cast_messages,
     )
     .await;
 
@@ -150,6 +151,58 @@ async fn handle_tick(
     }
 }
 
+struct TickEffectsInput {
+    engagement_id: i64,
+    all_participant_ids: Vec<i64>,
+    turn_count: u64,
+    resolution_queue: Vec<QueuedAbility>,
+    phase: BattlePhase,
+}
+
+/// Applies this tick's innate and queued-ability effects (both routed through the engagement's
+/// pending attribute working copy), then — if this tick just completed the Resolution phase —
+/// flushes `Never`-condition attributes (hp, mp) from pending back into the actual entities.
+async fn resolve_tick_effects(
+    game_state: &Arc<GameState>,
+    input: TickEffectsInput,
+    speed_sorted_casters: &[i64],
+    entity_names: &HashMap<i64, String>,
+) -> Vec<BattleMessage> {
+    let mut cast_messages = Vec::new();
+    apply_innate_effects(
+        game_state,
+        input.engagement_id,
+        &input.all_participant_ids,
+        input.turn_count,
+        &mut cast_messages,
+    )
+    .await;
+    apply_battle_effects(
+        game_state,
+        input.engagement_id,
+        input.resolution_queue,
+        speed_sorted_casters,
+        entity_names,
+        &mut cast_messages,
+    )
+    .await;
+
+    if input.phase == BattlePhase::InnateEffects {
+        let mut entities = game_state.active_entities.write().await;
+        game_state
+            .engagements
+            .battles
+            .flush_never_attributes(
+                input.engagement_id,
+                &game_state.attribute_config,
+                &mut entities,
+            )
+            .await;
+    }
+
+    cast_messages
+}
+
 async fn handle_battle_ended(game_state: &Arc<GameState>, outcome: &BattleTickOutcome) {
     loot::resolve_loot(&outcome.all_participant_ids);
     clear_active_effects(game_state, &outcome.all_participant_ids).await;
@@ -176,6 +229,12 @@ async fn collect_entity_data(
         })
         .collect();
 
+    let pending = game_state
+        .engagements
+        .battles
+        .pending_attributes(result.engagement_id)
+        .await;
+
     let speed_sorted_casters = speed_sort_casters(
         &result
             .resolution_queue
@@ -183,6 +242,7 @@ async fn collect_entity_data(
             .map(|qa| qa.caster_id)
             .collect::<Vec<_>>(),
         &entities,
+        &pending,
         &game_state.attribute_config,
     );
 
@@ -192,40 +252,69 @@ async fn collect_entity_data(
 fn speed_sort_casters(
     caster_ids: &[i64],
     entities: &HashMap<i64, Entity>,
+    pending: &HashMap<i64, HashMap<String, Attribute>>,
     config: &AttributeConfig,
 ) -> Vec<i64> {
-    let entity_refs: Vec<&Entity> = caster_ids
+    let effective_entities: Vec<Entity> = caster_ids
         .iter()
         .collect::<std::collections::HashSet<_>>()
         .into_iter()
         .filter_map(|&id| entities.get(&id))
+        .map(|entity| with_pending_attributes(entity, pending.get(&entity.id)))
         .collect();
+    let entity_refs: Vec<&Entity> = effective_entities.iter().collect();
     TurnOrder::new_from_entities(&entity_refs, config)
         .order()
         .to_vec()
 }
 
+/// Clones an entity, overlaying any pending attribute values so battle decisions (like turn
+/// order) prefer in-turn working values over the entity's actual, persisted state.
+fn with_pending_attributes(
+    entity: &Entity,
+    pending: Option<&HashMap<String, Attribute>>,
+) -> Entity {
+    let mut effective = entity.clone();
+    if let Some(pending) = pending {
+        for (id, attr) in pending {
+            effective.attributes.insert(id.clone(), attr.clone());
+        }
+    }
+    effective
+}
+
 async fn apply_innate_effects(
     game_state: &Arc<GameState>,
+    engagement_id: i64,
     participant_ids: &[i64],
     turn_count: u64,
     cast_messages: &mut Vec<BattleMessage>,
 ) {
-    let mut entities = game_state.active_entities.write().await;
-    for &entity_id in participant_ids {
-        let Some(entity) = entities.get(&entity_id) else {
-            continue;
-        };
-        let triggered: Vec<_> = entity
-            .active_effects
+    let triggered_by_entity: Vec<(i64, Vec<_>)> = {
+        let entities = game_state.active_entities.read().await;
+        participant_ids
             .iter()
-            .filter(|e| is_over_time_triggered(&e.trigger_info, turn_count))
-            .cloned()
-            .collect();
-        if !triggered.is_empty() {
-            let messages = resolution::resolve_effects(entity_id, triggered, &mut entities);
-            cast_messages.extend(messages);
-        }
+            .filter_map(|&entity_id| {
+                let entity = entities.get(&entity_id)?;
+                let triggered: Vec<_> = entity
+                    .active_effects
+                    .iter()
+                    .filter(|e| is_over_time_triggered(&e.trigger_info, turn_count))
+                    .cloned()
+                    .collect();
+                (!triggered.is_empty()).then_some((entity_id, triggered))
+            })
+            .collect()
+    };
+
+    let mut entities = game_state.active_entities.write().await;
+    for (entity_id, triggered) in triggered_by_entity {
+        let messages = game_state
+            .engagements
+            .battles
+            .resolve_battle_effects(engagement_id, entity_id, triggered, &mut entities)
+            .await;
+        cast_messages.extend(messages);
     }
 }
 
@@ -242,12 +331,12 @@ fn is_over_time_triggered(trigger: &TriggerInfo, turn_count: u64) -> bool {
 
 async fn apply_battle_effects(
     game_state: &Arc<GameState>,
+    engagement_id: i64,
     resolution_queue: Vec<QueuedAbility>,
     speed_sorted_casters: &[i64],
     entity_names: &HashMap<i64, String>,
     cast_messages: &mut Vec<BattleMessage>,
 ) {
-    let mut entities = game_state.active_entities.write().await;
     let mut target_effects = HashMap::new();
 
     let mut by_caster: HashMap<i64, Vec<QueuedAbility>> = HashMap::new();
@@ -274,8 +363,13 @@ async fn apply_battle_effects(
         }
     }
 
+    let mut entities = game_state.active_entities.write().await;
     for (target_id, effects) in target_effects {
-        resolution::resolve_effects(target_id, effects, &mut entities);
+        game_state
+            .engagements
+            .battles
+            .resolve_battle_effects(engagement_id, target_id, effects, &mut entities)
+            .await;
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `pending_entity_attributes` to `BattleEngagement`: a per-entity working copy of attributes that effect resolution now writes to instead of the entity's actual state.
- `EachEngagementTurn` attributes reset from actual at the start of every faction turn; `EndOfEngagement`/`Never` attributes are seeded from actual only once. `Never`-condition attributes (hp, mp) are flushed from pending back to actual at the end of the Resolution phase.
- `queue_ability` cost checks and turn-order speed sorting now prefer pending values over actual when a pending copy exists.

## Design note
The issue's agent-context suggested computing the Never-attribute flush inside `advance_phase()`'s `Resolution` arm (optionally via a new `BattleTick.pending_flush` field). I deviated from that: doing it there would read pending *before* this round's queued-ability effects are merged in (that merge happens afterward, in `tick.rs`), causing hp to lag a full round behind on death detection and the UI. Instead, the flush runs in `tick.rs::handle_tick` right after this round's effects are applied to pending, gated on `result.phase == BattlePhase::InnateEffects` (true on exactly the tick where Resolution just completed).

## Test plan
- [x] `cargo fmt`
- [x] `cargo test` (474 passed, up from 468 baseline; new coverage for InnateEffects reset behavior, pending-not-actual writes, and Resolution flush)
- [x] `cargo clippy --all-targets` (no new warnings; one pre-existing, unrelated warning in `attribute_config.rs` confirmed present on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)