### PR TITLE
Fixes #229 Add semantic message kinds and a TUI message theme

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -6,25 +6,35 @@ pub use battle_state::{BattleFocus, BattleState, QueuedAbilityInfo};
 pub use conversation_state::ConversationState;
 
 use crate::network::event::{ClassInfo, PlayerInfo};
+use crate::tui::components::theme::{MessageKind, MessageTheme};
 
 #[derive(Debug, Clone)]
 pub struct AppMessage {
     pub text: String,
-    pub debug: bool,
+    pub kind: MessageKind,
 }
 
 impl AppMessage {
     pub fn normal(text: impl Into<String>) -> Self {
-        Self {
-            text: text.into(),
-            debug: false,
-        }
+        Self::with_kind(text, MessageKind::Narration)
+    }
+
+    pub fn command(text: impl Into<String>) -> Self {
+        Self::with_kind(text, MessageKind::PlayerCommand)
+    }
+
+    pub fn system(text: impl Into<String>) -> Self {
+        Self::with_kind(text, MessageKind::System)
     }
 
     pub fn debug(text: impl Into<String>) -> Self {
+        Self::with_kind(text, MessageKind::Debug)
+    }
+
+    fn with_kind(text: impl Into<String>, kind: MessageKind) -> Self {
         Self {
             text: text.into(),
-            debug: true,
+            kind,
         }
     }
 }
@@ -75,6 +85,7 @@ pub struct App {
     pub streaming_message_index: Option<usize>,
     pub agent_responding: bool,
     pub debug: bool,
+    pub theme: MessageTheme,
 }
 
 impl App {
@@ -82,8 +93,8 @@ impl App {
         Self {
             should_quit: false,
             messages: vec![
-                AppMessage::normal("Welcome to mudroom."),
-                AppMessage::normal("Type commands and press Enter."),
+                AppMessage::system("Welcome to mudroom."),
+                AppMessage::system("Type commands and press Enter."),
             ],
             input: String::new(),
             scroll_offset: 0,
@@ -97,6 +108,7 @@ impl App {
             streaming_message_index: None,
             agent_responding: false,
             debug,
+            theme: MessageTheme,
         }
     }
 
@@ -119,6 +131,7 @@ impl App {
             streaming_message_index: None,
             agent_responding: false,
             debug,
+            theme: MessageTheme,
         }
     }
 

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -10,10 +10,10 @@ impl App {
         match event {
             NetworkEvent::StartSession { session_id } => self
                 .messages
-                .push(AppMessage::normal(format!("Session started: {session_id}"))),
+                .push(AppMessage::system(format!("Session started: {session_id}"))),
             NetworkEvent::EndSession { session_id } => self
                 .messages
-                .push(AppMessage::normal(format!("Session ended: {session_id}"))),
+                .push(AppMessage::system(format!("Session ended: {session_id}"))),
             NetworkEvent::Ping => {
                 if self.debug {
                     self.messages.push(AppMessage::debug("[ping received]"));
@@ -34,7 +34,7 @@ impl App {
                 self.current_entity_id = Some(entity_id);
                 self.streaming_message_index = None;
                 self.messages
-                    .push(AppMessage::normal(format!("Playing as: {player_name}")));
+                    .push(AppMessage::system(format!("Playing as: {player_name}")));
             }
             NetworkEvent::Message { player_id, content } => {
                 if Some(player_id) == self.current_player_id {

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -1,1 +1,2 @@
 pub mod message_log;
+pub mod theme;

--- a/src/tui/components/message_log.rs
+++ b/src/tui/components/message_log.rs
@@ -1,16 +1,17 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Style},
     text::{Line, Span, Text},
     widgets::{Block, Paragraph, Wrap},
 };
 
+use super::theme::{MessageTheme, StyleKey};
 use crate::tui::app::AppMessage;
 
 pub fn render(
     frame: &mut Frame,
     messages: &[AppMessage],
+    theme: &MessageTheme,
     scroll_offset: usize,
     block: Block,
     area: Rect,
@@ -20,11 +21,7 @@ pub fn render(
     let all_lines: Vec<Line> = messages
         .iter()
         .flat_map(|msg| {
-            let style = if msg.debug {
-                Style::default().fg(Color::DarkGray)
-            } else {
-                Style::default()
-            };
+            let style = theme.resolve(StyleKey::Message(msg.kind), None);
             msg.text
                 .split('\n')
                 .map(|line| Line::from(Span::styled(line.to_string(), style)))

--- a/src/tui/components/theme.rs
+++ b/src/tui/components/theme.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+
+use ratatui::style::{Color, Modifier, Style};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MessageKind {
+    PlayerCommand,
+    Narration,
+    System,
+    /// Placeholder default for a single migrated battle message. Battle
+    /// currently has several distinct message variants (see
+    /// `battle_message_to_line` in `tui/screens/battle/render.rs`) that a
+    /// single coarse kind can't represent — that future migration should
+    /// lean on caller-supplied overrides rather than this default alone.
+    BattleEvent,
+    Debug,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Markup {
+    Bold,
+    Emphasis,
+    Highlight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum StyleKey {
+    Message(MessageKind),
+    Markup(Markup),
+}
+
+pub type StyleOverrides = HashMap<StyleKey, Style>;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MessageTheme;
+
+impl MessageTheme {
+    pub fn resolve(&self, key: StyleKey, overrides: Option<&StyleOverrides>) -> Style {
+        if let Some(style) = overrides.and_then(|map| map.get(&key)) {
+            return *style;
+        }
+        default_style(key)
+    }
+}
+
+fn default_style(key: StyleKey) -> Style {
+    match key {
+        StyleKey::Message(kind) => default_message_style(kind),
+        StyleKey::Markup(markup) => default_markup_style(markup),
+    }
+}
+
+fn default_message_style(kind: MessageKind) -> Style {
+    match kind {
+        MessageKind::PlayerCommand => Style::default().fg(Color::Cyan),
+        MessageKind::Narration => Style::default(),
+        MessageKind::System => Style::default().fg(Color::Green),
+        MessageKind::BattleEvent => Style::default().fg(Color::White),
+        MessageKind::Debug => Style::default().fg(Color::DarkGray),
+    }
+}
+
+fn default_markup_style(markup: Markup) -> Style {
+    match markup {
+        Markup::Bold => Style::default().add_modifier(Modifier::BOLD),
+        Markup::Emphasis => Style::default().add_modifier(Modifier::ITALIC),
+        Markup::Highlight => Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_returns_default_when_no_overrides() {
+        let theme = MessageTheme;
+        let style = theme.resolve(StyleKey::Message(MessageKind::Narration), None);
+        assert_eq!(style, Style::default());
+    }
+
+    #[test]
+    fn resolve_debug_matches_dark_gray_like_before() {
+        let theme = MessageTheme;
+        let style = theme.resolve(StyleKey::Message(MessageKind::Debug), None);
+        assert_eq!(style, Style::default().fg(Color::DarkGray));
+    }
+
+    #[test]
+    fn resolve_prefers_override_over_default() {
+        let theme = MessageTheme;
+        let mut overrides = StyleOverrides::new();
+        overrides.insert(
+            StyleKey::Message(MessageKind::Narration),
+            Style::default().fg(Color::Magenta),
+        );
+        let style = theme.resolve(StyleKey::Message(MessageKind::Narration), Some(&overrides));
+        assert_eq!(style, Style::default().fg(Color::Magenta));
+    }
+
+    #[test]
+    fn resolve_returns_default_for_markup() {
+        let theme = MessageTheme;
+        let style = theme.resolve(StyleKey::Markup(Markup::Bold), None);
+        assert_eq!(style, Style::default().add_modifier(Modifier::BOLD));
+    }
+}

--- a/src/tui/screens/agent_conversation.rs
+++ b/src/tui/screens/agent_conversation.rs
@@ -54,7 +54,7 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
                     });
                     let _ = send_interaction(url, client_id, &action).await;
                 }
-                app.messages.push(AppMessage::normal(input));
+                app.messages.push(AppMessage::command(input));
                 app.scroll_offset = 0;
                 app.agent_responding = true;
             }
@@ -77,6 +77,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
+        &app.theme,
         app.scroll_offset,
         Block::default().title("Conversation").borders(Borders::ALL),
         areas[0],

--- a/src/tui/screens/conversation.rs
+++ b/src/tui/screens/conversation.rs
@@ -48,6 +48,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
+        &app.theme,
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -28,7 +28,7 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
         (_, KeyCode::Enter) => {
             let input: String = app.input.drain(..).collect();
             dispatch_command(app, &input).await;
-            app.messages.push(AppMessage::normal(input));
+            app.messages.push(AppMessage::command(input));
             app.scroll_offset = 0;
         }
         (_, KeyCode::PageUp) => app.scroll_up(),
@@ -127,6 +127,7 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
+        &app.theme,
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],


### PR DESCRIPTION
Introduces a shared semantic message model and a central style theme for the TUI, so the world-mode message log can distinguish command echoes, narration, and system notices instead of rendering everything identically. This lays the styling foundation that later work (battle log refactor, markdown markup parsing, mud-authored themes) will build on.

- New `MessageKind`/`Markup`/`StyleKey` types and a `MessageTheme` with default styles plus caller-supplied overrides, in `tui/components/theme.rs`
- `AppMessage` now carries a semantic `kind` instead of a boolean `debug` flag
- `message_log::render` resolves per-message styles through the theme rather than a single inline debug/normal branch
- Reclassified existing message call sites (player command echoes, session/system notices, world narration, debug pings) to their appropriate kind

<details>
<summary>Agent Context</summary>

Goal: create the styling foundation in `tui/components/` for issue #229, ahead of follow-up issues covering distinct command echo styling, pulldown-cmark markup parsing, typewriter reveal, a battle log refactor, and mud-authored `ThemeConfig` support.

Key files:
- `src/tui/components/theme.rs` (new) — `MessageKind` (`PlayerCommand`, `Narration`, `System`, `BattleEvent`, `Debug`), `Markup` (`Bold`, `Emphasis`, `Highlight`, unused until the markup converter lands), `StyleKey` unifying both as one lookup key, `MessageTheme::resolve(&self, key: StyleKey, overrides: Option<&StyleOverrides>) -> Style`. Defaults are implemented as exhaustive `match` functions (not a `HashMap` built in `Default`) so the compiler forces a style for every new variant as the enum grows — no silent fallback risk. Inline `#[cfg(test)]` unit tests cover default resolution, override precedence, and that `Debug` still resolves to the prior `Color::DarkGray`.
- `src/tui/components.rs` — declares `pub mod theme;`.
- `src/tui/app.rs` — `AppMessage` drops `debug: bool` for `kind: MessageKind`; constructors `normal()` (Narration), `command()` (PlayerCommand), `system()` (System), `debug()` (Debug, unchanged effective styling). `App` gains `pub theme: MessageTheme`, initialized in both `App::new` and `App::with_player_select`. Welcome-banner messages switched to `system()` for consistency with other lifecycle notices.
- `src/tui/components/message_log.rs` — `render` takes a new `theme: &MessageTheme` param; per-message style now comes from `theme.resolve(StyleKey::Message(msg.kind), None)`.
- `src/tui/app/network_event_handler.rs` — session started/ended and "Playing as: {name}" reclassified to `system()`; ping/pong stay `debug()`; server-sent narration/streaming chunks stay `normal()`.
- `src/tui/screens/game.rs`, `src/tui/screens/agent_conversation.rs` — player input echoes reclassified to `command()`; both plus `src/tui/screens/conversation.rs` updated to pass `&app.theme` into `message_log::render`.

Explicitly out of scope: `src/tui/screens/battle/render.rs` is untouched. Battle currently hardcodes 7 distinct per-variant styles (`PhaseChange`, `AbilityCast`, `EntityDied`, `PendingAttack`, `Meta`, `EffectText`, `EffectExpired`) that a single coarse `MessageKind::BattleEvent` default can't represent — `BattleEvent`'s doc comment notes that a future battle migration should lean on the `overrides` map rather than the coarse default. That migration is a separate follow-up issue.

Default style choices: `PlayerCommand` → Cyan, `Narration` → plain default, `System` → Green, `BattleEvent` → White (placeholder), `Debug` → DarkGray (matches prior behavior exactly). `Markup::Highlight` reuses Yellow+Bold, the app's existing "attention/selection" color semantic (focused borders, selected list items, input line) rather than introducing a new color meaning.

Verified via `cargo fmt && cargo test && cargo clippy` — all 523 tests + doctests pass (including 4 new theme tests); no new clippy warnings (one pre-existing, unrelated `cognitive_complexity` warning in `src/game/config/attribute_config.rs` predates this branch).