### PR TITLE
Fixes #231 Parse markdown descriptions into themed spans with pulldown-cmark

### DIFF
--- a/muds/basic/maps/default/default/default.toml
+++ b/muds/basic/maps/default/default/default.toml
@@ -1,5 +1,5 @@
 [description]
-standard = "You stand at the crossroads of a small town. A tavern lies to the north. A dark corridor leads to the east."
+standard = "You stand at the crossroads of a small town. A **tavern** lies to the north. A dark corridor leads to the east."
 
 [north]
 room_id = "tavern"

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,43 +1,14 @@
 mod battle_state;
 mod conversation_state;
+mod message;
 mod network_event_handler;
 
 pub use battle_state::{BattleFocus, BattleState, QueuedAbilityInfo};
 pub use conversation_state::ConversationState;
+pub use message::AppMessage;
 
 use crate::network::event::{ClassInfo, PlayerInfo};
-use crate::tui::components::theme::{MessageKind, MessageTheme};
-
-#[derive(Debug, Clone)]
-pub struct AppMessage {
-    pub text: String,
-    pub kind: MessageKind,
-}
-
-impl AppMessage {
-    pub fn normal(text: impl Into<String>) -> Self {
-        Self::with_kind(text, MessageKind::Narration)
-    }
-
-    pub fn command(text: impl Into<String>) -> Self {
-        Self::with_kind(text, MessageKind::PlayerCommand)
-    }
-
-    pub fn system(text: impl Into<String>) -> Self {
-        Self::with_kind(text, MessageKind::System)
-    }
-
-    pub fn debug(text: impl Into<String>) -> Self {
-        Self::with_kind(text, MessageKind::Debug)
-    }
-
-    fn with_kind(text: impl Into<String>, kind: MessageKind) -> Self {
-        Self {
-            text: text.into(),
-            kind,
-        }
-    }
-}
+use crate::tui::components::theme::MessageTheme;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum GameMode {
@@ -90,11 +61,12 @@ pub struct App {
 
 impl App {
     pub fn new(debug: bool) -> Self {
+        let theme = MessageTheme;
         Self {
             should_quit: false,
             messages: vec![
-                AppMessage::system("Welcome to mudroom."),
-                AppMessage::system("Type commands and press Enter."),
+                AppMessage::system("Welcome to mudroom.", &theme),
+                AppMessage::system("Type commands and press Enter.", &theme),
             ],
             input: String::new(),
             scroll_offset: 0,

--- a/src/tui/app/message.rs
+++ b/src/tui/app/message.rs
@@ -1,0 +1,132 @@
+use ratatui::text::{Line, Span};
+
+use crate::tui::components::markup;
+use crate::tui::components::theme::{MessageKind, MessageTheme, StyleKey, StyleOverrides};
+
+#[derive(Debug, Clone)]
+pub struct AppMessage {
+    pub text: String,
+    pub kind: MessageKind,
+    pub lines: Vec<Line<'static>>,
+}
+
+impl AppMessage {
+    pub fn normal(text: impl Into<String>, theme: &MessageTheme) -> Self {
+        Self::with_kind(text, MessageKind::Narration, theme)
+    }
+
+    pub fn command(text: impl Into<String>, theme: &MessageTheme) -> Self {
+        Self::with_kind(text, MessageKind::PlayerCommand, theme)
+    }
+
+    pub fn system(text: impl Into<String>, theme: &MessageTheme) -> Self {
+        Self::with_kind(text, MessageKind::System, theme)
+    }
+
+    pub fn debug(text: impl Into<String>, theme: &MessageTheme) -> Self {
+        Self::with_kind(text, MessageKind::Debug, theme)
+    }
+
+    fn with_kind(text: impl Into<String>, kind: MessageKind, theme: &MessageTheme) -> Self {
+        let text = text.into();
+        let lines = styled_lines(&text, kind, theme);
+        Self { text, kind, lines }
+    }
+
+    /// Appends `chunk` to the message text and re-parses the accumulated
+    /// text, so a streamed SSE message stays correctly styled as it grows.
+    pub fn append(&mut self, chunk: &str, theme: &MessageTheme) {
+        self.text.push_str(chunk);
+        self.lines = styled_lines(&self.text, self.kind, theme);
+    }
+}
+
+fn styled_lines(text: &str, kind: MessageKind, theme: &MessageTheme) -> Vec<Line<'static>> {
+    let overrides = StyleOverrides::new();
+    let base_style = theme.resolve(StyleKey::Message(kind), None);
+
+    let lines = markup::parse(text, theme, &overrides)
+        .into_iter()
+        .map(|line| {
+            let spans: Vec<Span<'static>> = line
+                .spans
+                .into_iter()
+                .map(|span| Span::styled(span.content, base_style.patch(span.style)))
+                .collect();
+            Line::from(spans)
+        });
+
+    if kind == MessageKind::PlayerCommand {
+        lines.map(prefix_command_line).collect()
+    } else {
+        lines.collect()
+    }
+}
+
+fn prefix_command_line(mut line: Line<'static>) -> Line<'static> {
+    line.spans.insert(0, Span::raw("> "));
+    line
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::Modifier;
+
+    fn plain_text(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn normal_message_parses_markdown() {
+        let theme = MessageTheme;
+        let msg = AppMessage::normal("**bold**", &theme);
+        assert_eq!(msg.text, "**bold**");
+        assert_eq!(plain_text(&msg.lines), "bold");
+        assert!(
+            msg.lines[0].spans[0]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn command_message_prefixes_every_line() {
+        let theme = MessageTheme;
+        let msg = AppMessage::command("line one\nline two", &theme);
+        assert_eq!(msg.lines.len(), 2);
+        assert_eq!(plain_text(&msg.lines), "> line one\n> line two");
+    }
+
+    #[test]
+    fn system_and_debug_use_expected_kind() {
+        let theme = MessageTheme;
+        assert_eq!(AppMessage::system("hi", &theme).kind, MessageKind::System);
+        assert_eq!(AppMessage::debug("hi", &theme).kind, MessageKind::Debug);
+    }
+
+    #[test]
+    fn append_accumulates_and_reparses() {
+        let theme = MessageTheme;
+        let mut msg = AppMessage::normal("**bo", &theme);
+        msg.append("ld**", &theme);
+        assert_eq!(msg.text, "**bold**");
+        assert_eq!(plain_text(&msg.lines), "bold");
+        assert!(
+            msg.lines[0].spans[0]
+                .style
+                .add_modifier
+                .contains(Modifier::BOLD)
+        );
+    }
+}

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -8,20 +8,24 @@ use super::{App, AppMessage, BattleState, GameMode};
 impl App {
     pub fn handle_network_event(&mut self, event: NetworkEvent) {
         match event {
-            NetworkEvent::StartSession { session_id } => self
-                .messages
-                .push(AppMessage::system(format!("Session started: {session_id}"))),
-            NetworkEvent::EndSession { session_id } => self
-                .messages
-                .push(AppMessage::system(format!("Session ended: {session_id}"))),
+            NetworkEvent::StartSession { session_id } => self.messages.push(AppMessage::system(
+                format!("Session started: {session_id}"),
+                &self.theme,
+            )),
+            NetworkEvent::EndSession { session_id } => self.messages.push(AppMessage::system(
+                format!("Session ended: {session_id}"),
+                &self.theme,
+            )),
             NetworkEvent::Ping => {
                 if self.debug {
-                    self.messages.push(AppMessage::debug("[ping received]"));
+                    self.messages
+                        .push(AppMessage::debug("[ping received]", &self.theme));
                 }
             }
             NetworkEvent::Pong => {
                 if self.debug {
-                    self.messages.push(AppMessage::debug("[pong received]"));
+                    self.messages
+                        .push(AppMessage::debug("[pong received]", &self.theme));
                 }
             }
             NetworkEvent::PlayerSelected {
@@ -33,12 +37,14 @@ impl App {
                 self.current_player_id = Some(player_id);
                 self.current_entity_id = Some(entity_id);
                 self.streaming_message_index = None;
-                self.messages
-                    .push(AppMessage::system(format!("Playing as: {player_name}")));
+                self.messages.push(AppMessage::system(
+                    format!("Playing as: {player_name}"),
+                    &self.theme,
+                ));
             }
             NetworkEvent::Message { player_id, content } => {
                 if Some(player_id) == self.current_player_id {
-                    self.messages.push(AppMessage::normal(content));
+                    self.messages.push(AppMessage::normal(content, &self.theme));
                 }
             }
             NetworkEvent::MessageChunk {
@@ -73,17 +79,18 @@ impl App {
         if Some(player_id) != self.current_player_id {
             return;
         }
+        let theme = self.theme;
         match self.streaming_message_index {
             None => {
                 let idx = self.messages.len();
-                self.messages.push(AppMessage::normal(chunk));
+                self.messages.push(AppMessage::normal(chunk, &theme));
                 if !is_final {
                     self.streaming_message_index = Some(idx);
                 }
             }
             Some(idx) => {
                 if let Some(msg) = self.messages.get_mut(idx) {
-                    msg.text.push_str(&chunk);
+                    msg.append(&chunk, &theme);
                 }
                 if is_final {
                     self.streaming_message_index = None;

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -1,2 +1,3 @@
+pub mod markup;
 pub mod message_log;
 pub mod theme;

--- a/src/tui/components/markup.rs
+++ b/src/tui/components/markup.rs
@@ -1,0 +1,264 @@
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use super::theme::{Markup, MessageTheme, StyleKey, StyleOverrides};
+
+/// Parses markdown-ish description/narration text into themed `Line`s.
+///
+/// Only inline styling is honored (bold, emphasis, inline code as highlight).
+/// Unsupported constructs (headings, lists, blockquotes, links, images, html)
+/// render their inner text as plain spans in the surrounding style; they never
+/// cause a panic.
+pub fn parse(text: &str, theme: &MessageTheme, overrides: &StyleOverrides) -> Vec<Line<'static>> {
+    let mut builder = LineBuilder::new(theme, overrides);
+    for event in Parser::new(text) {
+        builder.handle_event(event);
+    }
+    builder.finish()
+}
+
+struct LineBuilder<'a> {
+    theme: &'a MessageTheme,
+    overrides: &'a StyleOverrides,
+    style_stack: Vec<Style>,
+    current_spans: Vec<Span<'static>>,
+    lines: Vec<Line<'static>>,
+}
+
+impl<'a> LineBuilder<'a> {
+    fn new(theme: &'a MessageTheme, overrides: &'a StyleOverrides) -> Self {
+        Self {
+            theme,
+            overrides,
+            style_stack: vec![Style::default()],
+            current_spans: Vec::new(),
+            lines: Vec::new(),
+        }
+    }
+
+    fn current_style(&self) -> Style {
+        *self.style_stack.last().unwrap_or(&Style::default())
+    }
+
+    fn resolve(&self, markup: Markup) -> Style {
+        self.theme
+            .resolve(StyleKey::Markup(markup), Some(self.overrides))
+    }
+
+    fn push_style(&mut self, markup: Markup) {
+        let patched = self.current_style().patch(self.resolve(markup));
+        self.style_stack.push(patched);
+    }
+
+    fn pop_style(&mut self) {
+        if self.style_stack.len() > 1 {
+            self.style_stack.pop();
+        }
+    }
+
+    fn push_text(&mut self, text: String) {
+        self.current_spans
+            .push(Span::styled(text, self.current_style()));
+    }
+
+    fn flush_line(&mut self) {
+        let spans = std::mem::take(&mut self.current_spans);
+        self.lines.push(Line::from(spans));
+    }
+
+    fn flush_line_if_nonempty(&mut self) {
+        if !self.current_spans.is_empty() {
+            self.flush_line();
+        }
+    }
+
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Start(tag) => self.handle_start(tag),
+            Event::End(tag_end) => self.handle_end(tag_end),
+            Event::Text(text) => self.push_text(text.into_string()),
+            Event::Code(text) => {
+                let style = self.current_style().patch(self.resolve(Markup::Highlight));
+                self.current_spans
+                    .push(Span::styled(text.into_string(), style));
+            }
+            Event::SoftBreak | Event::HardBreak => self.flush_line(),
+            _ => {}
+        }
+    }
+
+    fn handle_start(&mut self, tag: Tag) {
+        match tag {
+            Tag::Strong => self.push_style(Markup::Bold),
+            Tag::Emphasis => self.push_style(Markup::Emphasis),
+            _ => {}
+        }
+    }
+
+    fn handle_end(&mut self, tag_end: TagEnd) {
+        match tag_end {
+            TagEnd::Strong | TagEnd::Emphasis => self.pop_style(),
+            TagEnd::Paragraph
+            | TagEnd::Heading(_)
+            | TagEnd::Item
+            | TagEnd::BlockQuote(_)
+            | TagEnd::CodeBlock => self.flush_line_if_nonempty(),
+            _ => {}
+        }
+    }
+
+    fn finish(mut self) -> Vec<Line<'static>> {
+        self.flush_line_if_nonempty();
+        self.lines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::{Color, Modifier};
+
+    fn plain_text(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn plain_text_passthrough() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("Hello, traveller.", &theme, &overrides);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(plain_text(&lines), "Hello, traveller.");
+        assert_eq!(lines[0].spans[0].style, Style::default());
+    }
+
+    #[test]
+    fn bold_applies_theme_bold_style() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("**bold**", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "bold");
+        assert_eq!(
+            lines[0].spans[0].style,
+            Style::default().add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn emphasis_applies_theme_emphasis_style() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("*em*", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "em");
+        assert_eq!(
+            lines[0].spans[0].style,
+            Style::default().add_modifier(Modifier::ITALIC)
+        );
+    }
+
+    #[test]
+    fn nested_bold_and_emphasis_compose() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("**bold *and em***", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "bold and em");
+        let bold_span = &lines[0].spans[0];
+        assert_eq!(bold_span.content.as_ref(), "bold ");
+        assert_eq!(
+            bold_span.style,
+            Style::default().add_modifier(Modifier::BOLD)
+        );
+        let nested_span = &lines[0].spans[1];
+        assert_eq!(nested_span.content.as_ref(), "and em");
+        assert_eq!(
+            nested_span.style,
+            Style::default().add_modifier(Modifier::BOLD | Modifier::ITALIC)
+        );
+    }
+
+    #[test]
+    fn inline_code_applies_highlight_style() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("`code`", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "code");
+        assert_eq!(
+            lines[0].spans[0].style,
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        );
+    }
+
+    #[test]
+    fn soft_break_starts_new_line() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("line one\nline two", &theme, &overrides);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(plain_text(&lines), "line one\nline two");
+    }
+
+    #[test]
+    fn hard_break_starts_new_line() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("line one  \nline two", &theme, &overrides);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(plain_text(&lines), "line one\nline two");
+    }
+
+    #[test]
+    fn unsupported_heading_renders_as_plain_text() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("# A Heading", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "A Heading");
+    }
+
+    #[test]
+    fn unsupported_list_renders_as_plain_text() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("- one\n- two", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "one\ntwo");
+    }
+
+    #[test]
+    fn unclosed_marker_does_not_panic() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("**bold with no close", &theme, &overrides);
+        assert_eq!(plain_text(&lines), "**bold with no close");
+    }
+
+    #[test]
+    fn override_takes_precedence_over_default() {
+        let theme = MessageTheme;
+        let mut overrides = StyleOverrides::new();
+        overrides.insert(
+            StyleKey::Markup(Markup::Bold),
+            Style::default().fg(Color::Red),
+        );
+        let lines = parse("**bold**", &theme, &overrides);
+        assert_eq!(lines[0].spans[0].style, Style::default().fg(Color::Red));
+    }
+
+    #[test]
+    fn empty_text_returns_no_lines() {
+        let theme = MessageTheme;
+        let overrides = StyleOverrides::new();
+        let lines = parse("", &theme, &overrides);
+        assert!(lines.is_empty());
+    }
+}

--- a/src/tui/components/message_log.rs
+++ b/src/tui/components/message_log.rs
@@ -1,38 +1,22 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    text::{Line, Span, Text},
+    text::{Line, Text},
     widgets::{Block, Paragraph, Wrap},
 };
 
-use super::theme::{MessageKind, MessageTheme, StyleKey};
 use crate::tui::app::AppMessage;
 
 pub fn render(
     frame: &mut Frame,
     messages: &[AppMessage],
-    theme: &MessageTheme,
     scroll_offset: usize,
     block: Block,
     area: Rect,
 ) {
     let panel_height = area.height.saturating_sub(2) as usize;
 
-    let all_lines: Vec<Line> = messages
-        .iter()
-        .flat_map(|msg| {
-            let style = theme.resolve(StyleKey::Message(msg.kind), None);
-            let prefix = if msg.kind == MessageKind::PlayerCommand {
-                "> "
-            } else {
-                ""
-            };
-            msg.text
-                .split('\n')
-                .map(|line| Line::from(Span::styled(format!("{prefix}{line}"), style)))
-                .collect::<Vec<_>>()
-        })
-        .collect();
+    let all_lines: Vec<Line> = messages.iter().flat_map(|msg| msg.lines.clone()).collect();
 
     let total_lines = all_lines.len();
     let max_offset = total_lines.saturating_sub(panel_height);

--- a/src/tui/screens/agent_conversation.rs
+++ b/src/tui/screens/agent_conversation.rs
@@ -54,7 +54,7 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
                     });
                     let _ = send_interaction(url, client_id, &action).await;
                 }
-                app.messages.push(AppMessage::command(input));
+                app.messages.push(AppMessage::command(input, &app.theme));
                 app.scroll_offset = 0;
                 app.agent_responding = true;
             }
@@ -77,7 +77,6 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
-        &app.theme,
         app.scroll_offset,
         Block::default().title("Conversation").borders(Borders::ALL),
         areas[0],

--- a/src/tui/screens/conversation.rs
+++ b/src/tui/screens/conversation.rs
@@ -48,7 +48,6 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
-        &app.theme,
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -28,7 +28,7 @@ pub async fn handle_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
         (_, KeyCode::Enter) => {
             let input: String = app.input.drain(..).collect();
             dispatch_command(app, &input).await;
-            app.messages.push(AppMessage::command(input));
+            app.messages.push(AppMessage::command(input, &app.theme));
             app.scroll_offset = 0;
         }
         (_, KeyCode::PageUp) => app.scroll_up(),
@@ -127,7 +127,6 @@ pub fn render(frame: &mut Frame, app: &App) {
     message_log::render(
         frame,
         &app.messages,
-        &app.theme,
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],


### PR DESCRIPTION
Room and entity descriptions were plain strings, giving mud authors no way to emphasize or highlight parts of narration text. Descriptions now support a markdown-ish flavor (bold, emphasis, inline-code-as-highlight) that renders as themed spans in the TUI, resolved through the message theme built in #229.

- New pure converter (`tui/components/markup.rs`) that folds a `pulldown-cmark` event stream into a style-stack of `ratatui` `Line`/`Span` output, honoring only inline styling — unsupported constructs (headings, lists, blockquotes, links, etc.) degrade to plain text without panicking
- Markdown is parsed once, at message construction/streaming-append time in `AppMessage` (not per render frame), with the message-kind's base style patched underneath the markup styling
- `message_log::render` simplified to a plain line-flattener now that styling is baked into each `AppMessage`
- `AppMessage` extracted from `app.rs` into its own submodule (`app/message.rs`) to hold the new parsing/styling logic

<details>
<summary>Agent Context</summary>

Depends on #229 (`MessageTheme`, `Markup`, `StyleKey`, `StyleOverrides` in `tui/components/theme.rs`), already merged. `pulldown-cmark = "0.13.3"` was already an exact-pinned dependency (used in `game/config/dialog_parser.rs`/`persona_parser.rs`), so no `Cargo.toml` change was needed.

Key files:
- `src/tui/components/markup.rs` — `pub fn parse(text: &str, theme: &MessageTheme, overrides: &StyleOverrides) -> Vec<Line<'static>>`. Implementation is a `LineBuilder` struct driving a style stack over `pulldown_cmark::Parser` events: `Tag::Strong`/`Tag::Emphasis` push a patched style (patch composes nested styles, e.g. `**bold *and em***`), `Event::Code` applies `Markup::Highlight` to a single leaf span, `SoftBreak`/`HardBreak` flush the current line, block-level `End` tags (`Paragraph`/`Heading`/`Item`/`BlockQuote`/`CodeBlock`) flush the line if non-empty so separate blocks don't mash together, everything else is a no-op. 12 unit tests cover nesting, unclosed markers, empty input, and override precedence.
- `src/tui/app/message.rs` (new) — `AppMessage { text, kind, lines: Vec<Line<'static>> }`. Constructors (`normal`/`command`/`system`/`debug`) and `append()` (used by streamed `MessageChunk` events) all take `&MessageTheme` and call a private `styled_lines()` helper: `markup::parse` → patch each span with `theme.resolve(StyleKey::Message(kind), None)` as the base style → for `PlayerCommand`, prepend `"> "` to every resulting line (preserves prior per-line prefix behavior for multi-line commands).
- `src/tui/app/network_event_handler.rs`, `src/tui/screens/game.rs`, `src/tui/screens/agent_conversation.rs` — updated call sites to thread `&self.theme`/`&app.theme` through.
- `src/tui/components/message_log.rs` — dropped the now-unused `theme` parameter and per-message kind/prefix logic; just flattens `msg.lines`.

Design decision (explicitly confirmed with the user): parse at message-construction/append time, never in the render path — `message_log::render` does zero styling work now.

No override source is wired into `App` yet; `styled_lines` always passes an empty `StyleOverrides`. That's intentionally left for the future mud-authored `ThemeConfig` issue to plug into.

Verified live: ran the server + a TUI client via tmux, created a player, and issued `look` against a room description containing `**bold**`/`*emphasis*`/`` `code` `` — confirmed correct bold/italic/highlight rendering in the actual TUI before reverting the temporary test edit (a small permanent example, bolding "tavern" in `muds/basic/maps/default/default/default.toml`, was left in per the user's own follow-up edit).

</details>