### PR TITLE
Fixes #227 Ensure battles conclude for every disconnect path

### DIFF
--- a/src/game/game_loop/activations.rs
+++ b/src/game/game_loop/activations.rs
@@ -45,6 +45,12 @@ async fn register_in_game_state(
         .await
         .insert(activation.entity.id, activation.entity);
 
+    evict_stale_client_registrations(
+        game_state,
+        activation.player.entity_id,
+        &activation.client_id,
+    )
+    .await;
     game_state
         .active_players
         .write()
@@ -54,6 +60,24 @@ async fn register_in_game_state(
     if let Err(e) = game_state.sync_active_entities(db.pool()).await {
         tracing::error!(error = %e, "Failed to sync active entities on player activation");
     }
+}
+
+/// Removes any existing `active_players` entry for `entity_id` registered under a different
+/// client_id. A reconnect under a new client_id (e.g. a new process) can otherwise leave a stale
+/// entry behind if the old client_id's disconnect was never processed — leaving two entries
+/// pointing at the same entity. That stale entry would be indistinguishable, by entity-scoped
+/// activation epoch alone, from the fresh one when a disconnect eventually gets dispatched for
+/// it, risking exactly the entity it aliases getting torn down out from under the live client.
+async fn evict_stale_client_registrations(
+    game_state: &Arc<GameState>,
+    entity_id: i64,
+    new_client_id: &str,
+) {
+    game_state
+        .active_players
+        .write()
+        .await
+        .retain(|client_id, player| player.entity_id != entity_id || client_id == new_client_id);
 }
 
 /// Bumps the entity's activation epoch and discards any already-queued stale disconnects. The
@@ -155,6 +179,41 @@ mod tests {
             },
             client_id: client_id.to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn activation_evicts_stale_registration_under_old_client_id() {
+        let game_state = Arc::new(GameState::load(None).unwrap());
+        let db = Database::connect_in_memory().await.unwrap();
+        // Simulate a reconnect under a new client_id (e.g. a new process) while the old
+        // client_id's registration for the same entity was never cleaned up.
+        game_state.active_players.write().await.insert(
+            "old-client".to_string(),
+            Player {
+                id: 1,
+                client_id: "old-client".to_string(),
+                name: "Hero".to_string(),
+                entity_id: 1,
+            },
+        );
+        let activation = test_activation("new-client");
+        game_state
+            .push_pending_activation(
+                activation.entity,
+                activation.player,
+                "new-client".to_string(),
+            )
+            .await;
+
+        process(&game_state, &db).await;
+
+        let players = game_state.active_players.read().await;
+        assert!(
+            !players.contains_key("old-client"),
+            "stale registration under the old client_id must be evicted"
+        );
+        assert!(players.contains_key("new-client"));
+        assert_eq!(players.len(), 1);
     }
 
     #[tokio::test]

--- a/src/network/server/handlers.rs
+++ b/src/network/server/handlers.rs
@@ -47,7 +47,7 @@ use tracing::info;
 
 use super::state::{
     AppState, ConnectedClient, GuardedStream, PingBody, SessionEndBody, SessionStartBody,
-    SseCleanupGuard, SseQuery,
+    SseCleanupGuard, SseQuery, queue_player_disconnected,
 };
 use std::sync::atomic::Ordering;
 
@@ -150,13 +150,7 @@ pub async fn session_end_handler(
     Json(body): Json<SessionEndBody>,
 ) -> &'static str {
     let client_id = &body.session_id;
-    let entity_id = state
-        .game_state
-        .active_players
-        .read()
-        .await
-        .get(client_id)
-        .map(|p| p.entity_id);
+    let entity_id = queue_player_disconnected(&state.game_state, client_id).await;
     let removed_connection = state.connections.write().await.remove(client_id).is_some();
     info!(
         client_id = %client_id,
@@ -174,4 +168,94 @@ pub async fn maps_reload_handler(State(state): State<Arc<AppState>>) -> &'static
         .reload_pending
         .store(true, Ordering::Release);
     "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::GameState;
+    use crate::game::component::Location;
+    use crate::game::entity::{Entity, EntityType};
+    use crate::game::interaction;
+    use crate::game::player::Player;
+    use crate::network::session::ServerSession;
+    use crate::persistence::Database;
+    use std::collections::HashMap;
+    use tokio::sync::RwLock;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
+        }
+    }
+
+    async fn battle_app_state(client_id: &str) -> Arc<AppState> {
+        let game_state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = game_state.active_entities.write().await;
+            entities.insert(1, Entity::new(1, EntityType::Player, test_location()));
+            entities.insert(2, Entity::new(2, EntityType::Enemy, test_location()));
+        }
+        game_state.active_players.write().await.insert(
+            client_id.to_string(),
+            Player {
+                id: 1,
+                client_id: client_id.to_string(),
+                name: "Hero".to_string(),
+                entity_id: 1,
+            },
+        );
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        game_state
+            .engagements
+            .add_battle(
+                "r".to_string(),
+                vec!["player".to_string(), "enemy".to_string()],
+                participants,
+            )
+            .await;
+
+        Arc::new(AppState {
+            server_session: ServerSession {
+                id: "srv".to_string(),
+                name: None,
+            },
+            game_state,
+            db: Database::connect_in_memory().await.unwrap(),
+            connections: Arc::new(RwLock::new(HashMap::new())),
+            next_connection_seq: Arc::new(std::sync::atomic::AtomicU64::new(1)),
+        })
+    }
+
+    #[tokio::test]
+    async fn session_end_handler_concludes_battle_for_last_departing_faction_member() {
+        let state = battle_app_state("m:1").await;
+
+        session_end_handler(
+            State(state.clone()),
+            Json(SessionEndBody {
+                session_id: "m:1".to_string(),
+            }),
+        )
+        .await;
+
+        // session_end_handler only queues the disconnect; the game loop's interaction
+        // processing is what actually tears the battle down.
+        interaction::process(&state.game_state, &state.db, 0).await;
+
+        assert_eq!(
+            state
+                .game_state
+                .engagements
+                .battles
+                .find_for_entity(2)
+                .await,
+            None,
+            "battle should conclude once the only player-faction member disconnects"
+        );
+    }
 }

--- a/src/network/server/ping_reaper.rs
+++ b/src/network/server/ping_reaper.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 use tokio::sync::RwLock;
 use tracing::info;
 
-use super::state::ConnectedClient;
+use super::state::{ConnectedClient, queue_player_disconnected};
 use crate::game::GameState;
 
 pub async fn run_ping_reaper(
@@ -16,30 +16,141 @@ pub async fn run_ping_reaper(
     let interval = std::time::Duration::from_secs(10);
     loop {
         tokio::time::sleep(interval).await;
-        let now = Instant::now();
-        let stale: Vec<String> = connections
-            .read()
-            .await
-            .iter()
-            .filter(|(_, c)| now.duration_since(c.last_ping) > timeout)
-            .map(|(id, _)| id.clone())
-            .collect();
-        if !stale.is_empty() {
-            let mut guard = connections.write().await;
-            for id in stale {
-                guard.remove(&id);
-                let entity_id = game_state
-                    .active_players
-                    .read()
-                    .await
-                    .get(&id)
-                    .map(|p| p.entity_id);
-                info!(
-                    client_id = %id,
-                    entity_id,
-                    "player disconnected due to ping/pong timeout"
-                );
-            }
+        reap_stale_connections(&connections, &game_state, timeout).await;
+    }
+}
+
+async fn reap_stale_connections(
+    connections: &Arc<RwLock<HashMap<String, ConnectedClient>>>,
+    game_state: &Arc<GameState>,
+    timeout: std::time::Duration,
+) {
+    let now = Instant::now();
+    let stale: Vec<String> = connections
+        .read()
+        .await
+        .iter()
+        .filter(|(_, c)| now.duration_since(c.last_ping) > timeout)
+        .map(|(id, _)| id.clone())
+        .collect();
+    if stale.is_empty() {
+        return;
+    }
+    let mut guard = connections.write().await;
+    for id in &stale {
+        guard.remove(id);
+    }
+    drop(guard);
+    for id in stale {
+        let entity_id = queue_player_disconnected(game_state, &id).await;
+        info!(
+            client_id = %id,
+            entity_id,
+            "player disconnected due to ping/pong timeout"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::component::Location;
+    use crate::game::entity::{Entity, EntityType};
+    use crate::game::interaction;
+    use crate::game::player::Player;
+    use crate::network::event::NetworkEvent;
+    use crate::persistence::Database;
+    use std::time::Duration;
+    use tokio::sync::mpsc;
+
+    fn test_location() -> Location {
+        Location {
+            world_id: "w".to_string(),
+            dungeon_id: "d".to_string(),
+            room_id: "r".to_string(),
         }
+    }
+
+    async fn battle_game_state(client_id: &str) -> Arc<GameState> {
+        let game_state = Arc::new(GameState::load(None).unwrap());
+        {
+            let mut entities = game_state.active_entities.write().await;
+            entities.insert(1, Entity::new(1, EntityType::Player, test_location()));
+            entities.insert(2, Entity::new(2, EntityType::Enemy, test_location()));
+        }
+        game_state.active_players.write().await.insert(
+            client_id.to_string(),
+            Player {
+                id: 1,
+                client_id: client_id.to_string(),
+                name: "Hero".to_string(),
+                entity_id: 1,
+            },
+        );
+        let mut participants = HashMap::new();
+        participants.insert("player".to_string(), vec![1]);
+        participants.insert("enemy".to_string(), vec![2]);
+        game_state
+            .engagements
+            .add_battle(
+                "r".to_string(),
+                vec!["player".to_string(), "enemy".to_string()],
+                participants,
+            )
+            .await;
+        game_state
+    }
+
+    #[tokio::test]
+    async fn reap_stale_connections_concludes_battle_for_timed_out_player() {
+        let game_state = battle_game_state("m:1").await;
+        let (personal_tx, _rx) = mpsc::channel::<NetworkEvent>(1);
+        let connections = Arc::new(RwLock::new(HashMap::from([(
+            "m:1".to_string(),
+            ConnectedClient {
+                last_ping: Instant::now() - Duration::from_secs(40),
+                personal_tx,
+                seq: 1,
+            },
+        )])));
+        let timeout = Duration::from_secs(30);
+
+        reap_stale_connections(&connections, &game_state, timeout).await;
+
+        assert!(
+            !connections.read().await.contains_key("m:1"),
+            "timed-out connection should be reaped"
+        );
+
+        // Reaping only queues the disconnect; the game loop's interaction processing is what
+        // actually tears the battle down.
+        let db = Database::connect_in_memory().await.unwrap();
+        interaction::process(&game_state, &db, 0).await;
+
+        assert_eq!(
+            game_state.engagements.battles.find_for_entity(2).await,
+            None,
+            "battle should conclude once the only player-faction member times out"
+        );
+    }
+
+    #[tokio::test]
+    async fn reap_stale_connections_leaves_fresh_connections_untouched() {
+        let game_state = battle_game_state("m:2").await;
+        let (personal_tx, _rx) = mpsc::channel::<NetworkEvent>(1);
+        let connections = Arc::new(RwLock::new(HashMap::from([(
+            "m:2".to_string(),
+            ConnectedClient {
+                last_ping: Instant::now(),
+                personal_tx,
+                seq: 1,
+            },
+        )])));
+        let timeout = Duration::from_secs(30);
+
+        reap_stale_connections(&connections, &game_state, timeout).await;
+
+        assert!(connections.read().await.contains_key("m:2"));
+        assert!(game_state.mailboxes.drain(1).await.is_empty());
     }
 }

--- a/src/network/server/state.rs
+++ b/src/network/server/state.rs
@@ -63,34 +63,45 @@ impl Drop for SseCleanupGuard {
                 }
             }
             info!(client_id = %client_id, "SSE disconnected — queuing cleanup");
-            let entity_id = {
-                let players = game_state.active_players.read().await;
-                players.get(&client_id).map(|p| p.entity_id)
-            };
-            if let Some(entity_id) = entity_id {
-                // Captured now, as early as possible after deciding to queue the disconnect —
-                // not right before the push below — so a reactivation racing this cleanup task
-                // is reflected as a bumped epoch by the time dispatch checks it, rather than
-                // this stale disconnect picking up the reactivation's own epoch and looking
-                // fresh again.
-                let epoch = game_state.current_activation_epoch(entity_id).await;
-                info!(
-                    entity_id,
-                    client_id = %client_id,
-                    seq,
-                    epoch,
-                    "queuing PlayerDisconnected"
-                );
-                game_state
-                    .mailboxes
-                    .push(
-                        entity_id,
-                        Interaction::PlayerDisconnected { client_id, epoch },
-                    )
-                    .await;
-            }
+            queue_player_disconnected(&game_state, &client_id).await;
         });
     }
+}
+
+/// Looks up the entity behind `client_id` and queues `Interaction::PlayerDisconnected` for it,
+/// capturing the entity's current activation epoch immediately beforehand — as early as possible
+/// after deciding to queue the disconnect — so a reactivation racing this call is reflected as a
+/// bumped epoch by the time dispatch checks it, rather than this stale disconnect picking up the
+/// reactivation's own epoch and looking fresh again. Every disconnect source (SSE drop, explicit
+/// session end, ping/pong timeout) routes through this so they all converge on the same
+/// epoch-guarded teardown path. Returns the entity id, or `None` if `client_id` has no registered
+/// player.
+pub async fn queue_player_disconnected(
+    game_state: &Arc<GameState>,
+    client_id: &str,
+) -> Option<i64> {
+    let entity_id = {
+        let players = game_state.active_players.read().await;
+        players.get(client_id).map(|p| p.entity_id)
+    }?;
+    let epoch = game_state.current_activation_epoch(entity_id).await;
+    info!(
+        entity_id,
+        client_id = %client_id,
+        epoch,
+        "queuing PlayerDisconnected"
+    );
+    game_state
+        .mailboxes
+        .push(
+            entity_id,
+            Interaction::PlayerDisconnected {
+                client_id: client_id.to_string(),
+                epoch,
+            },
+        )
+        .await;
+    Some(entity_id)
 }
 
 // Stream wrapper that keeps the guard alive until the stream is dropped.
@@ -203,6 +214,16 @@ mod tests {
             game_state.mailboxes.drain(1).await.is_empty(),
             "stale guard must not queue PlayerDisconnected"
         );
+    }
+
+    #[tokio::test]
+    async fn queue_player_disconnected_is_noop_for_unregistered_client() {
+        let game_state = Arc::new(GameState::load(None).unwrap());
+
+        let entity_id = queue_player_disconnected(&game_state, "unknown").await;
+
+        assert_eq!(entity_id, None);
+        assert!(game_state.mailboxes.drain(1).await.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Battles could get stuck forever when a faction's last member left by any path other than a raw TCP-level drop — an explicit client quit or a ping/pong timeout never actually removed the departing player from battle participation, so the engine's own survivor-count check could never see them as gone. Closes #227.

- Explicit session end (`POST /session/end`) and ping/pong-timeout reaping now queue the same `PlayerDisconnected` interaction the SSE-drop path already used, converging all three disconnect sources on one teardown/battle-conclusion pipeline
- Extracted the shared entity-lookup/epoch-capture/mailbox-push logic into a single `queue_player_disconnected` helper to keep the three call sites in lockstep
- Fixes a related regression the above change would have exposed: a reconnect under a new client_id could leave a stale `active_players` registration for the same entity under the old client_id, which a later disconnect dispatch could pick up and use to tear down the entity out from under the still-connected session ("ghost state")
- Added test coverage for battle conclusion via explicit session end and ping-timeout reap, plus a regression test for the stale-registration eviction

<details>
<summary>Agent Context</summary>

Goal: ensure a `Battle` engagement concludes whenever only one faction has surviving participants, regardless of which departure path caused the reduction (in-app leave, TCP-level SSE drop, explicit client quit, or ping/pong timeout).

Root gap (per #227's own investigation, itself a follow-up from #225/#226): `battle::participants::remove_entity` — the only thing that removes a departing player from a battle's participant list — is only invoked via `lifecycle::player_disconnected`, which only runs when `Interaction::PlayerDisconnected` is queued to the entity's mailbox. That interaction was previously queued from exactly one place: `SseCleanupGuard::drop` in `src/network/server/state.rs`. Two other disconnect sources never queued it: `session_end_handler` (`src/network/server/handlers.rs`, `POST /session/end`) and `run_ping_reaper` (`src/network/server/ping_reaper.rs`).

Fix: extracted the entity-lookup → epoch-capture → mailbox-push logic from `SseCleanupGuard::drop` into `queue_player_disconnected(game_state, client_id) -> Option<i64>` in `src/network/server/state.rs`, preserving the original race-safety ordering (epoch captured immediately after the entity lookup, right before the push — same invariant added in #226 for the epoch-based staleness guard in `game::interaction::dispatch_player_disconnected`). `session_end_handler` and a new `reap_stale_connections` (extracted from `run_ping_reaper`'s loop body so it's unit-testable without real sleeps) now call this helper.

Regression found and fixed in the same PR: `register_in_game_state` in `src/game/game_loop/activations.rs` only ever inserted the new client_id's `active_players` entry on (re)activation — it never evicted a stale entry for the same `entity_id` left behind under an *older* client_id (e.g. a reconnect from a new process before the old connection's disconnect was ever processed). Before this PR that duplicate was inert; once session-end/ping-reaper disconnects reliably fire, `game::interaction::process`'s snapshot-then-iterate over `active_players` could dispatch the queued disconnect using the *stale* `(client_id, player)` pair, deleting `active_entities[entity_id]` while leaving the live client's `active_players` entry dangling — because the activation epoch guard is scoped per-entity, not per-`(entity, client_id)`, it can't distinguish a legitimate current-session disconnect from a stale aliasing one. Fixed by evicting any `active_players` entry for the same entity under a different client_id in `register_in_game_state` (new `evict_stale_client_registrations` helper), so at most one entry can ever reference a given entity.

Files changed:
- `src/network/server/state.rs` — `queue_player_disconnected` helper; `SseCleanupGuard::drop` now delegates to it
- `src/network/server/handlers.rs` — `session_end_handler` uses the helper
- `src/network/server/ping_reaper.rs` — `reap_stale_connections` extracted and uses the helper
- `src/game/game_loop/activations.rs` — `evict_stale_client_registrations` closes the stale-duplicate-registration gap

No changes were needed in `src/game/interaction.rs`, `src/game/interaction/lifecycle.rs`, `src/game/engagement/battle/participants.rs`, or `src/game/engagement/battle/end.rs` — the teardown/conclusion chain those own was already correct once reliably invoked.

`cargo fmt`, `cargo test` (519 passed), and `cargo clippy` all clean (one pre-existing, unrelated cognitive-complexity warning in `src/game/config/attribute_config.rs` untouched by this change).

</details>