### PR TITLE
Render player command echoes in a distinct style (#230)

### DIFF
--- a/src/tui/components/message_log.rs
+++ b/src/tui/components/message_log.rs
@@ -5,7 +5,7 @@ use ratatui::{
     widgets::{Block, Paragraph, Wrap},
 };
 
-use super::theme::{MessageTheme, StyleKey};
+use super::theme::{MessageKind, MessageTheme, StyleKey};
 use crate::tui::app::AppMessage;
 
 pub fn render(
@@ -22,9 +22,14 @@ pub fn render(
         .iter()
         .flat_map(|msg| {
             let style = theme.resolve(StyleKey::Message(msg.kind), None);
+            let prefix = if msg.kind == MessageKind::PlayerCommand {
+                "> "
+            } else {
+                ""
+            };
             msg.text
                 .split('\n')
-                .map(|line| Line::from(Span::styled(line.to_string(), style)))
+                .map(|line| Line::from(Span::styled(format!("{prefix}{line}"), style)))
                 .collect::<Vec<_>>()
         })
         .collect();

--- a/src/tui/components/theme.rs
+++ b/src/tui/components/theme.rs
@@ -52,7 +52,7 @@ fn default_style(key: StyleKey) -> Style {
 
 fn default_message_style(kind: MessageKind) -> Style {
     match kind {
-        MessageKind::PlayerCommand => Style::default().fg(Color::Cyan),
+        MessageKind::PlayerCommand => Style::default().fg(Color::Cyan).add_modifier(Modifier::DIM),
         MessageKind::Narration => Style::default(),
         MessageKind::System => Style::default().fg(Color::Green),
         MessageKind::BattleEvent => Style::default().fg(Color::White),


### PR DESCRIPTION
## Summary

Makes player-typed commands visually distinct in the message log by applying a dimmed cyan style with a `> ` prompt prefix, so the log reads as a conversation between the player and the world.

## Changes

- **`src/tui/components/theme.rs`** — Added `Modifier::DIM` to the `PlayerCommand` default style (dimmed cyan instead of bright cyan).
- **`src/tui/components/message_log.rs`** — Prepends `> ` to lines rendered from `PlayerCommand` kind messages; other kinds are unchanged.

## Context

PR #229 (already merged) introduced the `PlayerCommand` message kind and switched the push sites (`game.rs`, `agent_conversation.rs`) to use `AppMessage::command()`. This PR completes the visual treatment by styling the rendering side.

Closes #230