### PR TITLE
Fixes #220 Add info-level tracing for battle phase transitions

### DIFF
--- a/src/game/engagement/battle/action_queue.rs
+++ b/src/game/engagement/battle/action_queue.rs
@@ -80,6 +80,13 @@ impl ActionQueue {
             .collect()
     }
 
+    pub fn queued_count(&self, entity_ids: &[i64]) -> usize {
+        entity_ids
+            .iter()
+            .filter(|id| self.queued.contains_key(id))
+            .count()
+    }
+
     /// Read the currently queued abilities without draining them.
     pub fn snapshot(&self) -> Vec<QueuedAbility> {
         self.queued.values().cloned().collect()
@@ -195,6 +202,15 @@ mod tests {
         queue.queue(1, attack_ability(None), 2, &attrs);
         queue.skip(3);
         assert_eq!(queue.unacted(&[1, 3, 4]), vec![4]);
+    }
+
+    #[test]
+    fn queued_count_counts_only_queued_ids() {
+        let mut queue = ActionQueue::new();
+        let attrs = HashMap::new();
+        queue.queue(1, attack_ability(None), 2, &attrs);
+        queue.skip(3);
+        assert_eq!(queue.queued_count(&[1, 3, 4]), 1);
     }
 
     #[test]

--- a/src/game/engagement/battle/turn.rs
+++ b/src/game/engagement/battle/turn.rs
@@ -118,7 +118,7 @@ impl BattleEngagement {
 
     pub fn tick(&mut self, engagement_id: i64, max_engage_ticks: u64) -> BattleTick {
         let all_participant_ids = self.all_entity_ids();
-        let output = self.advance_phase(max_engage_ticks);
+        let output = self.advance_phase(engagement_id, max_engage_ticks);
         BattleTick {
             engagement_id,
             all_participant_ids,
@@ -145,7 +145,7 @@ impl BattleEngagement {
     /// more raw ticks than the old 5-phase machine's equivalent single-call transitions did. None
     /// of the new phases block on player input, so this only adds a few non-waiting game-loop
     /// ticks per turn — do not "optimize" this into a multi-arm-per-call loop.
-    fn advance_phase(&mut self, max_engage_ticks: u64) -> PhaseOutput {
+    fn advance_phase(&mut self, engagement_id: i64, max_engage_ticks: u64) -> PhaseOutput {
         let completed_phase = self.turn_phase.clone();
         let mut out = PhaseOutput {
             messages: Vec::new(),
@@ -154,19 +154,23 @@ impl BattleEngagement {
             completed_phase: completed_phase.clone(),
         };
         match completed_phase {
-            BattlePhase::ResetAttributes { .. } => self.advance_reset_attributes(&mut out),
+            BattlePhase::ResetAttributes { .. } => {
+                self.advance_reset_attributes(&mut out, engagement_id)
+            }
             BattlePhase::AnnounceState { .. } => self.advance_announce_state(&mut out),
             BattlePhase::ApplyEffects { .. } => self.advance_apply_effects(&mut out),
             BattlePhase::DeclareAttacks { faction } => {
-                self.advance_declare_attacks(&mut out, faction, max_engage_ticks)
+                self.advance_declare_attacks(&mut out, engagement_id, faction, max_engage_ticks)
             }
             BattlePhase::DeclareDefense { .. } => {
-                self.advance_declare_defense(&mut out, max_engage_ticks)
+                self.advance_declare_defense(&mut out, engagement_id, max_engage_ticks)
             }
-            BattlePhase::ResolveAbilities => self.advance_resolve_abilities(&mut out),
+            BattlePhase::ResolveAbilities => {
+                self.advance_resolve_abilities(&mut out, engagement_id)
+            }
             BattlePhase::ResolveEntityState => self.advance_resolve_entity_state(&mut out),
             BattlePhase::Cleanup => self.advance_cleanup(&mut out),
-            BattlePhase::VictoryCheck => self.advance_victory_check(&mut out),
+            BattlePhase::VictoryCheck => self.advance_victory_check(&mut out, engagement_id),
             BattlePhase::Concluded => {}
         }
         out
@@ -180,8 +184,14 @@ impl BattleEngagement {
         self.ticks_in_phase = 0;
     }
 
-    fn advance_reset_attributes(&mut self, out: &mut PhaseOutput) {
+    fn advance_reset_attributes(&mut self, out: &mut PhaseOutput, engagement_id: i64) {
         self.turn_count += 1;
+        tracing::info!(
+            engagement_id,
+            faction = %self.planning_faction(),
+            turn_count = self.turn_count,
+            "Starting battle turn for faction"
+        );
         let next = BattlePhase::AnnounceState {
             faction: self.planning_faction().to_string(),
         };
@@ -205,6 +215,7 @@ impl BattleEngagement {
     fn advance_declare_attacks(
         &mut self,
         out: &mut PhaseOutput,
+        engagement_id: i64,
         faction: String,
         max_engage_ticks: u64,
     ) {
@@ -213,22 +224,47 @@ impl BattleEngagement {
         let all_submitted = self.action_queue.all_submitted(&planning_ids);
         if all_submitted || self.ticks_in_phase >= max_engage_ticks {
             out.pending_actions = self.action_queue.snapshot();
+            tracing::info!(
+                engagement_id,
+                faction = %faction,
+                planning_count = planning_ids.len(),
+                queued_count = self.action_queue.queued_count(&planning_ids),
+                timed_out = !all_submitted,
+                "DeclareAttacks phase complete"
+            );
             self.transition_to(out, BattlePhase::DeclareDefense { faction });
         }
     }
 
-    fn advance_declare_defense(&mut self, out: &mut PhaseOutput, max_engage_ticks: u64) {
+    fn advance_declare_defense(
+        &mut self,
+        out: &mut PhaseOutput,
+        engagement_id: i64,
+        max_engage_ticks: u64,
+    ) {
         self.ticks_in_phase += 1;
         let responding_ids = self.responding_ids();
         let all_submitted =
             responding_ids.is_empty() || self.action_queue.all_submitted(&responding_ids);
         if all_submitted || self.ticks_in_phase >= max_engage_ticks {
+            tracing::info!(
+                engagement_id,
+                responding_count = responding_ids.len(),
+                queued_count = self.action_queue.queued_count(&responding_ids),
+                timed_out = !all_submitted,
+                "DeclareDefense phase complete"
+            );
             self.transition_to(out, BattlePhase::ResolveAbilities);
         }
     }
 
-    fn advance_resolve_abilities(&mut self, out: &mut PhaseOutput) {
+    fn advance_resolve_abilities(&mut self, out: &mut PhaseOutput, engagement_id: i64) {
         out.resolution_queue = self.action_queue.drain();
+        tracing::info!(
+            engagement_id,
+            resolution_count = out.resolution_queue.len(),
+            "Resolving queued abilities"
+        );
         self.transition_to(out, BattlePhase::ResolveEntityState);
     }
 
@@ -241,18 +277,37 @@ impl BattleEngagement {
         self.transition_to(out, BattlePhase::VictoryCheck);
     }
 
-    fn advance_victory_check(&mut self, out: &mut PhaseOutput) {
+    fn advance_victory_check(&mut self, out: &mut PhaseOutput, engagement_id: i64) {
         if self.surviving_faction_count() <= 1 {
+            self.log_battle_concluded(engagement_id);
             self.transition_to(out, BattlePhase::Concluded);
             return;
         }
         if !self.factions.is_empty() {
             self.planning_faction_index = (self.planning_faction_index + 1) % self.factions.len();
         }
+        self.log_battle_continuing(engagement_id);
         let next = BattlePhase::ResetAttributes {
             faction: self.planning_faction().to_string(),
         };
         self.transition_to(out, next);
+    }
+
+    fn log_battle_concluded(&self, engagement_id: i64) {
+        tracing::info!(
+            engagement_id,
+            survivors = self.surviving_faction_count(),
+            "Battle concluded"
+        );
+    }
+
+    fn log_battle_continuing(&self, engagement_id: i64) {
+        tracing::info!(
+            engagement_id,
+            next_faction = %self.planning_faction(),
+            survivor_factions = self.surviving_faction_count(),
+            "Battle continuing to next faction"
+        );
     }
 }
 


### PR DESCRIPTION
Adds info-level trace logs at key points in the battle state machine so server operators can observe battle progress (phase transitions, faction turns, queue participation, and victory outcomes) directly from the console, without needing to instrument or debug the code itself.

- Threads `engagement_id` through `advance_phase()` and the relevant `advance_*` methods in the turn state machine
- Logs faction turn start, DeclareAttacks/DeclareDefense completion (with participant/queued counts and timeout flag), resolution queue size at ResolveAbilities, and victory-check outcome (concluded vs. rotating to next faction)
- Adds an `ActionQueue::queued_count()` helper to support the queue-count log fields

<details>
<summary>Agent Context</summary>

**Goal:** Complement PR #221 (issue #192), which logs per-turn *attribute values*, with logs of *phase progression* — which phase, which faction, how much waiting vs. queued/skipped.

**Files changed:**
- `src/game/engagement/battle/turn.rs` — added `engagement_id: i64` parameter to `advance_phase()` and to `advance_reset_attributes`, `advance_declare_attacks`, `advance_declare_defense`, `advance_resolve_abilities`, `advance_victory_check`; added five `tracing::info!` log points. Extracted the two victory-check log calls into `log_battle_concluded`/`log_battle_continuing` helpers to keep `advance_victory_check` under clippy's `cognitive_complexity` threshold (was 17/15) — per CLAUDE.md, complexity warnings are fixed by refactoring, never `#[allow]`.
- `src/game/engagement/battle/action_queue.rs` — added `queued_count(&self, entity_ids: &[i64]) -> usize` helper plus a unit test.

**Log points added:**
1. `advance_reset_attributes`: `"Starting battle turn for faction"` — engagement_id, faction, turn_count
2. `advance_declare_attacks` (on transition out): `"DeclareAttacks phase complete"` — engagement_id, faction, planning_count, queued_count, timed_out
3. `advance_declare_defense` (on transition out): `"DeclareDefense phase complete"` — engagement_id, responding_count, queued_count, timed_out
4. `advance_resolve_abilities`: `"Resolving queued abilities"` — engagement_id, resolution_count
5. `advance_victory_check`: `"Battle concluded"` (survivors) or `"Battle continuing to next faction"` (next_faction, survivor_factions)

**Style:** Matches the structured-field `tracing::info!` pattern established in `attribute_snapshot.rs`/`effect.rs` from PR #221 — `%` for Display types (faction strings), plain fields for numerics/bools.

**No changes needed** to `collection.rs` — it already passes `engagement_id` into `battle.tick()`, the single call site of `advance_phase()`.

**Testing:** All 504 existing tests pass unchanged (logging is side-effect free); added one new unit test for `queued_count`. `cargo fmt`/`cargo clippy` clean — the one remaining clippy warning (`attribute_config.rs:146`, test cognitive complexity) is pre-existing on `main` and unrelated to this change.

**Related:** Closes #220. Complements #221 (#192).

</details>