### PR TITLE
Fixes #192 Add info-level tracing for pending attribute state

### DIFF
--- a/src/game/engagement/battle/attribute_snapshot.rs
+++ b/src/game/engagement/battle/attribute_snapshot.rs
@@ -63,11 +63,42 @@ pub(super) async fn reset_turn_start_attributes(
         snapshot_locked(&entities, entity_ids)
     };
 
+    log_reset_attributes(engagement_id, entity_ids, &turn_start, &reset_ids);
+
     game_state
         .engagements
         .battles
         .set_turn_start_snapshot(engagement_id, turn_start)
         .await;
+}
+
+fn log_reset_attributes(
+    engagement_id: i64,
+    entity_ids: &[i64],
+    turn_start: &AttributeSnapshot,
+    reset_ids: &[&str],
+) {
+    for &entity_id in entity_ids {
+        let Some(attrs) = turn_start.get(&entity_id) else {
+            continue;
+        };
+        let pairs = attribute_pairs(attrs, reset_ids);
+        tracing::info!(
+            engagement_id,
+            entity_id,
+            pending_attributes = ?pairs,
+            "Pending attributes reset for entity"
+        );
+    }
+}
+
+fn attribute_pairs(attrs: &HashMap<String, Attribute>, ids: &[&str]) -> Vec<(String, i64)> {
+    let mut pairs: Vec<(String, i64)> = ids
+        .iter()
+        .filter_map(|&id| attrs.get(id).map(|a| (id.to_string(), a.current_value)))
+        .collect();
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    pairs
 }
 
 /// Resets every `EndOfEngagement` attribute on every given entity back to its `battle_start`

--- a/src/game/engagement/battle/resolution/effect.rs
+++ b/src/game/engagement/battle/resolution/effect.rs
@@ -59,6 +59,12 @@ fn apply_attribute_update(effect: &Effect, entity: &mut Entity, context: &mut Re
         attr.current_value = (attr.current_value + adjusted)
             .max(attr.min_value)
             .min(attr.max_value);
+        tracing::info!(
+            entity_id = entity.id,
+            attribute_id = %attribute_id,
+            pending_value = attr.current_value,
+            "Pending attribute impacted"
+        );
     }
 }
 


### PR DESCRIPTION
Adds info-level trace logs so server operators can observe attribute state changes during a battle, without needing to change `RUST_LOG`. Closes #192.

- Logs each entity's `EachEngagementTurn` attribute values right after they're reset at the start of a faction turn
- Logs each attribute an effect actually changes (entity id, attribute id, resulting value) as it happens during effect resolution
- Uses `tracing::info!` with structured fields, consistent with existing logging style (e.g. `world_update.rs`, `loot.rs`)

<details>
<summary>Agent Context</summary>

**Goal:** Give server operators visibility into per-turn attribute state in the battle engine (originally scoped in #192 against a pre-#191 "pending vs actual" design that no longer exists in the codebase — adapted here to the real #191 implementation).

**Log point 1 — turn-start reset (`src/game/engagement/battle/attribute_snapshot.rs`):**
- `reset_turn_start_attributes` now calls a new private `log_reset_attributes` helper right after computing `turn_start`, before it's stored via `set_turn_start_snapshot`.
- Logs one `tracing::info!("Pending attributes reset for entity")` per entity with `engagement_id`, `entity_id`, and `pending_attributes` — a sorted `Vec<(String, i64)>` of the entity's `EachEngagementTurn`-scoped attribute values, built by a new shared `attribute_pairs` helper.
- Only fires when a `battle_start` snapshot exists for the engagement (same early-return as before).

**Log point 2 — per-attribute impact (`src/game/engagement/battle/resolution/effect.rs`):**
- Original plan was a single "flush to actual" log for `Never`-condition (hp/mp) attributes after the `ResolveAbilities` phase (`log_never_condition_attributes` in `attribute_snapshot.rs`, called from `tick.rs`). Per user feedback, this was replaced with a log directly inside `apply_attribute_update` — the actual point where an `AttributeUpdate` effect writes a new `current_value` onto an entity.
- `tracing::info!("Pending attribute impacted")` fires for every attribute an effect actually changes (any attribute id, not just `Never`-condition ones), with fields `entity_id`, `attribute_id`, `pending_value` (the resulting `current_value` after shield absorption and min/max clamping).
- This fires from both call paths through `resolve_effects`: `apply_innate_effects` (`ApplyEffects` phase, over-time effects) and `apply_battle_effects` (`ResolveAbilities` phase, ability effects) — no changes needed to either caller.
- Deliberately not gated by `AttributeConfig`/`ResetCondition` — `resolve_effects`/`apply_attribute_update` don't have config threaded in, and scoping to `Never` attrs only would require new plumbing through `resolve_effects` → `apply_battle_effects`/`apply_innate_effects` → `tick.rs` for no clear benefit.

**Not changed:** `reset_end_of_engagement_attributes` (out of scope — issue only calls out `EachEngagementTurn` and `Never`/hp-mp).

**Tests:** No dedicated log-output assertions (issue explicitly notes none required — behavior is covered by #191's existing tests). Existing test suite (503 tests) passes unchanged after removing the earlier "flush" smoke test that no longer applies.

**Related:** #191 (attribute-snapshot resets — merged), #190 (`ResetCondition` config — merged).