### PR TITLE
Fixes #232 Add typewriter reveal for narration messages

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,13 +2,17 @@ mod battle_state;
 mod conversation_state;
 mod message;
 mod network_event_handler;
+mod reveal;
 
 pub use battle_state::{BattleFocus, BattleState, QueuedAbilityInfo};
 pub use conversation_state::ConversationState;
 pub use message::AppMessage;
 
+use std::collections::VecDeque;
+
 use crate::network::event::{ClassInfo, PlayerInfo};
 use crate::tui::components::theme::MessageTheme;
+use crate::tui::components::typewriter::{DEFAULT_REVEAL_RATE, TypewriterState};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum GameMode {
@@ -55,6 +59,9 @@ pub struct App {
     pub current_entity_id: Option<i64>,
     pub streaming_message_index: Option<usize>,
     pub agent_responding: bool,
+    pub reveal: Option<TypewriterState>,
+    pub reveal_queue: VecDeque<usize>,
+    pub reveal_rate: f64,
     pub debug: bool,
     pub theme: MessageTheme,
 }
@@ -79,6 +86,9 @@ impl App {
             current_entity_id: None,
             streaming_message_index: None,
             agent_responding: false,
+            reveal: None,
+            reveal_queue: VecDeque::new(),
+            reveal_rate: DEFAULT_REVEAL_RATE,
             debug,
             theme: MessageTheme,
         }
@@ -102,6 +112,9 @@ impl App {
             current_entity_id: None,
             streaming_message_index: None,
             agent_responding: false,
+            reveal: None,
+            reveal_queue: VecDeque::new(),
+            reveal_rate: DEFAULT_REVEAL_RATE,
             debug,
             theme: MessageTheme,
         }

--- a/src/tui/app/network_event_handler.rs
+++ b/src/tui/app/network_event_handler.rs
@@ -44,7 +44,9 @@ impl App {
             }
             NetworkEvent::Message { player_id, content } => {
                 if Some(player_id) == self.current_player_id {
+                    let idx = self.messages.len();
                     self.messages.push(AppMessage::normal(content, &self.theme));
+                    self.start_reveal(idx);
                 }
             }
             NetworkEvent::MessageChunk {
@@ -84,6 +86,7 @@ impl App {
             None => {
                 let idx = self.messages.len();
                 self.messages.push(AppMessage::normal(chunk, &theme));
+                self.start_reveal(idx);
                 if !is_final {
                     self.streaming_message_index = Some(idx);
                 }
@@ -113,6 +116,8 @@ impl App {
                 self.mode = GameMode::AgentConversation;
                 self.messages.clear();
                 self.scroll_offset = 0;
+                self.reveal = None;
+                self.reveal_queue.clear();
             }
         }
     }

--- a/src/tui/app/reveal.rs
+++ b/src/tui/app/reveal.rs
@@ -1,0 +1,217 @@
+use std::time::Duration;
+
+use super::App;
+use crate::tui::components::theme::MessageKind;
+use crate::tui::components::typewriter::{self, TypewriterState};
+
+impl App {
+    /// Starts revealing the message at `message_index`, if it's narration.
+    ///
+    /// A burst of narration messages (e.g. a move confirmation followed by a
+    /// room description) can be pushed within the same tick, well before the
+    /// first one finishes revealing. Rather than letting each new message
+    /// steal the reveal from the one in progress, later messages queue up
+    /// and reveal in turn.
+    pub fn start_reveal(&mut self, message_index: usize) {
+        let is_narration = self
+            .messages
+            .get(message_index)
+            .is_some_and(|msg| msg.kind == MessageKind::Narration);
+        if !is_narration {
+            return;
+        }
+        if self.reveal.is_some() {
+            self.reveal_queue.push_back(message_index);
+        } else {
+            self.reveal = Some(TypewriterState::new(message_index));
+        }
+    }
+
+    /// Advances the active reveal by `tick`, moving on to the next queued
+    /// reveal once the tracked message is fully shown and no longer
+    /// streaming in new chunks.
+    pub fn tick_reveal(&mut self, tick: Duration) {
+        let Some(index) = self.reveal.as_ref().map(|state| state.message_index) else {
+            return;
+        };
+        let Some(msg) = self.messages.get(index) else {
+            self.advance_reveal_queue();
+            return;
+        };
+
+        let total = typewriter::visible_len(&msg.lines);
+        let rate = self.reveal_rate;
+        let still_streaming = self.streaming_message_index == Some(index);
+
+        if let Some(state) = self.reveal.as_mut() {
+            state.advance(rate, tick, total);
+            if state.is_caught_up(total) && !still_streaming {
+                self.advance_reveal_queue();
+            }
+        }
+    }
+
+    /// Completes the active reveal immediately and moves on to the next
+    /// queued reveal, if any.
+    pub fn skip_reveal(&mut self) {
+        self.advance_reveal_queue();
+    }
+
+    fn advance_reveal_queue(&mut self) {
+        while let Some(next_index) = self.reveal_queue.pop_front() {
+            let is_narration = self
+                .messages
+                .get(next_index)
+                .is_some_and(|msg| msg.kind == MessageKind::Narration);
+            if is_narration {
+                self.reveal = Some(TypewriterState::new(next_index));
+                return;
+            }
+        }
+        self.reveal = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::app::AppMessage;
+    use crate::tui::components::theme::MessageTheme;
+
+    fn app_with_message(kind_normal: bool) -> App {
+        let mut app = App::new(false);
+        app.messages.clear();
+        let theme = MessageTheme;
+        let msg = if kind_normal {
+            AppMessage::normal("hello world", &theme)
+        } else {
+            AppMessage::system("hello world", &theme)
+        };
+        app.messages.push(msg);
+        app
+    }
+
+    fn app_with_narration_messages(texts: &[&str]) -> App {
+        let mut app = App::new(false);
+        app.messages.clear();
+        let theme = MessageTheme;
+        for text in texts {
+            app.messages.push(AppMessage::normal(*text, &theme));
+        }
+        app
+    }
+
+    #[test]
+    fn start_reveal_arms_for_narration() {
+        let mut app = app_with_message(true);
+        app.start_reveal(0);
+        assert!(app.reveal.is_some());
+    }
+
+    #[test]
+    fn start_reveal_ignores_non_narration() {
+        let mut app = app_with_message(false);
+        app.start_reveal(0);
+        assert!(app.reveal.is_none());
+    }
+
+    #[test]
+    fn tick_reveal_advances_and_clears_when_caught_up() {
+        let mut app = app_with_message(true);
+        app.reveal_rate = 1000.0;
+        app.start_reveal(0);
+        app.tick_reveal(Duration::from_secs(1));
+        assert!(app.reveal.is_none());
+    }
+
+    #[test]
+    fn tick_reveal_stays_open_while_streaming() {
+        let mut app = app_with_message(true);
+        app.reveal_rate = 1000.0;
+        app.streaming_message_index = Some(0);
+        app.start_reveal(0);
+        app.tick_reveal(Duration::from_secs(1));
+        assert!(app.reveal.is_some());
+        assert!(app.reveal.unwrap().is_caught_up(11));
+    }
+
+    #[test]
+    fn tick_reveal_resumes_once_streaming_finishes() {
+        let mut app = app_with_message(true);
+        app.reveal_rate = 1000.0;
+        app.streaming_message_index = Some(0);
+        app.start_reveal(0);
+        app.tick_reveal(Duration::from_secs(1));
+        assert!(app.reveal.is_some());
+
+        app.streaming_message_index = None;
+        app.tick_reveal(Duration::from_secs(1));
+        assert!(app.reveal.is_none());
+    }
+
+    #[test]
+    fn skip_reveal_clears_state() {
+        let mut app = app_with_message(true);
+        app.start_reveal(0);
+        assert!(app.reveal.is_some());
+        app.skip_reveal();
+        assert!(app.reveal.is_none());
+    }
+
+    #[test]
+    fn start_reveal_queues_a_second_message_instead_of_stealing_the_reveal() {
+        let mut app = app_with_narration_messages(&["you move north.", "a warm tavern."]);
+        app.start_reveal(0);
+        app.start_reveal(1);
+
+        assert_eq!(app.reveal.unwrap().message_index, 0);
+        assert_eq!(app.reveal_queue.len(), 1);
+        assert_eq!(app.reveal_queue[0], 1);
+    }
+
+    #[test]
+    fn completing_current_reveal_starts_the_queued_one() {
+        let mut app = app_with_narration_messages(&["you move north.", "a warm tavern."]);
+        app.reveal_rate = 1000.0;
+        app.start_reveal(0);
+        app.start_reveal(1);
+
+        // Finishes message 0 and should immediately begin message 1.
+        app.tick_reveal(Duration::from_secs(1));
+
+        assert_eq!(app.reveal.unwrap().message_index, 1);
+        assert!(app.reveal_queue.is_empty());
+    }
+
+    #[test]
+    fn a_burst_of_three_narration_messages_reveals_each_in_turn() {
+        let mut app =
+            app_with_narration_messages(&["move.", "room description.", "an npc is here."]);
+        app.reveal_rate = 1000.0;
+        app.start_reveal(0);
+        app.start_reveal(1);
+        app.start_reveal(2);
+        assert_eq!(app.reveal.unwrap().message_index, 0);
+
+        app.tick_reveal(Duration::from_secs(1));
+        assert_eq!(app.reveal.unwrap().message_index, 1);
+
+        app.tick_reveal(Duration::from_secs(1));
+        assert_eq!(app.reveal.unwrap().message_index, 2);
+
+        app.tick_reveal(Duration::from_secs(1));
+        assert!(app.reveal.is_none());
+    }
+
+    #[test]
+    fn skip_reveal_advances_to_the_queued_message() {
+        let mut app = app_with_narration_messages(&["you move north.", "a warm tavern."]);
+        app.start_reveal(0);
+        app.start_reveal(1);
+
+        app.skip_reveal();
+
+        assert_eq!(app.reveal.unwrap().message_index, 1);
+        assert!(app.reveal_queue.is_empty());
+    }
+}

--- a/src/tui/components.rs
+++ b/src/tui/components.rs
@@ -1,3 +1,4 @@
 pub mod markup;
 pub mod message_log;
 pub mod theme;
+pub mod typewriter;

--- a/src/tui/components/message_log.rs
+++ b/src/tui/components/message_log.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use ratatui::{
     Frame,
     layout::Rect,
@@ -6,6 +8,7 @@ use ratatui::{
 };
 
 use crate::tui::app::AppMessage;
+use crate::tui::components::typewriter::{self, TypewriterState};
 
 pub fn render(
     frame: &mut Frame,
@@ -13,10 +16,25 @@ pub fn render(
     scroll_offset: usize,
     block: Block,
     area: Rect,
+    reveal: Option<&TypewriterState>,
+    reveal_queue: &VecDeque<usize>,
 ) {
     let panel_height = area.height.saturating_sub(2) as usize;
 
-    let all_lines: Vec<Line> = messages.iter().flat_map(|msg| msg.lines.clone()).collect();
+    // Messages still waiting their turn in the reveal queue haven't "started"
+    // yet and stay hidden, rather than flashing in full before their
+    // typewriter reveal begins.
+    let all_lines: Vec<Line> = messages
+        .iter()
+        .enumerate()
+        .flat_map(|(i, msg)| match reveal {
+            Some(state) if state.message_index == i => {
+                typewriter::truncate_lines(&msg.lines, state.revealed_chars)
+            }
+            _ if reveal_queue.contains(&i) => Vec::new(),
+            _ => msg.lines.clone(),
+        })
+        .collect();
 
     let total_lines = all_lines.len();
     let max_offset = total_lines.saturating_sub(panel_height);

--- a/src/tui/components/typewriter.rs
+++ b/src/tui/components/typewriter.rs
@@ -1,0 +1,199 @@
+use std::time::Duration;
+
+use ratatui::text::{Line, Span};
+
+/// Default typewriter reveal rate, in characters per second.
+pub const DEFAULT_REVEAL_RATE: f64 = 80.0;
+
+/// Tracks progressive reveal of a single message in the log.
+///
+/// `carry` retains the fractional character left over between ticks so slow
+/// rates (or fast ticks) don't lose precision to integer truncation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TypewriterState {
+    pub message_index: usize,
+    pub revealed_chars: usize,
+    carry: f64,
+}
+
+impl TypewriterState {
+    pub fn new(message_index: usize) -> Self {
+        Self {
+            message_index,
+            revealed_chars: 0,
+            carry: 0.0,
+        }
+    }
+
+    pub fn advance(&mut self, rate_chars_per_sec: f64, tick: Duration, total_chars: usize) {
+        self.carry += rate_chars_per_sec * tick.as_secs_f64();
+        let whole = self.carry.floor();
+        self.revealed_chars = (self.revealed_chars + whole as usize).min(total_chars);
+        self.carry -= whole;
+    }
+
+    pub fn is_caught_up(&self, total_chars: usize) -> bool {
+        self.revealed_chars >= total_chars
+    }
+}
+
+/// Total revealable character count across already-parsed spans.
+pub fn visible_len(lines: &[Line<'static>]) -> usize {
+    lines
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.chars().count())
+                .sum::<usize>()
+        })
+        .sum()
+}
+
+/// Truncates parsed lines to the first `revealed_chars` characters,
+/// preserving span styling and dropping unrevealed lines/spans entirely.
+pub fn truncate_lines(lines: &[Line<'static>], revealed_chars: usize) -> Vec<Line<'static>> {
+    let mut remaining = revealed_chars;
+    let mut out = Vec::new();
+
+    for line in lines {
+        if remaining == 0 {
+            break;
+        }
+
+        let mut spans = Vec::new();
+        for span in &line.spans {
+            if remaining == 0 {
+                break;
+            }
+            let span_len = span.content.chars().count();
+            if remaining >= span_len {
+                spans.push(span.clone());
+                remaining -= span_len;
+            } else {
+                let truncated: String = span.content.chars().take(remaining).collect();
+                spans.push(Span::styled(truncated, span.style));
+                remaining = 0;
+            }
+        }
+        out.push(Line::from(spans));
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::{Color, Style};
+
+    fn plain_text(lines: &[Line<'static>]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn advance_accumulates_fractional_chars_across_ticks() {
+        let mut state = TypewriterState::new(0);
+        // 40 chars/sec at 50ms ticks = 2 chars/tick exactly.
+        state.advance(40.0, Duration::from_millis(50), 100);
+        assert_eq!(state.revealed_chars, 2);
+        state.advance(40.0, Duration::from_millis(50), 100);
+        assert_eq!(state.revealed_chars, 4);
+    }
+
+    #[test]
+    fn advance_carries_fractional_remainder() {
+        let mut state = TypewriterState::new(0);
+        // 10 chars/sec at 50ms ticks = 0.5 chars/tick; carries across ticks.
+        state.advance(10.0, Duration::from_millis(50), 100);
+        assert_eq!(state.revealed_chars, 0);
+        state.advance(10.0, Duration::from_millis(50), 100);
+        assert_eq!(state.revealed_chars, 1);
+    }
+
+    #[test]
+    fn advance_clamps_at_total_chars() {
+        let mut state = TypewriterState::new(0);
+        state.advance(1000.0, Duration::from_secs(1), 5);
+        assert_eq!(state.revealed_chars, 5);
+    }
+
+    #[test]
+    fn is_caught_up_reflects_total() {
+        let mut state = TypewriterState::new(0);
+        assert!(!state.is_caught_up(5));
+        state.advance(1000.0, Duration::from_secs(1), 5);
+        assert!(state.is_caught_up(5));
+    }
+
+    #[test]
+    fn visible_len_sums_span_chars() {
+        let lines = vec![
+            Line::from(vec![Span::raw("abc"), Span::raw("de")]),
+            Line::from(vec![Span::raw("f")]),
+        ];
+        assert_eq!(visible_len(&lines), 6);
+    }
+
+    #[test]
+    fn truncate_lines_mid_span() {
+        let lines = vec![Line::from(vec![Span::raw("hello world")])];
+        let truncated = truncate_lines(&lines, 5);
+        assert_eq!(plain_text(&truncated), "hello");
+    }
+
+    #[test]
+    fn truncate_lines_preserves_style() {
+        let style = Style::default().fg(Color::Yellow);
+        let lines = vec![Line::from(vec![Span::styled("hello", style)])];
+        let truncated = truncate_lines(&lines, 3);
+        assert_eq!(truncated[0].spans[0].style, style);
+        assert_eq!(truncated[0].spans[0].content.as_ref(), "hel");
+    }
+
+    #[test]
+    fn truncate_lines_at_span_boundary() {
+        let lines = vec![Line::from(vec![Span::raw("abc"), Span::raw("def")])];
+        let truncated = truncate_lines(&lines, 3);
+        assert_eq!(plain_text(&truncated), "abc");
+        assert_eq!(truncated[0].spans.len(), 1);
+    }
+
+    #[test]
+    fn truncate_lines_drops_unrevealed_lines() {
+        let lines = vec![
+            Line::from(vec![Span::raw("abc")]),
+            Line::from(vec![Span::raw("def")]),
+        ];
+        let truncated = truncate_lines(&lines, 3);
+        assert_eq!(plain_text(&truncated), "abc");
+        assert_eq!(truncated.len(), 1);
+    }
+
+    #[test]
+    fn truncate_lines_zero_chars_returns_empty() {
+        let lines = vec![Line::from(vec![Span::raw("abc")])];
+        let truncated = truncate_lines(&lines, 0);
+        assert!(truncated.is_empty());
+    }
+
+    #[test]
+    fn truncate_lines_full_length_matches_original() {
+        let lines = vec![
+            Line::from(vec![Span::raw("abc")]),
+            Line::from(vec![Span::raw("def")]),
+        ];
+        let total = visible_len(&lines);
+        let truncated = truncate_lines(&lines, total);
+        assert_eq!(plain_text(&truncated), "abc\ndef");
+    }
+}

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crossterm::event::{Event, EventStream, MouseEventKind};
+use crossterm::event::{Event, EventStream, KeyCode, KeyModifiers, MouseEventKind};
 use futures_util::StreamExt;
 use ratatui::DefaultTerminal;
 use tokio::sync::mpsc;
@@ -14,6 +14,8 @@ use super::screens::{
     agent_conversation, battle as battle_screen, conversation, game as game_screen, player_select,
 };
 
+const REVEAL_TICK: Duration = Duration::from_millis(50);
+
 pub async fn run(
     terminal: &mut DefaultTerminal,
     app: &mut App,
@@ -22,6 +24,8 @@ pub async fn run(
     let mut event_stream = EventStream::new();
     let mut spinner_ticker = time::interval(Duration::from_millis(100));
     spinner_ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+    let mut reveal_ticker = time::interval(REVEAL_TICK);
+    reveal_ticker.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
     // Load player list immediately if in PlayerSelect mode
     if app.mode == GameMode::PlayerSelect
@@ -39,6 +43,9 @@ pub async fn run(
 
         tokio::select! {
             _ = spinner_ticker.tick(), if app.agent_responding => {}
+            _ = reveal_ticker.tick(), if app.reveal.is_some() => {
+                app.tick_reveal(REVEAL_TICK);
+            }
             maybe_event = event_stream.next() => {
                 if !handle_terminal_event(app, maybe_event).await {
                     break;
@@ -62,6 +69,12 @@ async fn handle_terminal_event(
 ) -> bool {
     match maybe_event {
         Some(Ok(Event::Key(key))) => {
+            let is_quit_shortcut =
+                key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c');
+            if app.reveal.is_some() && !is_quit_shortcut {
+                app.skip_reveal();
+                return true;
+            }
             match app.mode {
                 GameMode::PlayerSelect => {
                     player_select::handle_key(app, key.modifiers, key.code).await;

--- a/src/tui/screens/agent_conversation.rs
+++ b/src/tui/screens/agent_conversation.rs
@@ -80,6 +80,8 @@ pub fn render(frame: &mut Frame, app: &App) {
         app.scroll_offset,
         Block::default().title("Conversation").borders(Borders::ALL),
         areas[0],
+        app.reveal.as_ref(),
+        &app.reveal_queue,
     );
 
     let status_text = if app.agent_responding {

--- a/src/tui/screens/conversation.rs
+++ b/src/tui/screens/conversation.rs
@@ -51,6 +51,8 @@ pub fn render(frame: &mut Frame, app: &App) {
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],
+        app.reveal.as_ref(),
+        &app.reveal_queue,
     );
 
     let items: Vec<ListItem> = app

--- a/src/tui/screens/game.rs
+++ b/src/tui/screens/game.rs
@@ -130,6 +130,8 @@ pub fn render(frame: &mut Frame, app: &App) {
         app.scroll_offset,
         Block::default().title("Messages").borders(Borders::ALL),
         areas[0],
+        app.reveal.as_ref(),
+        &app.reveal_queue,
     );
 
     // Status bar


### PR DESCRIPTION
Room descriptions and other narration text used to appear in the message log all at once. This adds a classic MUD typewriter effect: narration types out progressively at a configurable rate, chases growing SSE chunks from streamed agent replies, and can be skipped with any keypress.

- New `TypewriterState` reveal tracker and span-aware truncation helpers (`src/tui/components/typewriter.rs`), driven by a dedicated ticker in the TUI event loop that's only active while a reveal is in progress
- `App` gained a reveal queue so a burst of narration messages fired within a single interaction (e.g. move confirmation + room description + entity description) types out sequentially instead of the newest message stealing the reveal mid-animation
- Any keypress completes the current reveal instead of being processed as input, without breaking Ctrl+C quit
- Message log rendering hides messages still waiting their turn in the queue, avoiding a flash-full-then-retype flicker

<details>
<summary>Agent Context</summary>

Implements #232. Builds on #229 (`MessageKind`/`MessageTheme`) and the pulldown-cmark markup parser (`src/tui/components/markup.rs`) — reveal truncates already-parsed `Line`/`Span` output (`AppMessage.lines`) rather than raw text, so partial reveals never show raw markdown markers.

Key files:
- `src/tui/components/typewriter.rs` (new): `TypewriterState { message_index, revealed_chars, carry }`, `advance(rate, tick, total)` (carries fractional chars across ticks, tick-duration-agnostic via `Duration::as_secs_f64()`), `visible_len()`/`truncate_lines()` span-aware helpers, `DEFAULT_REVEAL_RATE`.
- `src/tui/app/reveal.rs` (new): `App::start_reveal/tick_reveal/skip_reveal` + `advance_reveal_queue` private helper. `start_reveal` only arms for `MessageKind::Narration`; if a reveal is already active it pushes onto `App.reveal_queue: VecDeque<usize>` instead of preempting it.
- `src/tui/app.rs`: added `reveal: Option<TypewriterState>`, `reveal_queue: VecDeque<usize>`, `reveal_rate: f64` fields.
- `src/tui/app/network_event_handler.rs`: calls `start_reveal` after pushing a complete `NetworkEvent::Message` and after the first chunk of a `NetworkEvent::MessageChunk` stream; `tick_reveal` keeps the reveal open while `streaming_message_index` still matches so it chases growing chunks. Also clears `reveal`/`reveal_queue` when messages are wiped on entering `AgentConversation` mode, to avoid stale indices.
- `src/tui/event.rs`: `REVEAL_TICK = Duration::from_millis(50)` ticker gated on `app.reveal.is_some()`, mirroring the existing `spinner_ticker` pattern. Skip-to-end is centralized in `handle_terminal_event`: any keypress while `app.reveal.is_some()` calls `skip_reveal()` and is swallowed (not forwarded to the per-mode handler), except Ctrl+C which still falls through to quit.
- `src/tui/components/message_log.rs`: `render()` gained `reveal: Option<&TypewriterState>` and `reveal_queue: &VecDeque<usize>` params. The active reveal's message is truncated via `typewriter::truncate_lines`; messages still in `reveal_queue` render as empty (hidden) rather than in full, since they haven't started their turn yet; scroll-to-bottom-while-revealing falls out of the existing `max_offset` computation for free. Updated the three call sites (`screens/game.rs`, `screens/agent_conversation.rs`, `screens/conversation.rs`).

Root cause of a bug found during review: `execute_move` (`src/game/interaction/movement.rs`) sends up to three separate Narration messages synchronously within one interaction ("You move {direction}.", the room description via `look::process`, then possibly a `room_threats` message) — all delivered to the client in the same burst. Without the queue, each `start_reveal` call clobbered the in-progress one, so only the last message in the burst ever animated. The queue plus the "hide queued messages" render change fixes this; verified manually against a live server/client (tmux) that all three messages now reveal in turn.

Also confirmed (raised during review, no code change needed): `TypewriterState::advance` is not tick-duration-dependent — it scales by `tick.as_secs_f64()` — so it's correctly decoupled from the server's configurable `game_loop.tick_rate_ms` (e.g. 500ms in `muds/basic/mud.toml`); the reveal ticker's 50ms cadence is a pure client-side animation-smoothness choice.

Tests: unit tests added in `typewriter.rs` (advance/clamp/truncation/visible_len) and `app/reveal.rs` (start/tick/skip, streaming chase, queueing and burst-sequencing, skip-to-queued). `cargo fmt`, `cargo test`, `cargo clippy` all clean (one pre-existing unrelated clippy warning in `attribute_config.rs`, confirmed present on `main` too).

Deferred/out of scope: no config file or CLI flag for the reveal rate yet (per issue, `reveal_rate` lives on `App` for a future flag to feed); battle log reuse of this component is a separate future issue per the original ticket's "Related" section.
