### PR TITLE
Fixes #191 Add attribute-snapshot resets to the battle engine

### DIFF
--- a/muds/basic/attributes.toml
+++ b/muds/basic/attributes.toml
@@ -6,6 +6,7 @@ min_value = 0
 max_value = 999
 attribute_type = "hp"
 attribute_category = "life"
+reset_condition = "never"
 
 [[attributes]]
 id = "mp"
@@ -15,6 +16,7 @@ min_value = 0
 max_value = 999
 attribute_type = "mp"
 attribute_category = "general"
+reset_condition = "never"
 
 [[attributes]]
 id = "level"

--- a/src/game/engagement.rs
+++ b/src/game/engagement.rs
@@ -7,8 +7,8 @@ pub mod turn_action;
 pub mod turn_order;
 
 pub use battle::{
-    BattleAiContext, BattleEngagement, BattleMessage, BattlePhase, BattleTick, Battles,
-    QueuedAbility,
+    AttributeSnapshot, AttributeSnapshots, BattleAiContext, BattleEngagement, BattleMessage,
+    BattlePhase, BattleTick, Battles, QueuedAbility,
 };
 pub use conversation::Conversations;
 pub use engagement_type::EngagementType;
@@ -29,6 +29,7 @@ pub struct Engagement {
     pub pending_actions: HashMap<i64, TurnAction>,
     pub ticks_on_current_turn: u64,
     pub battle: Option<BattleEngagement>,
+    pub attribute_snapshots: AttributeSnapshots,
 }
 
 impl Engagement {
@@ -43,6 +44,7 @@ impl Engagement {
             pending_actions: HashMap::new(),
             ticks_on_current_turn: 0,
             battle: None,
+            attribute_snapshots: AttributeSnapshots::default(),
         }
     }
 

--- a/src/game/engagement/battle.rs
+++ b/src/game/engagement/battle.rs
@@ -1,6 +1,7 @@
 pub mod abilities;
 pub mod action_queue;
 pub mod ai;
+pub mod attribute_snapshot;
 pub mod collection;
 pub mod death;
 pub mod factory;
@@ -19,6 +20,7 @@ use std::collections::HashMap;
 
 pub use abilities::entity_innate_battle_abilities;
 pub use ai::{BattleAiContext, run_battle_ai};
+pub use attribute_snapshot::{AttributeSnapshot, AttributeSnapshots};
 pub use collection::Battles;
 pub use message::BattleMessage;
 pub use phase::BattlePhase;

--- a/src/game/engagement/battle/attribute_snapshot.rs
+++ b/src/game/engagement/battle/attribute_snapshot.rs
@@ -1,0 +1,325 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::game::GameState;
+use crate::game::component::Attribute;
+use crate::game::component::attribute_definition::ResetCondition;
+use crate::game::config::AttributeConfig;
+use crate::game::entity::Entity;
+
+/// Per-entity attribute values as of some snapshot point, keyed by entity id.
+pub type AttributeSnapshot = HashMap<i64, HashMap<String, Attribute>>;
+
+/// Per-engagement attribute snapshots used to restore live attribute values on a schedule driven
+/// by each `AttributeDefinition`'s `ResetCondition`. `battle_start` is captured once when the
+/// battle is created and never changes; `turn_start` is a working record recaptured at the start
+/// of every faction turn — it is not itself a reset source.
+#[derive(Debug, Clone, Default)]
+pub struct AttributeSnapshots {
+    pub battle_start: AttributeSnapshot,
+    pub turn_start: AttributeSnapshot,
+}
+
+/// Captures the battle-start attribute snapshot for a freshly created battle: the live attribute
+/// values of every participant, taken once. Used later as the restore target for both
+/// `EachEngagementTurn` and `EndOfEngagement` resets. Call this exactly once, immediately after
+/// the engagement has been inserted into `Battles`.
+pub async fn capture_battle_start(
+    game_state: &Arc<GameState>,
+    engagement_id: i64,
+    entity_ids: &[i64],
+) {
+    let snapshot = read_attribute_snapshot(game_state, entity_ids).await;
+    game_state
+        .engagements
+        .battles
+        .set_battle_start_snapshot(engagement_id, snapshot)
+        .await;
+}
+
+/// Runs the `ResetAttributes` phase's attribute work for one faction turn: resets every
+/// `EachEngagementTurn` attribute on every given entity back to its `battle_start` value, then
+/// recaptures `turn_start` from the (now-reset) live values. Only call this when the current
+/// battle tick has just completed a `ResetAttributes` phase.
+pub(super) async fn reset_turn_start_attributes(
+    game_state: &Arc<GameState>,
+    engagement_id: i64,
+    entity_ids: &[i64],
+    config: &AttributeConfig,
+) {
+    let Some(battle_start) = game_state
+        .engagements
+        .battles
+        .battle_start_snapshot(engagement_id)
+        .await
+    else {
+        return;
+    };
+    let reset_ids = reset_condition_ids(config, &ResetCondition::EachEngagementTurn);
+
+    let turn_start = {
+        let mut entities = game_state.active_entities.write().await;
+        reset_attributes(&mut entities, entity_ids, &battle_start, &reset_ids);
+        snapshot_locked(&entities, entity_ids)
+    };
+
+    game_state
+        .engagements
+        .battles
+        .set_turn_start_snapshot(engagement_id, turn_start)
+        .await;
+}
+
+/// Resets every `EndOfEngagement` attribute on every given entity back to its `battle_start`
+/// value. Only call this when a battle has just reached `BattlePhase::Concluded`, before the
+/// engagement is removed from `Battles`.
+pub(super) async fn reset_end_of_engagement_attributes(
+    game_state: &Arc<GameState>,
+    engagement_id: i64,
+    entity_ids: &[i64],
+    config: &AttributeConfig,
+) {
+    let Some(battle_start) = game_state
+        .engagements
+        .battles
+        .battle_start_snapshot(engagement_id)
+        .await
+    else {
+        return;
+    };
+    let reset_ids = reset_condition_ids(config, &ResetCondition::EndOfEngagement);
+
+    let mut entities = game_state.active_entities.write().await;
+    reset_attributes(&mut entities, entity_ids, &battle_start, &reset_ids);
+}
+
+async fn read_attribute_snapshot(
+    game_state: &Arc<GameState>,
+    entity_ids: &[i64],
+) -> AttributeSnapshot {
+    let entities = game_state.active_entities.read().await;
+    snapshot_locked(&entities, entity_ids)
+}
+
+fn snapshot_locked(entities: &HashMap<i64, Entity>, entity_ids: &[i64]) -> AttributeSnapshot {
+    entity_ids
+        .iter()
+        .filter_map(|&id| entities.get(&id).map(|e| (id, e.attributes.clone())))
+        .collect()
+}
+
+fn reset_condition_ids<'a>(
+    config: &'a AttributeConfig,
+    condition: &ResetCondition,
+) -> Vec<&'a str> {
+    config
+        .attributes
+        .iter()
+        .filter(|def| &def.reset_condition == condition)
+        .map(|def| def.id.as_str())
+        .collect()
+}
+
+fn reset_attributes(
+    entities: &mut HashMap<i64, Entity>,
+    entity_ids: &[i64],
+    battle_start: &AttributeSnapshot,
+    reset_ids: &[&str],
+) {
+    for &id in entity_ids {
+        let Some(entity) = entities.get_mut(&id) else {
+            continue;
+        };
+        let Some(start_attrs) = battle_start.get(&id) else {
+            continue;
+        };
+        for &attr_id in reset_ids {
+            if let (Some(current), Some(start)) =
+                (entity.attributes.get_mut(attr_id), start_attrs.get(attr_id))
+            {
+                *current = start.clone();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::Location;
+    use crate::game::entity::EntityType;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    fn entity_with_attrs(id: i64, hp: i64, strength: i64) -> Entity {
+        let mut entity = Entity::new(id, EntityType::Player, test_location());
+        entity.attributes.insert(
+            "hp".to_string(),
+            Attribute::new("hp".to_string(), 0, 100, hp),
+        );
+        entity.attributes.insert(
+            "strength".to_string(),
+            Attribute::new("strength".to_string(), 1, 20, strength),
+        );
+        entity
+    }
+
+    /// `AttributeConfig::default_config` has no `EndOfEngagement` attributes (only `Never` and
+    /// `EachEngagementTurn`), so tests exercising the end-of-engagement reset re-tag "strength".
+    fn config_with_end_of_engagement_strength() -> AttributeConfig {
+        let mut config = AttributeConfig::default_config();
+        if let Some(def) = config.attributes.iter_mut().find(|d| d.id == "strength") {
+            def.reset_condition = ResetCondition::EndOfEngagement;
+        }
+        config
+    }
+
+    async fn game_state_with_battle(entity: Entity) -> (Arc<GameState>, i64) {
+        let entity_id = entity.id;
+        let game_state = Arc::new(GameState::load(None).unwrap());
+        game_state
+            .active_entities
+            .write()
+            .await
+            .insert(entity_id, entity);
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![entity_id]);
+        let engagement_id = game_state
+            .engagements
+            .add_battle("room".to_string(), vec!["player".to_string()], participants)
+            .await;
+        (game_state, engagement_id)
+    }
+
+    #[tokio::test]
+    async fn capture_battle_start_stores_snapshot_once_and_is_stable() {
+        let (game_state, engagement_id) =
+            game_state_with_battle(entity_with_attrs(1, 100, 10)).await;
+
+        capture_battle_start(&game_state, engagement_id, &[1]).await;
+
+        game_state
+            .active_entities
+            .write()
+            .await
+            .get_mut(&1)
+            .unwrap()
+            .attributes
+            .get_mut("strength")
+            .unwrap()
+            .current_value = 3;
+
+        let snapshot = game_state
+            .engagements
+            .battles
+            .battle_start_snapshot(engagement_id)
+            .await
+            .unwrap();
+        assert_eq!(snapshot[&1]["strength"].current_value, 10);
+    }
+
+    #[tokio::test]
+    async fn reset_turn_start_attributes_resets_each_engagement_turn_and_leaves_never() {
+        let (game_state, engagement_id) =
+            game_state_with_battle(entity_with_attrs(1, 100, 10)).await;
+        capture_battle_start(&game_state, engagement_id, &[1]).await;
+
+        {
+            let mut entities = game_state.active_entities.write().await;
+            let entity = entities.get_mut(&1).unwrap();
+            entity.attributes.get_mut("strength").unwrap().current_value = 3;
+            entity.attributes.get_mut("hp").unwrap().current_value = 40;
+        }
+
+        reset_turn_start_attributes(
+            &game_state,
+            engagement_id,
+            &[1],
+            &AttributeConfig::default_config(),
+        )
+        .await;
+
+        let entities = game_state.active_entities.read().await;
+        assert_eq!(entities[&1].attributes["strength"].current_value, 10);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 40);
+    }
+
+    #[tokio::test]
+    async fn reset_turn_start_attributes_recaptures_turn_start_from_post_reset_values() {
+        let (game_state, engagement_id) =
+            game_state_with_battle(entity_with_attrs(1, 100, 10)).await;
+        capture_battle_start(&game_state, engagement_id, &[1]).await;
+        game_state
+            .active_entities
+            .write()
+            .await
+            .get_mut(&1)
+            .unwrap()
+            .attributes
+            .get_mut("strength")
+            .unwrap()
+            .current_value = 3;
+
+        reset_turn_start_attributes(
+            &game_state,
+            engagement_id,
+            &[1],
+            &AttributeConfig::default_config(),
+        )
+        .await;
+
+        let map = game_state.engagements.battles.map.read().await;
+        let turn_start = &map[&engagement_id].attribute_snapshots.turn_start;
+        assert_eq!(turn_start[&1]["strength"].current_value, 10);
+    }
+
+    #[tokio::test]
+    async fn reset_end_of_engagement_attributes_resets_only_end_of_engagement_and_leaves_never() {
+        let (game_state, engagement_id) =
+            game_state_with_battle(entity_with_attrs(1, 100, 10)).await;
+        capture_battle_start(&game_state, engagement_id, &[1]).await;
+
+        {
+            let mut entities = game_state.active_entities.write().await;
+            let entity = entities.get_mut(&1).unwrap();
+            entity.attributes.get_mut("strength").unwrap().current_value = 3;
+            entity.attributes.get_mut("hp").unwrap().current_value = 40;
+        }
+
+        reset_end_of_engagement_attributes(
+            &game_state,
+            engagement_id,
+            &[1],
+            &config_with_end_of_engagement_strength(),
+        )
+        .await;
+
+        let entities = game_state.active_entities.read().await;
+        assert_eq!(entities[&1].attributes["strength"].current_value, 10);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 40);
+    }
+
+    #[tokio::test]
+    async fn reset_is_no_op_when_battle_start_snapshot_absent() {
+        let (game_state, engagement_id) =
+            game_state_with_battle(entity_with_attrs(1, 100, 10)).await;
+        // Note: capture_battle_start is intentionally never called here.
+
+        reset_turn_start_attributes(
+            &game_state,
+            engagement_id,
+            &[1],
+            &AttributeConfig::default_config(),
+        )
+        .await;
+
+        let entities = game_state.active_entities.read().await;
+        assert_eq!(entities[&1].attributes["strength"].current_value, 10);
+    }
+}

--- a/src/game/engagement/battle/collection.rs
+++ b/src/game/engagement/battle/collection.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 use crate::game::component::{Ability, Attribute};
 use crate::game::engagement::{Engagement, EngagementType};
 
-use super::{BattleAiContext, BattlePhase, BattleTick, factory};
+use super::{AttributeSnapshot, BattleAiContext, BattlePhase, BattleTick, factory};
 
 pub struct Battles {
     pub(in crate::game::engagement) map: RwLock<HashMap<i64, Engagement>>,
@@ -126,6 +126,33 @@ impl Battles {
             && let Some(battle) = &mut engagement.battle
         {
             battle.turn_phase = BattlePhase::Concluded;
+        }
+    }
+
+    /// Stores the battle-start attribute snapshot for `engagement_id`, captured once when the
+    /// battle is created. No-op if the engagement no longer exists.
+    pub async fn set_battle_start_snapshot(&self, engagement_id: i64, snapshot: AttributeSnapshot) {
+        let mut map = self.map.write().await;
+        if let Some(engagement) = map.get_mut(&engagement_id) {
+            engagement.attribute_snapshots.battle_start = snapshot;
+        }
+    }
+
+    /// Returns a clone of the battle-start attribute snapshot for `engagement_id`, or `None` if
+    /// the engagement doesn't exist.
+    pub async fn battle_start_snapshot(&self, engagement_id: i64) -> Option<AttributeSnapshot> {
+        let map = self.map.read().await;
+        map.get(&engagement_id)
+            .map(|e| e.attribute_snapshots.battle_start.clone())
+    }
+
+    /// Stores the turn-start attribute snapshot for `engagement_id`, recaptured every faction
+    /// turn after `EachEngagementTurn` resets are applied. No-op if the engagement no longer
+    /// exists.
+    pub async fn set_turn_start_snapshot(&self, engagement_id: i64, snapshot: AttributeSnapshot) {
+        let mut map = self.map.write().await;
+        if let Some(engagement) = map.get_mut(&engagement_id) {
+            engagement.attribute_snapshots.turn_start = snapshot;
         }
     }
 }

--- a/src/game/engagement/battle/factory.rs
+++ b/src/game/engagement/battle/factory.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::game::engagement::{Engagement, EngagementType, TurnOrder};
 
-use super::BattleEngagement;
+use super::{AttributeSnapshots, BattleEngagement};
 
 pub fn new_battle(
     id: i64,
@@ -22,6 +22,7 @@ pub fn new_battle(
         pending_actions: HashMap::new(),
         ticks_on_current_turn: 0,
         battle: Some(battle),
+        attribute_snapshots: AttributeSnapshots::default(),
     }
 }
 

--- a/src/game/engagement/battle/tick.rs
+++ b/src/game/engagement/battle/tick.rs
@@ -7,7 +7,7 @@ use super::message::broadcast::{self, BattleUpdateParams};
 use super::message::tick_message::assemble_tick_messages;
 use super::resolution::{ability, innate};
 use super::{BattleMessage, BattlePhase, BattleTick, QueuedAbility};
-use super::{death, timer, victory};
+use super::{attribute_snapshot, death, timer, victory};
 
 /// Advances all active battle engagements one tick and handles the full lifecycle:
 /// phase state machine → effect resolution → dead-entity removal → engagement conclusion.
@@ -79,9 +79,10 @@ async fn handle_tick(game_state: &Arc<GameState>, result: BattleTick, max_engage
     }
 }
 
-/// Runs the work gated on `completed_phase`: over-time effect application (`ApplyEffects`),
-/// ability effect resolution (`ResolveAbilities`), or dead-entity detection and removal
-/// (`ResolveEntityState`). Returns the messages and dead entity ids produced, if any.
+/// Runs the work gated on `completed_phase`: attribute resets (`ResetAttributes`), over-time
+/// effect application (`ApplyEffects`), ability effect resolution (`ResolveAbilities`), or
+/// dead-entity detection and removal (`ResolveEntityState`). Returns the messages and dead entity
+/// ids produced, if any.
 async fn dispatch_phase_work(
     game_state: &Arc<GameState>,
     engagement_id: i64,
@@ -94,6 +95,15 @@ async fn dispatch_phase_work(
     let mut cast_messages = Vec::new();
     let mut dead_ids = Vec::new();
     match completed_phase {
+        BattlePhase::ResetAttributes { .. } => {
+            attribute_snapshot::reset_turn_start_attributes(
+                game_state,
+                engagement_id,
+                all_ids,
+                &game_state.attribute_config,
+            )
+            .await;
+        }
         BattlePhase::ApplyEffects { .. } => {
             innate::apply_innate_effects(game_state, all_ids, turn_count, &mut cast_messages).await;
         }
@@ -205,6 +215,20 @@ mod tests {
         entity
     }
 
+    fn entity_with_strength(id: i64, name: &str) -> Entity {
+        let mut entity = Entity::new(id, EntityType::Player, test_location());
+        entity.name = name.to_string();
+        entity.attributes.insert(
+            "hp".to_string(),
+            Attribute::new("hp".to_string(), 0, 100, 100),
+        );
+        entity.attributes.insert(
+            "strength".to_string(),
+            Attribute::new("strength".to_string(), 1, 20, 10),
+        );
+        entity
+    }
+
     #[tokio::test]
     async fn apply_effects_fires_once_per_turn_while_dwelling_in_declare_phases() {
         let game_state = Arc::new(GameState::load(None).unwrap());
@@ -238,5 +262,48 @@ mod tests {
         // The over-time effect is resolved and re-pushed onto active_effects each time it
         // fires; if it fired once, the count grows from 1 to 2 — not once per dwelling tick.
         assert_eq!(entities[&1].active_effects.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn reset_attributes_phase_restores_battle_start_and_leaves_hp_alone() {
+        let game_state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = game_state.active_entities.write().await;
+            entities.insert(1, entity_with_strength(1, "Hero"));
+            entities.insert(2, plain_entity(2, "Goblin"));
+        }
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        let factions = vec!["player".to_string(), "enemy".to_string()];
+        let engagement_id = game_state
+            .engagements
+            .add_battle("room".to_string(), factions, participants)
+            .await;
+        attribute_snapshot::capture_battle_start(&game_state, engagement_id, &[1, 2]).await;
+
+        let max_engage_ticks = 1;
+        // Completes the initial ResetAttributes{player} phase — a no-op reset since nothing has
+        // mutated live attributes yet.
+        process_ticks(&game_state, max_engage_ticks).await;
+
+        // Simulate a mid-turn effect write, exactly as `resolution/effect.rs` would do.
+        {
+            let mut entities = game_state.active_entities.write().await;
+            let entity = entities.get_mut(&1).unwrap();
+            entity.attributes.get_mut("strength").unwrap().current_value = 3;
+            entity.attributes.get_mut("hp").unwrap().current_value = 40;
+        }
+
+        // AnnounceState -> ApplyEffects -> DeclareAttacks -> DeclareDefense -> ResolveAbilities
+        // -> ResolveEntityState -> Cleanup -> VictoryCheck -> ResetAttributes{enemy} (9 ticks),
+        // then one more tick dispatches the ResetAttributes{enemy} phase's reset work.
+        for _ in 0..10 {
+            process_ticks(&game_state, max_engage_ticks).await;
+        }
+
+        let entities = game_state.active_entities.read().await;
+        assert_eq!(entities[&1].attributes["strength"].current_value, 10);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 40);
     }
 }

--- a/src/game/engagement/battle/victory.rs
+++ b/src/game/engagement/battle/victory.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use crate::game::component::effect::EffectScope;
 use crate::game::{GameState, messaging};
 
-use super::loot;
+use super::{attribute_snapshot, loot};
 
-/// Handles a battle reaching `BattlePhase::Concluded`: resolves loot, clears battle-scoped
-/// active effects from all participants, and notifies player participants the battle has ended.
+/// Handles a battle reaching `BattlePhase::Concluded`: resolves loot, resets `EndOfEngagement`
+/// attributes, clears battle-scoped active effects from all participants, and notifies player
+/// participants the battle has ended.
 pub(super) async fn handle_battle_ended(
     game_state: &Arc<GameState>,
     engagement_id: i64,
@@ -14,6 +15,13 @@ pub(super) async fn handle_battle_ended(
     player_ids: &[i64],
 ) {
     loot::resolve_loot(all_participant_ids);
+    attribute_snapshot::reset_end_of_engagement_attributes(
+        game_state,
+        engagement_id,
+        all_participant_ids,
+        &game_state.attribute_config,
+    )
+    .await;
     clear_active_effects(game_state, all_participant_ids).await;
     for &pid in player_ids {
         messaging::battle_ended(&game_state.message_tx, pid, engagement_id);
@@ -33,9 +41,12 @@ async fn clear_active_effects(game_state: &Arc<GameState>, entity_ids: &[i64]) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
-    use crate::game::component::Location;
+    use crate::game::component::attribute_definition::ResetCondition;
     use crate::game::component::effect::{Effect, EffectDescription, EffectType, TriggerInfo};
+    use crate::game::component::{Attribute, Location};
     use crate::game::entity::{Entity, EntityType};
     use tokio::sync::broadcast;
 
@@ -118,6 +129,58 @@ mod tests {
             message.is_ok(),
             "expected a battle_ended message to be sent"
         );
+    }
+
+    #[tokio::test]
+    async fn handle_battle_ended_resets_end_of_engagement_and_leaves_hp() {
+        let mut entity = Entity::new(1, EntityType::Player, test_location());
+        entity.attributes.insert(
+            "hp".to_string(),
+            Attribute::new("hp".to_string(), 0, 100, 100),
+        );
+        entity.attributes.insert(
+            "strength".to_string(),
+            Attribute::new("strength".to_string(), 1, 20, 10),
+        );
+
+        // `AttributeConfig::default_config` has no `EndOfEngagement` attributes (only `Never`
+        // and `EachEngagementTurn`), so re-tag "strength" to exercise this reset.
+        let mut game_state = GameState::load(None).unwrap();
+        if let Some(def) = game_state
+            .attribute_config
+            .attributes
+            .iter_mut()
+            .find(|d| d.id == "strength")
+        {
+            def.reset_condition = ResetCondition::EndOfEngagement;
+        }
+        let game_state = Arc::new(game_state);
+        game_state
+            .active_entities
+            .write()
+            .await
+            .insert(entity.id, entity);
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        let engagement_id = game_state
+            .engagements
+            .add_battle("room".to_string(), vec!["player".to_string()], participants)
+            .await;
+
+        attribute_snapshot::capture_battle_start(&game_state, engagement_id, &[1]).await;
+
+        {
+            let mut entities = game_state.active_entities.write().await;
+            let entity = entities.get_mut(&1).unwrap();
+            entity.attributes.get_mut("strength").unwrap().current_value = 3;
+            entity.attributes.get_mut("hp").unwrap().current_value = 40;
+        }
+
+        handle_battle_ended(&game_state, engagement_id, &[1], &[]).await;
+
+        let entities = game_state.active_entities.read().await;
+        assert_eq!(entities[&1].attributes["strength"].current_value, 10);
+        assert_eq!(entities[&1].attributes["hp"].current_value, 40);
     }
 
     #[tokio::test]

--- a/src/game/engagement/conversation/factory.rs
+++ b/src/game/engagement/conversation/factory.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::game::engagement::{Engagement, EngagementType, TurnOrder};
+use crate::game::engagement::{AttributeSnapshots, Engagement, EngagementType, TurnOrder};
 
 pub fn new_conversation(id: i64, player_entity_id: i64, npc_entity_id: i64) -> Engagement {
     let turn_order = TurnOrder::new(&[player_entity_id]);
@@ -13,6 +13,7 @@ pub fn new_conversation(id: i64, player_entity_id: i64, npc_entity_id: i64) -> E
         pending_actions: HashMap::new(),
         ticks_on_current_turn: 0,
         battle: None,
+        attribute_snapshots: AttributeSnapshots::default(),
     }
 }
 

--- a/src/game/interaction/room_threats.rs
+++ b/src/game/interaction/room_threats.rs
@@ -5,7 +5,9 @@ use tracing;
 
 use crate::game::component::attribute_definition::AttributeType;
 use crate::game::component::faction_relations::FactionRelation;
-use crate::game::engagement::battle::{BattlePhase, entity_innate_battle_abilities};
+use crate::game::engagement::battle::{
+    BattlePhase, attribute_snapshot, entity_innate_battle_abilities,
+};
 use crate::game::entity::Entity;
 use crate::game::messaging::{BattleParticipantInfo, BattleStartedMessage};
 use crate::game::player::Player;
@@ -94,6 +96,8 @@ async fn start_battle(
         .engagements
         .add_battle(room_id.to_string(), factions.clone(), participants.clone())
         .await;
+
+    attribute_snapshot::capture_battle_start(game_state, engagement_id, &all_ids).await;
 
     let max_engage_ticks = (game_state.mud_config.game_loop.max_engage_ms
         / game_state.mud_config.game_loop.tick_rate_ms)


### PR DESCRIPTION
Effects in battle wrote directly to live entity attributes but never reset anything, so temporary stat changes (e.g. a per-turn defense buff) persisted indefinitely instead of clearing. This adds per-engagement attribute snapshots and wires them into the turn/battle-end flow so each attribute resets on the schedule its `ResetCondition` declares.

- New `battle_start`/`turn_start` attribute snapshots captured per engagement, restored on a schedule driven by each attribute's `ResetCondition` (`EachEngagementTurn`, `EndOfEngagement`, or `Never`)
- Snapshot capture and resets wired into the existing phase-driven battle tick loop (`ResetAttributes` phase) and battle-conclusion cleanup, with no change to how effects themselves write live attribute values
- Fixed a config gap in `muds/basic/attributes.toml` where hp/mp had no explicit `reset_condition`, so they silently defaulted to `each_engagement_turn` instead of `never` and were getting reset every turn

<details>
<summary>Agent Context</summary>

Implements #191, unblocked by #215/#216 (battle phase state-machine restructure, merged `39b3fdf`/`65e4e9f`).

**New file** `src/game/engagement/battle/attribute_snapshot.rs`:
- `AttributeSnapshot = HashMap<i64, HashMap<String, Attribute>>`, `AttributeSnapshots { battle_start, turn_start }`
- `capture_battle_start(game_state, engagement_id, entity_ids)` — public, called once from `room_threats.rs::start_battle` right after `add_battle` returns
- `reset_turn_start_attributes` (`pub(super)`) — called from `tick.rs`'s new `BattlePhase::ResetAttributes` dispatch arm; resets `EachEngagementTurn` attrs to `battle_start`, then recaptures `turn_start` from post-reset live values
- `reset_end_of_engagement_attributes` (`pub(super)`) — called from `victory.rs::handle_battle_ended` before `clear_active_effects`, while the engagement (and its snapshot) still exists, prior to `battles.conclude()`/`.remove()`

**Lock-ordering decision:** the issue's original write-up proposed `Battles` methods taking `entities: &mut HashMap<i64, Entity>` directly, but that would require the caller's `active_entities` write guard to stay alive for the whole call while the method also locks `Battles`'s internal map — i.e. both locks alive simultaneously, which the issue explicitly calls out as unsafe (mirroring the `death::detect_dead_entities` + `battles.update_participants` precedent, where the two locks are never nested). Resolved with a three-layer split: free async functions in `attribute_snapshot.rs` take `game_state: &Arc<GameState>` and do their own independent, sequential locking (`Battles` map read → drop → `active_entities` write → drop → `Battles` map write → drop); `Battles` methods (`collection.rs`: `set_battle_start_snapshot`, `battle_start_snapshot`, `set_turn_start_snapshot`) never take an `entities` param and only ever lock `self.map`; a private sync helper (`reset_attributes`) mutates an already-locked map with no locking of its own.

**Storage:** `AttributeSnapshots` lives as a field on `Engagement` (`src/game/engagement.rs`), not on `BattleEngagement`, per #215's boundary that `BattleEngagement` stays phase-sequencing-only with no entity/attribute data. Initialized at all three `Engagement` construction sites: `Engagement::new`, `battle/factory.rs::new_battle`, and `conversation/factory.rs::new_conversation`.

**Safety property:** if `battle_start` was never captured for an engagement (shouldn't happen in production but keeps existing tests that call `add_battle` without capturing from breaking), `battle_start_snapshot` returns `Some(empty map)` and the reset becomes a no-op rather than panicking.

**Config fix:** `AttributeDefinition.reset_condition` is `#[serde(default)]` and `ResetCondition::default()` is `EachEngagementTurn`; `muds/basic/attributes.toml` never set `reset_condition` on any attribute, so hp/mp silently got `EachEngagementTurn` instead of `Never` once the reset logic went live — the in-repo docs (`src/instructions/attributes.rs`) already documented the intended `reset_condition = "never"` example for hp, so the TOML was simply out of sync (likely an oversight from #190). Added `reset_condition = "never"` to hp and mp entries.

Tests added in `attribute_snapshot.rs` (capture-once-stability, turn reset + `Never` untouched, `turn_start` recapture, end-of-engagement reset, no-op-without-capture), extended in `tick.rs` (full faction-turn cycle via `process_ticks`, mid-turn mutation reset by next `ResetAttributes`) and `victory.rs` (`handle_battle_ended` resets `EndOfEngagement` and leaves `Never` alone). All use the established `GameState::load(None)` + `Arc::new` + manual `active_entities`/`add_battle` idiom from `resolution/innate.rs`/`death.rs`/`tick.rs` — no new fixture machinery. `cargo fmt && cargo test && cargo clippy` all clean (503 tests passing; one pre-existing `cognitive_complexity` clippy warning in `attribute_config.rs` unrelated to this change).

</details>