### PR TITLE
[#222] Add --debug flag to server and downgrade ping/pong logs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,9 @@ pub enum Commands {
         /// Force map reload from config on startup, even if maps were previously loaded
         #[arg(long)]
         reload_maps: bool,
+        /// Enable debug output (e.g. show ping/pong messages)
+        #[arg(long)]
+        debug: bool,
     },
     /// Player administration commands
     Players {
@@ -162,6 +165,7 @@ mod tests {
                 name: None,
                 config: None,
                 reload_maps: false,
+                debug: false,
             })
         );
     }
@@ -175,6 +179,7 @@ mod tests {
                 name: Some("myserver".to_string()),
                 config: None,
                 reload_maps: false,
+                debug: false,
             })
         );
     }
@@ -188,6 +193,21 @@ mod tests {
                 name: None,
                 config: Some("muds/basic".to_string()),
                 reload_maps: false,
+                debug: false,
+            })
+        );
+    }
+
+    #[test]
+    fn server_subcommand_with_debug_parses() {
+        let cli = parse(&["mudroom", "server", "--debug"]);
+        assert_eq!(
+            cli.command,
+            Some(Commands::Server {
+                name: None,
+                config: None,
+                reload_maps: false,
+                debug: true,
             })
         );
     }
@@ -245,6 +265,7 @@ mod tests {
                 name: None,
                 config: None,
                 reload_maps: true,
+                debug: false,
             })
         );
     }

--- a/src/cli/router.rs
+++ b/src/cli/router.rs
@@ -9,7 +9,8 @@ impl CliRouter {
                 name,
                 config,
                 reload_maps,
-            }) => server::run(name, config, reload_maps).await,
+                debug,
+            }) => server::run(name, config, reload_maps, debug).await,
             Some(Commands::Client { url, debug }) => client::run(url, debug).await,
             Some(Commands::Players { command }) => players::run(command).await,
             Some(Commands::Completions { shell }) => {

--- a/src/cli/server.rs
+++ b/src/cli/server.rs
@@ -6,8 +6,9 @@ pub async fn run(
     name: Option<String>,
     config: Option<String>,
     reload_maps: bool,
+    debug: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    crate::logging::init_tracing();
+    crate::logging::init_tracing(debug);
     let (server_session, config_path_buf) = init_server_session(name, config).await?;
     let (game_state, db) = init_game_resources(&server_session, config_path_buf.as_deref()).await?;
     if reload_maps || game::should_auto_load(db.pool()).await? {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,6 @@
-pub fn init_tracing() {
+pub fn init_tracing(debug: bool) {
+    let default_level = if debug { "debug" } else { "info" };
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
     tracing_subscriber::fmt().with_env_filter(filter).init();
 }

--- a/src/network/server/handlers.rs
+++ b/src/network/server/handlers.rs
@@ -128,7 +128,7 @@ pub async fn ping_handler(
     State(state): State<Arc<AppState>>,
     Json(body): Json<PingBody>,
 ) -> &'static str {
-    info!(client_id = %body.client_id, "POST /ping");
+    tracing::debug!(client_id = %body.client_id, "POST /ping");
     let personal_tx = {
         let mut conns = state.connections.write().await;
         conns.get_mut(&body.client_id).map(|client| {

--- a/src/network/server/ping_reaper.rs
+++ b/src/network/server/ping_reaper.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::RwLock;
-use tracing::info;
+use tracing::debug;
 
 use super::state::ConnectedClient;
 
@@ -24,7 +24,7 @@ pub async fn run_ping_reaper(connections: Arc<RwLock<HashMap<String, ConnectedCl
             let mut guard = connections.write().await;
             for id in stale {
                 guard.remove(&id);
-                info!(client_id = %id, "Ping reaper removed stale client");
+                debug!(client_id = %id, "Ping reaper removed stale client");
             }
         }
     }


### PR DESCRIPTION
Closes #222

This PR reduces default server log noise from ping/pong traffic:

- Adds a `--debug` flag to the `server` subcommand.
- When `--debug` is passed, `init_tracing` defaults to the `debug` filter level instead of `info` (`RUST_LOG` still takes precedence).
- Downgrades the `POST /ping` log in `handlers.rs` from `info!` to `debug!`.
- Downgrades the stale-client removal log in `ping_reaper.rs` from `info!` to `debug!`.

### Verification
- `cargo fmt` ✅
- `cargo test` ✅ — 505 passed
- `cargo clippy` ✅
